### PR TITLE
ci: -linux Release 固定 make_latest=false（版本隔离确定性）

### DIFF
--- a/.github/workflows/build-arch-pacman.yml
+++ b/.github/workflows/build-arch-pacman.yml
@@ -283,5 +283,11 @@ jobs:
           files: release-artifacts/**/*
           draft: false
           generate_release_notes: true
+          # 版本隔离：-linux Release 永远不占 /releases/latest —— 该端点被
+          # v4 之前的老 Windows 客户端当作唯一更新源（v4 起才有按资产过滤
+          # 的平台围栏）。latest 必须始终指向 Windows Release，否则老客户端
+          # 会拿到只有 Linux 资产的 latest（虽因无 .exe 装不上，但会弹
+          # 「未找到安装包」错误）。Windows tag 走本 workflow 时保持默认。
+          make_latest: ${{ endsWith(github.ref, '-linux') && 'false' || 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

Windows 与 Linux 在同一仓库发版，版本号互相独立（当前 Linux 4.0.1 > Windows 4.0.0 属预期，非隔离失败）。

**v4 客户端更新器已有平台围栏**（`client-updater.js` checkLatest）：按版本降序扫 Release 列表、跳过无 Windows 安装包资产的版本，Linux-only Release 不会推给 Windows 用户。

**残余风险在老客户端**：v4 之前的 Windows 客户端用 `/releases/latest` 单对象。目前该端点恰好仍返回 v4.0.0（GitHub latest 启发式未把 linux 分支 tag 算进去），但这是偶然不是规则——一旦某天 -linux Release 被 GitHub 判为 latest，老客户端会弹「未找到安装包资产」错误（因无 .exe 装不上，无实际危害但体验差）。

## 修复

- Release 发布步骤显式 `make_latest: false`（-linux tag 时），把偶然变成确定规则：`/releases/latest` 永远归 Windows Release 所有
- 现有 Release 已手工补钉（上游 v4.0.1-linux / v3.0.2-linux，fork 侧同名）

纯 CI 改动，一个文件 6 行，不影响任何构建产物。