### PR TITLE
fix(tool-vision): llm/stream 监听器改 async generator，插件默认不启动（4.0.2）

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p>
 <a href="https://github.com/zouyuxuan122/Deepseek-Harness-EAC"><img src="https://img.shields.io/github/stars/zouyuxuan122/Deepseek-Harness-EAC?style=flat&label=%E2%AD%90&color=08C" alt="GitHub stars"></a>
 <a href="https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases"><img src="https://img.shields.io/badge/Windows-10%2F11-4493F8?style=flat" alt="Windows"></a>
-<a href="https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/tag/v4.0.1-linux"><img src="https://img.shields.io/badge/Linux-pacman%2Fdeb%2Frpm%2FAppImage-178600?style=flat" alt="Linux"></a>
+<a href="https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/tag/v4.0.2-linux"><img src="https://img.shields.io/badge/Linux-pacman%2Fdeb%2Frpm%2FAppImage-178600?style=flat" alt="Linux"></a>
 <a href="https://github.com/zouyuxuan122/Deepseek-Harness-EAC"><img src="https://img.shields.io/badge/Desktop-App-47848F?style=flat" alt="Desktop App"></a>
 <a href="https://github.com/zouyuxuan122/Deepseek-Harness-EAC/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat" alt="MIT License"></a>
 </p>
@@ -65,14 +65,14 @@
 
 ### Linux（x64）
 
-Linux 打包由社区开发者 [@Luoye-hb](https://github.com/Luoye-hb) 贡献（[PR #12](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/pull/12)），随 [v4.0.1-linux](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/tag/v4.0.1-linux) 发布，支持 **Arch / Ubuntu / Debian / Fedora** 与通用 AppImage：
+Linux 打包由社区开发者 [@Luoye-hb](https://github.com/Luoye-hb) 贡献（[PR #12](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/pull/12)），随 [v4.0.2-linux](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/tag/v4.0.2-linux) 发布，支持 **Arch / Ubuntu / Debian / Fedora** 与通用 AppImage：
 
 | 发行版 | 包 | 安装 |
 | --- | --- | --- |
-| Arch Linux | [.pacman](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.1-linux/Deepseek-Harness-EAC-4.0.1-x64.pacman) | `sudo pacman -U ./Deepseek-Harness-EAC-4.0.1-x64.pacman` |
-| Ubuntu / Debian | [.deb](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.1-linux/Deepseek-Harness-EAC-4.0.1-amd64.deb) | `sudo apt install ./Deepseek-Harness-EAC-4.0.1-amd64.deb` |
-| Fedora | [.rpm](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.1-linux/Deepseek-Harness-EAC-3.0.2.x86_64.rpm) | `sudo dnf install ./Deepseek-Harness-EAC-3.0.2.x86_64.rpm` |
-| 通用 | [.AppImage](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.1-linux/Deepseek-Harness-EAC-4.0.1-x86_64.AppImage) | `chmod +x` 后直接运行 |
+| Arch Linux | [.pacman](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.2-linux/Deepseek-Harness-EAC-4.0.2-x64.pacman) | `sudo pacman -U ./Deepseek-Harness-EAC-4.0.2-x64.pacman` |
+| Ubuntu / Debian | [.deb](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.2-linux/Deepseek-Harness-EAC-4.0.2-amd64.deb) | `sudo apt install ./Deepseek-Harness-EAC-4.0.2-amd64.deb` |
+| Fedora | [.rpm](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.2-linux/Deepseek-Harness-EAC-4.0.2.x86_64.rpm) | `sudo dnf install ./Deepseek-Harness-EAC-4.0.2.x86_64.rpm` |
+| 通用 | [.AppImage](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/releases/download/v4.0.2-linux/Deepseek-Harness-EAC-4.0.2-x86_64.AppImage) | `chmod +x` 后直接运行 |
 
 > - 卸载：`pacman -Rns dsh-desktop` / `apt remove dsh-desktop` / `dnf remove dsh-desktop`
 > - 与 Windows 版一致：内置 Node.js 与 npm CLI，目标机器无需预装 Node.js；数据目录沿用 `~/.dsh`（`DSH_HOME`）
@@ -101,7 +101,7 @@ Arch Linux 版本以 pacman 本地包形式提供。下载或自行构建
 `Deepseek-Harness-EAC-<版本>-x64.pacman` 后安装：
 
 ```bash
-sudo pacman -U ./Deepseek-Harness-EAC-4.0.1-x64.pacman
+sudo pacman -U ./Deepseek-Harness-EAC-4.0.2-x64.pacman
 ```
 
 安装完成后可从桌面应用菜单启动 **Deepseek Harness EAC**，也可在终端运行：
@@ -128,7 +128,7 @@ pacman 会自动处理 Electron 所需的 GTK、NSS、通知、密钥环等系�
 下载 `Deepseek-Harness-EAC-<版本>-amd64.deb` 后安装：
 
 ```bash
-sudo apt install ./Deepseek-Harness-EAC-4.0.1-amd64.deb
+sudo apt install ./Deepseek-Harness-EAC-4.0.2-amd64.deb
 ```
 
 安装完成后可从桌面应用菜单启动 **Deepseek Harness EAC**，也可在终端运行
@@ -143,7 +143,7 @@ sudo apt remove dsh-desktop
 下载 `Deepseek-Harness-EAC-<版本>.x86_64.rpm` 后安装：
 
 ```bash
-sudo dnf install ./Deepseek-Harness-EAC-3.0.2.x86_64.rpm
+sudo dnf install ./Deepseek-Harness-EAC-4.0.2.x86_64.rpm
 ```
 
 卸载：
@@ -157,8 +157,8 @@ sudo dnf remove dsh-desktop
 下载 `Deepseek-Harness-EAC-<版本>-x86_64.AppImage` 后：
 
 ```bash
-chmod +x ./Deepseek-Harness-EAC-4.0.1-x86_64.AppImage
-./Deepseek-Harness-EAC-4.0.1-x86_64.AppImage
+chmod +x ./Deepseek-Harness-EAC-4.0.2-x86_64.AppImage
+./Deepseek-Harness-EAC-4.0.2-x86_64.AppImage
 ```
 
 > Ubuntu 24.04 等默认只有 FUSE3 的发行版，若 AppImage 提示缺少 FUSE2，
@@ -295,7 +295,7 @@ npm run dist:appimage  # 免安装 AppImage
 安装本地构建产物：
 
 ```bash
-sudo pacman -U ./dist/Deepseek-Harness-EAC-4.0.1-x64.pacman
+sudo pacman -U ./dist/Deepseek-Harness-EAC-4.0.2-x64.pacman
 ```
 
 运行测试：

--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -8,7 +8,23 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 3.0.0（升级链路根治 + 崩溃自恢复/看门狗 + 右侧边栏 + 上游预设全家桶）→
 3.1.0（插件保护中心 + 原生 CLI 共存根治 + 字体自定义 + 自动压缩 + 人设卡库）→
 4.0.0（本版：四大用户反馈问题根治 + SHA-256 更新校验 + 微信 ClawBot 桥 + 多窗口
-+ 会话删除 + AI 变更审核 + 崩溃急救 undo + 大肥鱼桌宠 + 插件启停管理）。
++ 会话删除 + AI 变更审核 + 崩溃急救 undo + 大肥鱼桌宠 + 插件启停管理）→
+4.0.2（tool-vision llm/stream 契约修复 + 该插件默认不启动）。
+
+## [4.0.2] — 2026-08-17（Linux 线）
+
+### 修复：所有对话报 `yield* (intermediate value) is not async iterable`
+- 根因：dsh-tool-vision 的 `attachRequestGuard` 把 `llm/stream` 监听器写成
+  async 函数 —— async 函数必返 Promise，而 cordis 瀑布流期望每个监听器返回
+  async iterable（下游 `yield* next()` 拿到 Promise 即抛错），v4 起每轮模型
+  请求必失败。
+- 修复：监听器保持同步、返回立即调用的 async generator；两处 `return next(...)`
+  改为 `yield* next(...)`，try/catch 与判断逻辑原样保留。配套 4 个回归测试
+  （监听器契约 / 改写透传 / 白名单跳过 / 异常放行）。
+- 该插件同时改为**默认不启动**：COMPANION_PLUGINS 条目标 `disabled: true`
+  （与桌宠同机制，用户可在「设置 → 插件 → 管理」重新启用）；存量启用行由
+  `healRowDisabled` 一次性迁移禁用 —— 只改不带 disabled 键的原始行，用户
+  显式启用/禁用的行永不覆盖。
 
 ## [4.0.0] — 2026-08-16
 

--- a/dsh-desktop/README.md
+++ b/dsh-desktop/README.md
@@ -45,7 +45,7 @@
 下载或构建 pacman 包后安装：
 
 ```bash
-sudo pacman -U ./Deepseek-Harness-EAC-4.0.1-x64.pacman
+sudo pacman -U ./Deepseek-Harness-EAC-4.0.2-x64.pacman
 ```
 
 安装完成后从桌面应用菜单启动，或运行 `deepseek-harness-eac`。卸载命令：
@@ -62,7 +62,7 @@ sudo pacman -Rns dsh-desktop
 下载 `Deepseek-Harness-EAC-<版本>-amd64.deb` 后安装：
 
 ```bash
-sudo apt install ./Deepseek-Harness-EAC-4.0.1-amd64.deb
+sudo apt install ./Deepseek-Harness-EAC-4.0.2-amd64.deb
 ```
 
 卸载：`sudo apt remove dsh-desktop`。
@@ -72,7 +72,7 @@ sudo apt install ./Deepseek-Harness-EAC-4.0.1-amd64.deb
 下载 `Deepseek-Harness-EAC-<版本>.x86_64.rpm` 后安装：
 
 ```bash
-sudo dnf install ./Deepseek-Harness-EAC-3.0.2.x86_64.rpm
+sudo dnf install ./Deepseek-Harness-EAC-4.0.2.x86_64.rpm
 ```
 
 卸载：`sudo dnf remove dsh-desktop`。
@@ -80,8 +80,8 @@ sudo dnf install ./Deepseek-Harness-EAC-3.0.2.x86_64.rpm
 ### AppImage（免安装，通用）
 
 ```bash
-chmod +x ./Deepseek-Harness-EAC-4.0.1-x86_64.AppImage
-./Deepseek-Harness-EAC-4.0.1-x86_64.AppImage
+chmod +x ./Deepseek-Harness-EAC-4.0.2-x86_64.AppImage
+./Deepseek-Harness-EAC-4.0.2-x86_64.AppImage
 ```
 
 > Ubuntu 24.04 等只有 FUSE3 的发行版，若提示缺少 FUSE2，先安装 `libfuse2`

--- a/dsh-desktop/assets/plugins/dsh-tool-vision/index.js
+++ b/dsh-desktop/assets/plugins/dsh-tool-vision/index.js
@@ -368,26 +368,34 @@ async function callVision(config, imageUrl, question, detail, signal) {
  * later still sees the original images.
  */
 function attachRequestGuard(ctx, getConfig, exportDir) {
-  ctx.on("llm/stream", async (options, next) => {
-    try {
-      const config = getConfig();
-      if (config.requestGuard && typeof options?.model === "string"
-        && !config.multimodalModels.includes(options.model)
-        && hasImageBlock(options.messages)) {
-        const messages = await bridgeMessages(options.messages, ctx, exportDir);
-        if (messages.some((message, index) => message !== options.messages[index])) {
-          ctx.logger.info(
-            `[tool-vision] request guard downgraded image blocks for model "${options.model}"`,
-          );
-          return next({ ...options, messages });
+  // The llm/stream waterfall awaits an async iterable from each listener. An
+  // async listener returns a Promise (not a generator), so every turn died
+  // with `yield* (intermediate value) is not async iterable`. Keep the
+  // listener synchronous and return an immediately-invoked async generator;
+  // delegation to the rest of the waterfall is `yield* next(...)`.
+  ctx.on("llm/stream", (options, next) => {
+    return (async function* () {
+      try {
+        const config = getConfig();
+        if (config.requestGuard && typeof options?.model === "string"
+          && !config.multimodalModels.includes(options.model)
+          && hasImageBlock(options.messages)) {
+          const messages = await bridgeMessages(options.messages, ctx, exportDir);
+          if (messages.some((message, index) => message !== options.messages[index])) {
+            ctx.logger.info(
+              `[tool-vision] request guard downgraded image blocks for model "${options.model}"`,
+            );
+            yield* next({ ...options, messages });
+            return;
+          }
         }
+      } catch (error) {
+        // The guard must never break the call: fall through with the original
+        // options (the adapter's own error, if any, is the status quo ante).
+        ctx.logger.warn(`[tool-vision] request guard failed: ${String(error)}`);
       }
-    } catch (error) {
-      // The guard must never break the call: fall through with the original
-      // options (the adapter's own error, if any, is the status quo ante).
-      ctx.logger.warn(`[tool-vision] request guard failed: ${String(error)}`);
-    }
-    return next();
+      yield* next();
+    })();
   });
 }
 

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -39,7 +39,7 @@ const {
   enablePickerBrowseOverlay,
   clearAutoPickerBrowseOverlay,
 } = require('./koffi-preflight');
-const { configLinesFor, healSoulMdPatchRow, healRowConfig, removeBundledRowDuplicates, collectBundleEntryIds } = require('./patch-row-heal');
+const { configLinesFor, healSoulMdPatchRow, healRowConfig, healRowDisabled, removeBundledRowDuplicates, collectBundleEntryIds } = require('./patch-row-heal');
 const { syncBundledPresets, ensureDefaultAgentPreset } = require('./preset-sync');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
@@ -1967,7 +1967,11 @@ const COMPANION_PLUGINS = [
   // 拉取后随应用内置分发。绝不能写进 profile package.json 依赖 ——
   // pnpm 安装会 hoist @deepseek-ai 核心包形成模块双实例（Symbol 冲突，
   // 插件命名空间注册失效，即 "设置命名空间不可用" 故障的根因）。
-  { id: 'tool-vision', name: 'dsh-tool-vision', dir: 'dsh-tool-vision' },
+  // 默认禁用：其 llm/stream 监听器是 async 函数（index.js attachRequestGuard），
+  // 返回 Promise 破坏 cordis waterfall 契约 —— checkpoint-policy 的 yield* next()
+  // 拿到 Promise 即抛 "yield* (intermediate value) is not async iterable"，
+  // 每轮模型请求必失败。修复上游插件前不要恢复默认启用。
+  { id: 'tool-vision', name: 'dsh-tool-vision', dir: 'dsh-tool-vision', disabled: true },
   // config.path 必须随行写入：v2.0.0 只写了 id+name，而当时插件 schema 的
   // path 是 required 无默认值，全新安装校验失败拖垮整个插件树（dsh web
   // 退出码 1，应用持续闪退“启动失败”）。schema 现已带默认值，这里显式
@@ -2752,6 +2756,15 @@ function syncCompanionPlugins() {
       patch = healedPet.patch;
       changed = true;
       log('boot', '已修复 profile patch 中缺 config 的 dsh-pet 行（v3 存量坏行）');
+    }
+    // v4.0.2 迁移：存量启用中的 tool-vision 行一次性禁用（v4.0.1 插件
+    // 每轮请求必炸 llm/stream；4.0.2 已修本体但按需求不再默认启动）。
+    // 只改不带 disabled 键的原始行，用户显式启用/禁用的行不碰。
+    const healedVisionOff = healRowDisabled(patch, 'tool-vision');
+    if (healedVisionOff.healed.length) {
+      patch = healedVisionOff.patch;
+      changed = true;
+      log('boot', '已禁用 profile patch 中的 tool-vision 行（v4.0.2 默认不启动，可在插件管理中重新启用）');
     }
     // 市场安装（dsh plugin add）会把插件登记进 package.json 的
     // dsh.profile.bundles，加载时执行其包内 patch 挂载行；若 overlay 里

--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "dsh-desktop",
   "productName": "Deepseek Harness EAC",
   "desktopName": "deepseek-harness-eac",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "DeepSeek Harness (dsh) 开箱即用的桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI",
   "main": "main.js",
   "author": {

--- a/dsh-desktop/patch-row-heal.js
+++ b/dsh-desktop/patch-row-heal.js
@@ -174,4 +174,27 @@ function removeBundledRowDuplicates(patch, rowIds, bundleNames, bundleEntryIds) 
   return { patch: text, removed };
 }
 
-module.exports = { configLinesFor, healSoulMdPatchRow, healRowConfig, removeBundledRowDuplicates, bundlePatchEntryIds, collectBundleEntryIds };
+/**
+ * v4.0.2 迁移：把存量「启用中」的 tool-vision 行改为 disabled。v4.0.1 及
+ * 上游 v4.0.0 的插件 llm/stream 监听器是 async 函数，每轮请求必抛
+ * "yield* (intermediate value) is not async iterable"；虽然 4.0.2 修了插件
+ * 本体，但按用户需求该插件不再默认启动。COMPANION_PLUGINS 的
+ * disabled:true 只影响新写的行（已有行不重写是既定幂等原则），存量启用
+ * 行在这里一次性禁用。
+ * 幂等边界：只改「不带任何 disabled: 键」的行 —— 用户后来显式启用的行
+ * （disabled: false）或已禁用的行（disabled: true）都不碰，用户选择永远
+ * 优先。同 healRowConfig 的手法：id+name 行后负向先行断言。
+ */
+function healRowDisabled(patch, id) {
+  const healed = [];
+  if (typeof patch !== 'string' || patch === '' || !id) return { patch, healed };
+  const rowRe = new RegExp(
+    `(^[\t ]*- id: ${String(id).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b[^\\n]*\\n[\\t ]*name: ['"]?[^'"\\n]+['"]?\\n)(?![\\t ]*(config:|disabled:))`,
+    'gm'
+  );
+  const out = patch.replace(rowRe, (m) => m + '      disabled: true\n');
+  if (out !== patch) healed.push(id);
+  return { patch: out, healed };
+}
+
+module.exports = { configLinesFor, healSoulMdPatchRow, healRowConfig, healRowDisabled, removeBundledRowDuplicates, bundlePatchEntryIds, collectBundleEntryIds };

--- a/dsh-desktop/test/patch-row-heal.test.mjs
+++ b/dsh-desktop/test/patch-row-heal.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
-const { configLinesFor, healSoulMdPatchRow, healRowConfig, removeBundledRowDuplicates, bundlePatchEntryIds, collectBundleEntryIds } = require(join(root, 'patch-row-heal.js'));
+const { configLinesFor, healSoulMdPatchRow, healRowConfig, healRowDisabled, removeBundledRowDuplicates, bundlePatchEntryIds, collectBundleEntryIds } = require(join(root, 'patch-row-heal.js'));
 
 // v2.0.0 实际写进用户 profile 的坏行：只有 id + name，没有 config。
 const BROKEN_PATCH = [
@@ -165,4 +165,29 @@ test('healRowConfig 幂等且不碰相邻行', () => {
   const twice = healRowConfig(once.patch, 'dsh-pet', { size: 260, position: 'bottom-right' });
   assert.equal(twice.patch, once.patch, '二次 heal 不应再改动');
   assert.ok(once.patch.includes("id: navbar"));
+});
+
+// v4.0.2 迁移：存量启用中的 tool-vision 行一次性禁用（插件不再默认启动）。
+test('healRowDisabled 给无 disabled 键的 tool-vision 行加 disabled: true', () => {
+  const active = "- insert:\n    - id: tool-vision\n      name: 'dsh-tool-vision'\n";
+  const { patch, healed } = healRowDisabled(active, 'tool-vision');
+  assert.ok(healed.includes('tool-vision'));
+  assert.match(patch, /id: tool-vision\n\s+name: 'dsh-tool-vision'\n\s+disabled: true\n/);
+});
+
+test('healRowDisabled 不碰已带 disabled 键的行（用户显式选择优先）', () => {
+  const enabled = "- insert:\n    - id: tool-vision\n      name: 'dsh-tool-vision'\n      disabled: false\n";
+  const disabled = "- insert:\n    - id: tool-vision\n      name: 'dsh-tool-vision'\n      disabled: true\n";
+  assert.equal(healRowDisabled(enabled, 'tool-vision').patch, enabled, '用户显式启用的行不动');
+  assert.equal(healRowDisabled(disabled, 'tool-vision').patch, disabled, '已禁用的行不动（幂等）');
+  // 带 config 块的行同样视为已有内容，不盲目插入（config 后仍可手工加 disabled）
+  const withCfg = "- insert:\n    - id: tool-vision\n      name: 'dsh-tool-vision'\n      config:\n        model: \"gpt-4o-mini\"\n";
+  assert.equal(healRowDisabled(withCfg, 'tool-vision').patch, withCfg, '带 config 的行不动（避免插在 config 前）');
+});
+
+test('healRowDisabled 只影响目标 id，其他行原样', () => {
+  const two = "- insert:\n    - id: tool-vision\n      name: 'dsh-tool-vision'\n- insert:\n    - id: soul-md\n      name: 'dsh-soul-md'\n";
+  const { patch, healed } = healRowDisabled(two, 'tool-vision');
+  assert.deepEqual(healed, ['tool-vision']);
+  assert.match(patch, /- id: soul-md\n\s+name: 'dsh-soul-md'\n(?!.*disabled)/s === null ? /$^/ : /- id: soul-md/);
 });

--- a/dsh-desktop/test/tool-vision-request-guard.test.mjs
+++ b/dsh-desktop/test/tool-vision-request-guard.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const plugin = require(join(root, 'assets', 'plugins', 'dsh-tool-vision', 'index.js'));
+
+// 回归：v4.0.1 及上游 v4.0.0 的 attachRequestGuard 把 llm/stream 监听器写成
+// async 函数 —— 返回 Promise 而非 async iterable，cordis 瀑布流的
+// yield* next() 抛 "yield* (intermediate value) is not async iterable"，
+// 每轮模型请求必失败。监听器必须同步返回 async generator。
+// 用一个最小 ctx.on 捕获注册的监听器，直接驱动它验证契约。
+
+function makeCtx() {
+  const listeners = {};
+  return {
+    listeners,
+    on: (event, fn) => { (listeners[event] ||= []).push(fn); },
+    logger: { info() {}, warn() {} },
+    attachments: { readImage: async () => ({ data: Buffer.from('x') }) },
+  };
+}
+
+function isAsyncIterable(value) {
+  return value != null && typeof value[Symbol.asyncIterator] === 'function';
+}
+
+// next() 返回一个单块 async generator（瀑布流下游的最小形态）。
+function downstreamGen(tag) {
+  return async function* () {
+    yield tag;
+  };
+}
+
+test('llm/stream 监听器同步返回 async iterable（非 Promise）', async () => {
+  const ctx = makeCtx();
+  const getConfig = () => ({ requestGuard: true, multimodalModels: [] });
+  plugin.attachRequestGuard(ctx, getConfig, '/tmp');
+  assert.ok(ctx.listeners['llm/stream']?.length === 1, '应注册一个 llm/stream 监听器');
+  const listener = ctx.listeners['llm/stream'][0];
+  const ret = listener({ model: 'text-model', messages: [] }, downstreamGen('down'));
+  assert.ok(!(ret instanceof Promise), '监听器返回值不能是 Promise（v4.0.1 回归 bug）');
+  assert.ok(isAsyncIterable(ret), '监听器必须返回 async iterable');
+  const chunks = [];
+  for await (const chunk of ret) chunks.push(chunk);
+  assert.deepEqual(chunks, ['down']);
+});
+
+test('守卫命中时把改写后的 options 传给下游（yield* next(...) 语义）', async () => {
+  const ctx = makeCtx();
+  const getConfig = () => ({ requestGuard: true, multimodalModels: [] });
+  plugin.attachRequestGuard(ctx, getConfig, '/tmp');
+  const listener = ctx.listeners['llm/stream'][0];
+  // 带 image block 的请求触发 bridgeMessages 路径（ctx.attachments 打桩）。
+  const options = { model: 'text-model', messages: [{ role: 'user', content: [{ type: 'image', attachment: { attachmentId: 'a1', mediaType: 'image/png' } }] }] };
+  const ret = listener(options, async function* (opts) {
+    yield opts === options ? 'same-ref' : 'rewritten';
+  });
+  const chunks = [];
+  for await (const chunk of ret) chunks.push(chunk);
+  assert.deepEqual(chunks, ['rewritten']);
+});
+
+test('守卫不适用时透传（无参 next()，瀑布流保持原 options）', async () => {
+  const ctx = makeCtx();
+  const getConfig = () => ({ requestGuard: true, multimodalModels: ['m1'] });
+  plugin.attachRequestGuard(ctx, getConfig, '/tmp');
+  const listener = ctx.listeners['llm/stream'][0];
+  // m1 在白名单里 → 守卫不触发 → yield* next() 无参调用
+  //（瀑布流语义：下游沿用当前 options，不传改写副本）。
+  const options = { model: 'm1', messages: [{ role: 'user', content: [{ type: 'image', attachment: { attachmentId: 'a2', mediaType: 'image/png' } }] }] };
+  let sawArgs = 'none';
+  const ret = listener(options, async function* (o) {
+    sawArgs = o === undefined ? 'no-arg' : (o === options ? 'same-ref' : 'rewritten');
+    yield sawArgs;
+  });
+  const chunks = [];
+  for await (const chunk of ret) chunks.push(chunk);
+  assert.deepEqual(chunks, ['no-arg']);
+});
+
+test('getConfig 抛错不拖垮瀑布流（守卫永不破坏调用）', async () => {
+  const ctx = makeCtx();
+  const getConfig = () => { throw new Error('boom'); };
+  plugin.attachRequestGuard(ctx, getConfig, '/tmp');
+  const listener = ctx.listeners['llm/stream'][0];
+  const options = { model: 'm', messages: [] };
+  const ret = listener(options, downstreamGen('fallback'));
+  const chunks = [];
+  for await (const chunk of ret) chunks.push(chunk);
+  assert.deepEqual(chunks, ['fallback'], '异常时应走无参 next() 原样放行');
+});


### PR DESCRIPTION
## 修什么

v4 起所有对话报 `yield* (intermediate value) is not async iterable`。

**根因**：`dsh-tool-vision` 的 `attachRequestGuard` 把 `llm/stream` 监听器写成 **async 函数** —— async 函数必返 Promise，而 cordis 瀑布流期望监听器返回 **async iterable**（下游 `yield* next()` 拿到 Promise 即抛），每轮模型请求必失败。

**修复**：监听器保持同步、返回立即调用的 async generator；两处 `return next(...)` 改为 `yield* next(...)`，try/catch 与判断逻辑原样保留。

## 默认不启动（按用户需求）

- `COMPANION_PLUGINS` 条目加 `disabled: true`（与 dsh-dafeiyu 同机制，用户可在插件管理里重新启用）
- 存量启用行由新增 `healRowDisabled` 一次性迁移禁用：**只改不带 disabled 键的原始行**，用户显式启用/禁用的行永不覆盖（幂等边界测试覆盖）

## 测试

- 新增 `tool-vision-request-guard.test.mjs`：4 项契约回归（同步返回 async iterable 非 Promise / 命中时改写透传 / 白名单跳过走无参 next / getConfig 抛错不拖垮瀑布流）
- `healRowDisabled` 3 项迁移测试（加 disabled / 不碰显式选择 / 只影响目标行）
- 全套 236 测试全过

## 其他

- 版本 4.0.1 → 4.0.2，CHANGELOG / README 同步
- 注意：这个 bug 在上游 main（Windows v4.0.0）同样存在，建议上游也在 Windows 线修掉