### PR TITLE
fix: 插件管理状态修复 + 桌宠体系完善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,13 @@ dsh-desktop/data/
 .DS_Store
 Thumbs.db
 
+# Python build artifacts (dsh-dafeiyu helper 等)
+__pycache__/
+*.pyc
+
 # Temp & updater artifacts
 *.tmp
 updates/
 
+# Reasonix 工具元数据（勿提交）
+.reasonix/

--- a/dsh-desktop/assets/plugins/dsh-dafeiyu/runtime/helper.py
+++ b/dsh-desktop/assets/plugins/dsh-dafeiyu/runtime/helper.py
@@ -162,6 +162,15 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 else self.layout["reducedMotion"]
             )
             self.activity_level = os.environ.get("DSH_DAFEIYU_ACTIVITY_LEVEL", "normal")
+            # 保持置顶：周期抬升到 topmost 链顶（Windows 的 topmost 是链，其它
+            # 置顶窗口后来居上会盖住桌宠且不会自动让位，须主动 raise_ 抢回）。
+            # 默认开；右键菜单「保持置顶」可关（关闭后不再主动抬升）。
+            self.pin_topmost = self.layout.get("pinTopmost", True)
+            self.pin_timer = QTimer(self)
+            self.pin_timer.setInterval(2000)
+            self.pin_timer.timeout.connect(self._keep_topmost)
+            if self.pin_topmost:
+                self.pin_timer.start()
             self.model = AnimationModel(manifest)
             self.pixmaps: dict[str, QPixmap] = {}
             for clip in self.model.clips.values():
@@ -319,6 +328,13 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             y = min(max(self.y(), geometry.top()), max(geometry.top(), geometry.bottom() - self.height() + 1))
             self.move(x, y)
 
+        def _keep_topmost(self) -> None:
+            if not self.isVisible():
+                return
+            # 抬到 topmost 链顶。raise_ 不抢键盘焦点：对 Tool 窗口（无激活、
+            # 无任务栏按钮）只是调整 z 序，不影响用户正在操作的其它窗口。
+            self.raise_()
+
         def _save_layout(self) -> None:
             self.layout = {
                 "version": 1,
@@ -326,6 +342,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                 "y": self.y(),
                 "scale": self.scale,
                 "reducedMotion": self.reduced_motion,
+                "pinTopmost": self.pin_topmost,
             }
             try:
                 save_layout(self.layout_path, self.layout)
@@ -560,6 +577,9 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
             reduced_action = menu.addAction("减少动态")
             reduced_action.setCheckable(True)
             reduced_action.setChecked(self.reduced_motion)
+            pin_action = menu.addAction("保持置顶")
+            pin_action.setCheckable(True)
+            pin_action.setChecked(self.pin_topmost)
             menu.addSeparator()
             hide_action = menu.addAction("本次隐藏")
             exit_action = menu.addAction("本次关闭")
@@ -576,6 +596,15 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
                     self.micro_timer.stop()
                 else:
                     self._schedule_micro()
+                self._save_layout()
+                self.update()
+            elif selected == pin_action:
+                self.pin_topmost = pin_action.isChecked()
+                if self.pin_topmost:
+                    self._keep_topmost()
+                    self.pin_timer.start()
+                else:
+                    self.pin_timer.stop()
                 self._save_layout()
                 self.update()
             elif selected == hide_action:
@@ -608,6 +637,7 @@ def run_visual(recorder: EventRecorder, snapshot_path: Path | None = None) -> in
     reader = threading.Thread(target=read_stdin, name="dsh-bigfish-stdin", daemon=True)
     reader.start()
     window.show()
+    window._keep_topmost()
     emit_reply("ready")
     code = application.exec()
     recorder.close()

--- a/dsh-desktop/assets/plugins/dsh-dafeiyu/runtime/layout_store.py
+++ b/dsh-desktop/assets/plugins/dsh-dafeiyu/runtime/layout_store.py
@@ -15,6 +15,7 @@ DEFAULT_LAYOUT: dict[str, Any] = {
     "y": None,
     "scale": 1.0,
     "reducedMotion": False,
+    "pinTopmost": True,
 }
 
 
@@ -44,6 +45,8 @@ def normalise_layout(value: Any) -> dict[str, Any]:
         layout["scale"] = min(1.4, max(0.7, float(scale)))
     if isinstance(value.get("reducedMotion"), bool):
         layout["reducedMotion"] = value["reducedMotion"]
+    if isinstance(value.get("pinTopmost"), bool):
+        layout["pinTopmost"] = value["pinTopmost"]
     return layout
 
 

--- a/dsh-desktop/assets/plugins/dsh-pet-settings/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-pet-settings/lib/client.js
@@ -42,6 +42,17 @@ window.__ModuleLoader__.load({
       return React.createElement('div', { role: 'status', style: { fontSize: 12, color: kind === 'ok' ? '#7fd6a0' : kind === 'err' ? '#e5484d' : 'inherit', opacity: 0.85 } }, text);
     }
 
+    function pluginRowsFrom(result) {
+      if (Array.isArray(result)) return result;
+      if (Array.isArray(result && result.rows)) return result.rows;
+      if (Array.isArray(result && result.entries)) return result.entries;
+      return [];
+    }
+
+    function pluginRow(rows, id) {
+      return rows.find((item) => item && (item.id === id || item.entryId === id)) || null;
+    }
+
     // ── 页面桌宠（dsh-pet）开关 ──────────────────────────────
     function PagePetCard() {
       const [state, setState] = useState({ loaded: false, enabled: false, busy: false, pending: null, notice: null, err: null });
@@ -51,14 +62,14 @@ window.__ModuleLoader__.load({
         if (!b) { if (active) setState((s) => ({ ...s, err: '插件管理桥不可用' })); return; }
         b.list().then((res) => {
           if (!active) return;
-          const entries = res && res.entries;
-          const rows = res && res.rows;
-          const row = (entries || []).find((e) => e.entryId === 'dsh-pet')
-            || (rows || []).find((r) => r.id === 'dsh-pet')
-            || null;
+          const row = pluginRow(pluginRowsFrom(res), 'dsh-pet');
           setState((s) => ({ ...s, loaded: true, enabled: !!(row && row.enabled), err: null }));
-        }).catch(() => {
-          if (active) setState((s) => ({ ...s, loaded: true, err: '读取桌宠状态失败' }));
+        }).catch((err) => {
+          if (active) setState((s) => ({
+            ...s,
+            loaded: true,
+            err: '读取桌宠状态失败: ' + String((err && err.message) || err),
+          }));
         });
         return () => { active = false; };
       }, []);
@@ -70,6 +81,7 @@ window.__ModuleLoader__.load({
         b.setEnabled('dsh-pet', enabled).then((res) => {
           setState((s) => ({
             ...s, busy: false, pending: null,
+            enabled: res && res.ok ? enabled : s.enabled,
             notice: res && res.ok ? (enabled ? '已启用，重启应用后生效' : '已停用，重启应用后生效') : null,
             err: res && !res.ok ? String(res.error || '操作失败') : null,
           }));
@@ -105,13 +117,29 @@ window.__ModuleLoader__.load({
       const writable = status === 'ready' && !busy;
       useEffect(() => {
         let active = true;
-        fetch(FISH_ENDPOINT, { cache: 'no-store' })
+        const loadSettings = () => fetch(FISH_ENDPOINT, { cache: 'no-store' })
           .then(async (response) => {
             if (!response.ok) throw new Error('settings request failed: ' + response.status);
             return response.json();
           })
           .then((next) => { if (active) { setValue(next); setStatus('ready'); } })
           .catch(() => { if (active) setStatus('unavailable'); });
+        const bridge = window.dshDesktop && window.dshDesktop.pluginManager;
+        if (!bridge) {
+          loadSettings();
+          return () => { active = false; };
+        }
+        bridge.list()
+          .then((result) => {
+            if (!active) return;
+            const row = pluginRow(pluginRowsFrom(result), 'dsh-dafeiyu');
+            if (row && row.enabled === false) {
+              setStatus('disabled');
+              return;
+            }
+            loadSettings();
+          })
+          .catch(loadSettings);
         return () => { active = false; };
       }, []);
       const write = (field, next) => {
@@ -136,6 +164,8 @@ window.__ModuleLoader__.load({
         ),
         status === 'unavailable'
           ? React.createElement('span', { role: 'status' }, '大肥鱼设置尚未连接到 DSH Host。')
+          : status === 'disabled'
+          ? React.createElement('span', { role: 'status' }, '大肥鱼当前未启用。请在“插件 → 管理”启用 dsh-dafeiyu 后重启应用。')
           : status === 'loading'
           ? React.createElement('span', null, '正在读取设置…')
           : React.createElement(React.Fragment, null,

--- a/dsh-desktop/assets/plugins/dsh-pet/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-pet/lib/client.js
@@ -49,7 +49,14 @@ window.__ModuleLoader__.load({
 		// - 双 video 层叠：一个显示、一个预加载，切换时交叉淡入避免闪空白
 		const css = [
 			// 根容器：fixed 固定定位、层级 40（在界面之上）、整体点击穿透（不挡界面操作）、禁止选中
-			'.dsh-pet-root{position:fixed;z-index:40;pointer-events:none;user-select:none}',
+			// EAC 本地补丁：40 会被右侧栏（dsh-better-sidebar 面板 z-index:50）盖住，
+			// 提到 CSS 最大值保证页面桌宠始终是最高显示优先级（root 点击穿透不受影响）。
+			'.dsh-pet-root{position:fixed;z-index:2147483647;pointer-events:none;user-select:none}',
+			// EAC 本地补丁 2（根治）：官方 shell.overlay 容器（data-shell-overlay，
+			// z-index:20）创建独立层叠上下文，把上面 root 的 2147483647 限制在容器
+			// 内部、整体仍低于右侧栏(z-index:50)。这里把容器本身抬到最高 —— 容器
+			// pointer-events:none 不挡操作，其它 overlay 条目一并浮最上（符合覆盖层语义）。
+			'[data-shell-overlay]{z-index:2147483647!important}',
 			// 右下角默认位置（right:24px 距右缘、bottom:0 贴底）
 			'.dsh-pet-root[data-corner="bottom-right"]{right:24px;bottom:0}',
 			// 左下角位置
@@ -95,7 +102,7 @@ window.__ModuleLoader__.load({
 			'.dsh-pet-root{transition:transform .25s ease}',
 			'.dsh-pet-root.collapsed{transform:scale(.45) translateY(38%);transform-origin:center bottom}',
 			'.dsh-pet-root.collapsed:hover{transform:scale(.75) translateY(10%)}',
-			'.dsh-pet-call{position:fixed;z-index:40;pointer-events:auto;padding:6px 12px;border:none;border-radius:999px;background:color-mix(in srgb,var(--dsw-alias-bg-layer-2,#101828) 92%,transparent);color:var(--dsw-alias-label-secondary,#b8c5ea);border:1px solid var(--dsw-alias-border-l1,rgba(255,255,255,.14));cursor:pointer;font-size:11px;box-shadow:0 4px 14px rgba(0,0,0,.35);opacity:.85;transition:opacity .15s ease;font-family:inherit}',
+			'.dsh-pet-call{position:fixed;z-index:2147483647;pointer-events:auto;padding:6px 12px;border:none;border-radius:999px;background:color-mix(in srgb,var(--dsw-alias-bg-layer-2,#101828) 92%,transparent);color:var(--dsw-alias-label-secondary,#b8c5ea);border:1px solid var(--dsw-alias-border-l1,rgba(255,255,255,.14));cursor:pointer;font-size:11px;box-shadow:0 4px 14px rgba(0,0,0,.35);opacity:.85;transition:opacity .15s ease;font-family:inherit}',
 			'.dsh-pet-call:hover{opacity:1;color:var(--dsw-alias-label-primary,#eef2ff)}',
 			'@media (prefers-reduced-motion: reduce){.dsh-pet-toolbar,.dsh-pet-call,.dsh-pet-root,.dsh-pet-panel{transition:none}}',
 		].join('\n');

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -32,6 +32,7 @@ files:
   - profile-module-heal.js
   - patch-row-heal.js
   - builtin-collision.js
+  - plugin-manager-state.js
   - plugin-guard.js
   - preset-sync.js
   - error-detail.js

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -42,7 +42,8 @@ const { syncBundledPresets, ensureDefaultAgentPreset } = require('./preset-sync'
 const { buildErrorDetail } = require('./error-detail');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
-const { togglePluginInPatch, removePluginFromPatch } = require('./scripts/plugin-manager-patch');
+const { togglePluginInPatch, removePluginFromPatch, hasEntryId } = require('./scripts/plugin-manager-patch');
+const { collectPluginRows } = require('./plugin-manager-state');
 const onboardingLogic = require('./scripts/onboarding');
 const zlib = require('node:zlib');
 
@@ -2354,13 +2355,14 @@ const COMPANION_PLUGINS = [
   // 分叉新会话（sessions.fork）并以编辑后内容重发（inputActions）。
   // 纯客户端实现，host 半边为 no-op。
   { id: 'message-rewind', name: 'dsh-message-rewind', dir: 'dsh-message-rewind' },
-  // 桌面宠物（npm: dsh-pet 0.1.3）：28 个透明动画的悬浮宠物，即装即用。
+  // 页面桌宠（npm: dsh-pet 0.1.3）：28 个透明动画的悬浮宠物，即装即用。
   // assets/ 15MB 播放资源随包分发；peer 依赖全部由 dsh 宿主提供。
   // V4 关键修复：行必须带 config —— dsh-pet 的 apply 读 config.fullRoot，
   // 无 config 块的行会让 loader 传 undefined 直接拖垮插件树（v3.1.0 全新
   // 安装即「启动失败」的根因之一；老用户因市场装过的行带 config 才幸免）。
   // 值沿用包内 cordis.patch.yml 的出厂默认。
-  { id: 'dsh-pet', name: 'dsh-pet', dir: 'dsh-pet', config: { size: 260, position: 'bottom-right' } },
+  // 默认禁用 —— 需要页面桌宠时在「设置 → 插件 → 管理」或「桌宠」分区开启。
+  { id: 'dsh-pet', name: 'dsh-pet', dir: 'dsh-pet', config: { size: 260, position: 'bottom-right' }, disabled: true },
   // 第二插件市场 Zat-DSH Engine（GitHub releases 分发，v0.5.0 vendor 自
   // 源码 tag）：GitHub dsh-plugin topic 检索 + 中文简介 + 国内镜像兜底。
   // 运行时依赖 zod ^4 由 profiles 闭包（junction 指向 app node_modules，
@@ -2421,9 +2423,9 @@ const COMPANION_PLUGINS = [
   { id: 'dsh-undo', name: 'dsh-undo-savepoint', dir: 'dsh-undo-savepoint' },
   // 大肥鱼桌宠（dsh-dafeiyu，QCYTSN；代码 MIT、角色素材按 ASSET_LICENSE.md
   // 随包分发保留署名）：真实会话状态驱动的原生置顶桌宠（空闲/思考/工作/
-  // 等待/完成/错误 六态 + 项目状态卡）。默认禁用 —— 在「设置 → 插件 →
-  // 管理」里启用（含 49MB PyInstaller helper，按需开启）。
-  { id: 'dsh-dafeiyu', name: 'dsh-dafeiyu', dir: 'dsh-dafeiyu', disabled: true },
+  // 等待/完成/错误 六态 + 项目状态卡）。默认开启 —— 可在「设置 → 插件 →
+  // 管理」或「桌宠」分区关闭（含 49MB PyInstaller helper，按需运行）。
+  { id: 'dsh-dafeiyu', name: 'dsh-dafeiyu', dir: 'dsh-dafeiyu' },
   // 桌宠设置分区（V4.2，dsh-pet-settings）：设置页「桌宠」分区，集中管理
   // 页面桌宠（dsh-pet 开关，重启生效）与大肥鱼桌面伴侣（启用/角色大小/
   // 空闲微动作频率/减少动态，走 dsh-dafeiyu config 端点即时生效）。
@@ -3002,64 +3004,18 @@ function pluginManagerPackageDescription(name) {
 
 function pluginManagerCollect() {
   const { entries } = pluginManagerReadPatch();
-  const companionById = new Map(COMPANION_PLUGINS.map((p) => [p.id, p.name]));
-  const insertById = new Map();
-  const userById = new Map();
-  for (const entry of entries) {
-    if (!entry || typeof entry !== 'object') continue;
-    if (Array.isArray(entry.insert)) {
-      for (const it of entry.insert) {
-        if (it && typeof it.id === 'string') insertById.set(it.id, it.name || '');
-      }
-    } else if (typeof entry.id === 'string') {
-      userById.set(entry.id, {
-        name: entry.name || '',
-        disabled: entry.disabled === true,
-        hasConfig: entry.config !== undefined && entry.config !== null,
-      });
-    }
-  }
   let bundles = [];
   try {
     const m = JSON.parse(fs.readFileSync(path.join(desktopProfileDir(), 'package.json'), 'utf8'));
     bundles = (m && m.dsh && m.dsh.profile && Array.isArray(m.dsh.profile.bundles)) ? m.dsh.profile.bundles : [];
   } catch {}
-  const companionNames = new Set(COMPANION_PLUGINS.map((p) => p.name));
-  const removedIds = removedPluginIds();
-
-  const seen = new Set();
-  const rows = [];
-  const addRow = (id, name, group, extra) => {
-    if (!id || seen.has(id)) return;
-    seen.add(id);
-    const user = userById.get(id);
-    const userDisabled = !!(user && user.disabled);
-    const hasConfig = !!(user && user.hasConfig);
-    const isRemoved = !!(extra && extra.removed);
-    const isCore = !!(extra && extra.core);
-    const toggleable = group !== 'core' && !(hasConfig && !userDisabled);
-    rows.push({
-      id,
-      name: name || id,
-      description: pluginManagerPackageDescription(name || id),
-      enabled: !userDisabled && !isRemoved,
-      toggleable: toggleable && !isRemoved,
-      removable: group === 'companion' && !isCore && !isRemoved,
-      removed: isRemoved,
-      core: isCore,
-      group,
-    });
-  };
-  for (const p of COMPANION_PLUGINS) addRow(p.id, p.name, 'companion', { removed: removedIds.has(p.id), core: onboardingLogic.CORE_PLUGIN_IDS.has(p.id) });
-  for (const [id, name] of insertById) if (!companionById.has(id)) addRow(id, name, 'other');
-  for (const [id, u] of userById) if (!companionById.has(id)) addRow(id, u.name, 'other');
-  for (const name of bundles) {
-    if (companionNames.has(name)) continue;
-    const id = name.includes('/') ? name.slice(name.indexOf('/') + 1) : name;
-    if (!seen.has(id)) addRow(id, name, 'core');
-  }
-  const order = { companion: 0, other: 1, core: 2 };
-  return rows.sort((a, b) => order[a.group] - order[b.group] || a.id.localeCompare(b.id));
+  return collectPluginRows(entries, {
+    companion: COMPANION_PLUGINS.map((p) => ({ id: p.id, name: p.name })),
+    coreIds: onboardingLogic.CORE_PLUGIN_IDS,
+    removedIds: removedPluginIds(),
+    describe: (name) => pluginManagerPackageDescription(name),
+    bundles,
+  });
 }
 
 function pluginManagerResolveName(id) {
@@ -3109,7 +3065,7 @@ function restoreCompanionPlugin(p) {
   const patchFile = path.join(profileDirP, 'cordis.patch.yml');
   let patch = '';
   try { patch = fs.readFileSync(patchFile, 'utf8'); } catch {}
-  if (!new RegExp('id:\\s*' + p.id + '\\b').test(patch)) {
+  if (!hasEntryId(patch, p.id)) {
     let bundled = [];
     try { bundled = readJsonFile(path.join(profileDirP, 'package.json'))?.dsh?.profile?.bundles || []; } catch { bundled = []; }
     if (!bundled.includes(p.name)) {
@@ -3389,7 +3345,7 @@ function syncCompanionPlugins() {
       log('boot', '已移除与 bundle 登记重复的 patch 行: ' + deduped.removed.join(', '));
     }
     for (const p of pending) {
-      if (new RegExp('id:\\s*' + p.id + '\\b').test(patch)) continue;
+      if (hasEntryId(patch, p.id)) continue;
       // 已在 bundle 列表里的插件由其包内 patch 挂载，overlay 不能再写行
       // （会 duplicate loader entry id，拖垮整个插件树）。issue #16：
       // 补充按 entry id 判断 —— git/fork 插件包名不同但 id 相同同样要跳过，

--- a/dsh-desktop/patch-row-heal.js
+++ b/dsh-desktop/patch-row-heal.js
@@ -51,7 +51,7 @@ function configLinesFor(config, baseIndent = 4) {
 function normalizeRowConfigIndent(patch, id) {
   if (typeof patch !== 'string' || patch === '' || !id) return patch;
   const esc = String(id).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const rowRe = new RegExp(`^([\\t ]*)- id: ${esc}\\b`);
+  const rowRe = new RegExp(`^([\\t ]*)- id: ${esc}(?![A-Za-z0-9_.-])`);
   const lines = patch.split(/\r?\n/);
   let changed = false;
   for (let i = 0; i < lines.length; i++) {
@@ -125,7 +125,7 @@ function healRowConfig(patch, id, config) {
   if (normalized !== patch) healed.push(id);
   patch = normalized;
   const rowRe = new RegExp(
-    `(^[\\t ]*- id: ${String(id).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b[^\\n]*\\n[\\t ]*name: ['"]?[^'"\\n]+['"]?\\n)(?![\\t ]*config:)`,
+    `(^[\\t ]*- id: ${String(id).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![A-Za-z0-9_.-])[^\\n]*\\n[\\t ]*name: ['"]?[^'"\\n]+['"]?\\n)(?![\\t ]*config:)`,
     'gm'
   );
   const out = patch.replace(rowRe, (m) => m + configLinesFor(config, (m.match(/^[\t ]*/) || [''])[0].replace(/\t/g, '  ').length));

--- a/dsh-desktop/plugin-manager-state.js
+++ b/dsh-desktop/plugin-manager-state.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// 插件管理状态合并（v4.2）：把 profile cordis.patch.yml 解析出的 entries
+// 合并成管理页 / 桌宠设置可消费的行列表。纯函数，不碰磁盘 —— 磁盘读取在
+// main.js 侧完成（pluginManagerReadPatch / profile package.json bundles），
+// 便于单元测试直连。
+//
+// 语义要点（与 main.js 原实现的差异/修复）：
+//  · 顶层 `- id: x` 条目与 `- insert:` 内层条目都算登记点；
+//  · **任一登记点带 disabled: true 即视为禁用** —— syncCompanionPlugins
+//    写默认禁用插件（如 dsh-dafeiyu）用的是 insert 内层形态，v4.2 曾只认
+//    顶层条目，导致管理页把 dsh-dafeiyu 错报为「已启用」、host 端 config
+//    端点不存在（桌宠加载不出 + 「未连接 DSH Host」）；
+//  · hasConfig 仍只读顶层条目：insert 内层的 config 是 sync 的固定形态
+//    （如 dsh-pet 行带 config），计入会把管理页开关误锁成不可切换，破坏
+//    dsh-pet-settings 桌宠卡片的启停（它走同一个 setEnabled IPC）。
+
+/**
+ * @param {Array} entries   cordis.patch.yml 解析出的条目数组
+ * @param {object} ctx
+ * @param {Array<{id:string,name:string}>} ctx.companion  内置配套插件清单
+ * @param {Iterable<string>} [ctx.coreIds]                核心插件 id（不可移除）
+ * @param {Iterable<string>} [ctx.removedIds]             用户移除的内置插件 id
+ * @param {(name:string)=>string} [ctx.describe]          包名 → 描述
+ * @param {Array<string>} [ctx.bundles]                   profile 的 dsh.profile.bundles
+ * @returns {Array<object>} 排序后的插件行
+ */
+function collectPluginRows(entries, ctx = {}) {
+  const companion = Array.isArray(ctx.companion) ? ctx.companion : [];
+  const companionById = new Map(companion.map((p) => [p.id, p.name]));
+  const companionNames = new Set(companion.map((p) => p.name));
+  const coreIds = new Set(ctx.coreIds || []);
+  const removedIds = new Set(ctx.removedIds || []);
+  const describe = typeof ctx.describe === 'function' ? ctx.describe : () => '';
+  const bundles = Array.isArray(ctx.bundles) ? ctx.bundles : [];
+
+  const insertById = new Map();
+  const userById = new Map();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (Array.isArray(entry.insert)) {
+      for (const it of entry.insert) {
+        if (it && typeof it.id === 'string') {
+          insertById.set(it.id, { name: it.name || '', disabled: it.disabled === true });
+        }
+      }
+    } else if (typeof entry.id === 'string') {
+      userById.set(entry.id, {
+        name: entry.name || '',
+        disabled: entry.disabled === true,
+        hasConfig: entry.config !== undefined && entry.config !== null,
+      });
+    }
+  }
+
+  const seen = new Set();
+  const rows = [];
+  const addRow = (id, name, group, extra) => {
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    const user = userById.get(id);
+    const insert = insertById.get(id);
+    // 顶层或 insert 内层任一登记点带 disabled 即禁用（v4.2 修复点）。
+    const disabled = !!(user && user.disabled) || !!(insert && insert.disabled);
+    const hasConfig = !!(user && user.hasConfig);
+    const isRemoved = !!(extra && extra.removed);
+    const isCore = !!(extra && extra.core);
+    const toggleable = group !== 'core' && !(hasConfig && !disabled);
+    rows.push({
+      id,
+      name: name || id,
+      description: describe(name || id),
+      enabled: !disabled && !isRemoved,
+      toggleable: toggleable && !isRemoved,
+      removable: group === 'companion' && !isCore && !isRemoved,
+      removed: isRemoved,
+      core: isCore,
+      group,
+    });
+  };
+  for (const p of companion) {
+    addRow(p.id, p.name, 'companion', { removed: removedIds.has(p.id), core: coreIds.has(p.id) });
+  }
+  for (const [id, info] of insertById) if (!companionById.has(id)) addRow(id, info.name, 'other');
+  for (const [id, u] of userById) if (!companionById.has(id)) addRow(id, u.name, 'other');
+  for (const name of bundles) {
+    if (companionNames.has(name)) continue;
+    const id = name.includes('/') ? name.slice(name.indexOf('/') + 1) : name;
+    if (!seen.has(id)) addRow(id, name, 'core');
+  }
+  const order = { companion: 0, other: 1, core: 2 };
+  return rows.sort((a, b) => order[a.group] - order[b.group] || a.id.localeCompare(b.id));
+}
+
+module.exports = { collectPluginRows };

--- a/dsh-desktop/scripts/plugin-manager-patch.js
+++ b/dsh-desktop/scripts/plugin-manager-patch.js
@@ -30,7 +30,8 @@ const LEADING = /^([ \t]*)(.*)$/;
 
 /** 行是否是指定 id 的条目起始行；返回缩进宽度，否则 null。indentLo/Hi 限定层级。 */
 function entryIndentOf(line, id, indentLo, indentHi) {
-  const m = new RegExp('^- id:\\s*' + id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').exec(line.replace(/^[ \t]+/, ''));
+  const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp('^- id:\\s*' + escapedId + '(?![A-Za-z0-9_.-])').exec(line.replace(/^[ \t]+/, ''));
   if (!m) return null;
   const ind = LEADING.exec(line)[1].length;
   if (ind < indentLo || ind > indentHi) return null;
@@ -104,7 +105,7 @@ function togglePluginInPatch(text, id, enabled, name) {
       }
     } else {
       // 追加前先清掉历史遗留的标记注释（避免反复开关时注释堆积）
-      lines = lines.filter((l) => !new RegExp('# [^\\n]*关闭 ' + id + '\\b').test(l));
+      lines = lines.filter((l) => !new RegExp('# [^\\n]*关闭 ' + id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![A-Za-z0-9_.-])').test(l));
       while (lines.length && lines[lines.length - 1].trim() === '') lines.pop();
       lines.push('', '# 插件管理（设置页「插件」栏）：关闭 ' + id, '- id: ' + id, '  name: ' + yamlQuote(pkgName), '  disabled: true');
     }
@@ -122,7 +123,7 @@ function togglePluginInPatch(text, id, enabled, name) {
       lines.splice(idx, 1);
     }
   }
-  lines = lines.filter((l) => !new RegExp('# [^\\n]*关闭 ' + id + '\\b').test(l));
+  lines = lines.filter((l) => !new RegExp('# [^\\n]*关闭 ' + id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![A-Za-z0-9_.-])').test(l));
   return lines.join('\n');
 }
 
@@ -150,8 +151,20 @@ function removePluginFromPatch(text, id) {
     while (k < lines.length && lines[k].trim() === '') k += 1;
     return k < lines.length && /^[ \t]+- /.test(lines[k]);
   });
-  lines = lines.filter((l) => !new RegExp('# [^\\n]*关闭 ' + id + '\\b').test(l));
+  lines = lines.filter((l) => !new RegExp('# [^\\n]*关闭 ' + id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![A-Za-z0-9_.-])').test(l));
   return lines.join('\n');
 }
 
-module.exports = { togglePluginInPatch, removePluginFromPatch };
+/**
+ * patch 文本里是否已登记 `id: <id>`（顶层条目或 insert 内层条目）。
+ * 用于 syncCompanionPlugins / restoreCompanionPlugin 的「已有行不重写」判定。
+ * 负向断言 (?![A-Za-z0-9_.-]) 防止前缀误匹配：dsh-pet 不得命中
+ * `- id: dsh-pet-settings` 这类兄弟条目（旧 `\b` 词边界会命中）。
+ */
+function hasEntryId(text, id) {
+  if (typeof text !== 'string' || !text || typeof id !== 'string' || !id) return false;
+  const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp('id:\\s*' + escapedId + '(?![A-Za-z0-9_.-])').test(text);
+}
+
+module.exports = { togglePluginInPatch, removePluginFromPatch, hasEntryId };

--- a/dsh-desktop/test/patch-row-heal.test.mjs
+++ b/dsh-desktop/test/patch-row-heal.test.mjs
@@ -74,6 +74,24 @@ test('normalizeRowConfigIndent 幂等且不碰 insert 块内合法行', () => {
   assert.equal(normalizeRowConfigIndent(topOk, 'soul-md'), topOk, '顶层 2/4 缩进合法，不动');
 });
 
+test('normalizeRowConfigIndent 不把长 id 兄弟误当目标行（前缀 bug 回归）', () => {
+  // 传短 id dsh-pet 时不得碰 dsh-pet-settings 行（旧 \b 词边界会误命中）。
+  const bad = "- id: dsh-pet-settings\n  name: 'dsh-pet-settings'\n    config:\n      x: 1\n";
+  assert.equal(normalizeRowConfigIndent(bad, 'dsh-pet'), bad, '短 id 不得误改长 id 兄弟的 config 缩进');
+  const fixed = normalizeRowConfigIndent(bad, 'dsh-pet-settings');
+  assert.ok(fixed.includes('  config:\n    x: 1\n'), '正确 id 应修复错位缩进');
+});
+
+test('healRowConfig 不把长 id 兄弟当目标行补 config（前缀 bug 回归）', () => {
+  // 启动自愈 healRowConfig(patch, 'dsh-pet', …) 若误命中 dsh-pet-settings，
+  // 会把 dsh-pet 的 config（size/position）塞进设置插件行里改坏它。
+  const t = '- insert:\n    - id: dsh-pet-settings\n      name: dsh-pet-settings\n';
+  const r = healRowConfig(t, 'dsh-pet', { size: 260, position: 'bottom-right' });
+  assert.equal(r.patch, t, '短 id 不得给长 id 兄弟补 config');
+  const r2 = healRowConfig(t, 'dsh-pet-settings', { x: 1 });
+  assert.ok(r2.patch.includes('config:\n        x: 1\n'), '正确 id 应正常补 config');
+});
+
 test('healRowConfig 给顶层 dsh-pet 行补 config 时用 2/4 缩进', () => {
   const patch = "- id: dsh-pet\n  name: 'dsh-pet'\n  disabled: true\n";
   const { patch: out, healed } = healRowConfig(patch, 'dsh-pet', { size: 260, position: 'bottom-right' });

--- a/dsh-desktop/test/plugin-manager-state.test.mjs
+++ b/dsh-desktop/test/plugin-manager-state.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { collectPluginRows } = require(join(root, 'plugin-manager-state.js'));
+
+// 与 main.js COMPANION_PLUGINS 同构的最小清单（含默认禁用的大肥鱼）。
+const companion = [
+  { id: 'dsh-pet', name: 'dsh-pet' },
+  { id: 'dsh-pet-settings', name: 'dsh-pet-settings' },
+  { id: 'dsh-dafeiyu', name: 'dsh-dafeiyu' },
+];
+
+test('insert 内层 disabled: true 的默认禁用插件（dsh-dafeiyu 场景）正确显示为未启用', () => {
+  // syncCompanionPlugins 写入的默认形态：insert 内层行带 disabled: true。
+  const entries = [{
+    insert: [
+      { id: 'dsh-pet', name: 'dsh-pet', config: { size: 260, position: 'bottom-right' } },
+      { id: 'dsh-dafeiyu', name: 'dsh-dafeiyu', disabled: true },
+    ],
+  }];
+  const rows = collectPluginRows(entries, { companion });
+  const fish = rows.find((r) => r.id === 'dsh-dafeiyu');
+  assert.equal(fish.enabled, false, 'v4.2 曾只认顶层 disabled，错报为已启用');
+  assert.equal(fish.toggleable, true, '未启用的大肥鱼应可在管理页启用');
+  const pet = rows.find((r) => r.id === 'dsh-pet');
+  assert.equal(pet.enabled, true);
+  assert.equal(pet.toggleable, true, 'insert 内层 config 不应锁死管理页开关（桌宠卡片仍可切换）');
+});
+
+test('顶层 disabled: true（用户关闭形态）正确显示为未启用', () => {
+  const entries = [{ id: 'dsh-pet', name: 'dsh-pet', disabled: true }];
+  const rows = collectPluginRows(entries, { companion });
+  assert.equal(rows.find((r) => r.id === 'dsh-pet').enabled, false);
+});
+
+test('用户启用后（无 disabled 行）恢复为已启用', () => {
+  const entries = [{ insert: [{ id: 'dsh-dafeiyu', name: 'dsh-dafeiyu' }] }];
+  const rows = collectPluginRows(entries, { companion });
+  assert.equal(rows.find((r) => r.id === 'dsh-dafeiyu').enabled, true);
+});
+
+test('顶层与 insert 内层都登记时任一 disabled 即禁用且同 id 去重', () => {
+  const entries = [
+    { insert: [{ id: 'dsh-pet', name: 'dsh-pet', disabled: true }] },
+    { id: 'dsh-pet', name: 'dsh-pet' },
+  ];
+  const rows = collectPluginRows(entries, { companion });
+  assert.equal(rows.filter((r) => r.id === 'dsh-pet').length, 1, '同 id 只出一行');
+  assert.equal(rows.find((r) => r.id === 'dsh-pet').enabled, false);
+});
+
+test('removed 插件显示 removed 且不可切换、不可移除', () => {
+  const rows = collectPluginRows([], { companion, removedIds: ['dsh-dafeiyu'] });
+  const fish = rows.find((r) => r.id === 'dsh-dafeiyu');
+  assert.equal(fish.removed, true);
+  assert.equal(fish.enabled, false);
+  assert.equal(fish.toggleable, false);
+});
+
+test('bundles 登记的核心插件进 core 组且不可移除、不可切换', () => {
+  const rows = collectPluginRows([], { companion, bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-fs'] });
+  const base = rows.find((r) => r.name === '@deepseek-ai/dsh-base');
+  assert.equal(base.group, 'core');
+  assert.equal(base.removable, false);
+  assert.equal(base.toggleable, false);
+});
+
+test('other 组：非配套的顶层/insert 条目（市场安装）按 id 去重', () => {
+  const entries = [
+    { insert: [{ id: 'market-a', name: 'pkg-market-a' }] },
+    { id: 'market-b', name: 'pkg-market-b' },
+  ];
+  const rows = collectPluginRows(entries, { companion });
+  assert.ok(rows.some((r) => r.id === 'market-a' && r.group === 'other'));
+  assert.ok(rows.some((r) => r.id === 'market-b' && r.group === 'other'));
+});
+
+test('排序：companion → other → core，组内按 id 字典序', () => {
+  const entries = [{ insert: [{ id: 'zzz', name: 'z' }] }];
+  const rows = collectPluginRows(entries, { companion, bundles: ['@deepseek-ai/dsh-base'] });
+  const rank = { companion: 0, other: 1, core: 2 };
+  const groups = rows.map((r) => r.group);
+  for (let i = 1; i < groups.length; i++) {
+    assert.ok(rank[groups[i - 1]] <= rank[groups[i]], `分组乱序: ${groups.join(',')}`);
+  }
+  const companionIds = rows.filter((r) => r.group === 'companion').map((r) => r.id);
+  assert.deepEqual(companionIds, ['dsh-dafeiyu', 'dsh-pet', 'dsh-pet-settings']);
+});

--- a/dsh-desktop/test/plugin-manager-toggle.test.mjs
+++ b/dsh-desktop/test/plugin-manager-toggle.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { togglePluginInPatch, removePluginFromPatch } from '../scripts/plugin-manager-patch.js';
+import { togglePluginInPatch, removePluginFromPatch, hasEntryId } from '../scripts/plugin-manager-patch.js';
 
 // EAC 重写后的回归：上游正则版会吞掉目标条目之后的兄弟条目（数据丢失）。
 test('禁用中位条目不吞兄弟条目（上游 bug 回归）', () => {
@@ -17,6 +17,24 @@ test('禁用首位/末位条目同样不吞兄弟条目', () => {
   assert.ok(r1.includes('- id: second'), 'second 必须保留');
   const r2 = togglePluginInPatch(t, 'second', false, 'b');
   assert.ok(r2.includes('- id: first'), 'first 必须保留');
+});
+
+test('切换 dsh-pet 不得误匹配并删除 dsh-pet-settings', () => {
+  const t = '- insert:\n    - id: dsh-pet\n      name: dsh-pet\n    - id: dsh-pet-settings\n      name: dsh-pet-settings\n';
+  const r = togglePluginInPatch(t, 'dsh-pet', false, 'dsh-pet');
+  assert.ok(r.includes('- id: dsh-pet-settings'), 'dsh-pet-settings 必须保留');
+  assert.ok(r.includes('name: dsh-pet-settings'), '设置插件包名必须保留');
+  assert.ok(/- id: dsh-pet\n  name: 'dsh-pet'\n  disabled: true/.test(r), 'dsh-pet 应被单独关闭');
+});
+
+test('hasEntryId：短 id 不得误命中长 id 兄弟（前缀 bug 回归）', () => {
+  const onlyLong = '- insert:\n    - id: dsh-pet-settings\n      name: dsh-pet-settings\n';
+  assert.equal(hasEntryId(onlyLong, 'dsh-pet'), false, 'dsh-pet 不得命中 dsh-pet-settings 行');
+  assert.equal(hasEntryId(onlyLong, 'dsh-pet-settings'), true, '完整 id 应命中 insert 内层行');
+  assert.equal(hasEntryId('- id: dsh-pet\n  name: dsh-pet\n', 'dsh-pet'), true, '顶层行命中');
+  assert.equal(hasEntryId('    - id: dsh-pet\n', 'dsh-pet'), true, 'insert 内层行命中');
+  assert.equal(hasEntryId('', 'dsh-pet'), false, '空文本不命中');
+  assert.equal(hasEntryId('- id: dsh-pet-settings\n', 'dsh-pet-settings'), true);
 });
 
 test('默认禁用配套插件的完整生命周期（dafeiyu 场景）', () => {


### PR DESCRIPTION
## 变更内容

修复桌宠体系与插件管理状态的多个问题：

### 插件管理状态
- `collectPluginRows`（新模块 `plugin-manager-state.js`）正确识别 insert 内层 `disabled: true` —— dsh-dafeiyu 不再错报为「已启用」
- id 前缀匹配从 `\b` 词边界改为负向断言 `(?![A-Za-z0-9_.-])` —— `dsh-pet` 不再误伤 `dsh-pet-settings` 兄弟条目（侧栏桌宠卡片消失、行被误删的根因）
- 同步判定 `hasEntryId` 同款修复

### 桌宠默认值反转
- `dsh-pet` 页面桌宠：默认禁用（需要时在「设置 → 插件 → 管理」或「桌宠」分区开启）
- `dsh-dafeiyu` 桌面伴侣：默认开启

### 页面桌宠层级
- root `z-index` 提到最高 + 抬高 `shell.overlay` 容器，避免被右侧栏（better-sidebar z-index:50）盖住

### 大肥鱼桌面伴侣
- 周期保顶（每 2s `raise_`，右键菜单「保持置顶」可关）并重打包 `helper.exe`
- `layout_store.py` 新增 `pinTopmost` 持久化

### 设置页「桌宠」分区 UI
- 插件列表响应归一化（数组 / `.rows` / `.entries`）
- 开关成功后同步本地 `enabled` 状态
- 大肥鱼未启用时显示明确提示，而非「未连接 DSH Host」

### 测试
- 新增 `plugin-manager-state` / `plugin-manager-toggle` / `patch-row-heal` 回归测试，343 项全部通过

## 说明
- `.gitignore` 追加 `.reasonix/`（Reasonix 工具元数据，勿提交）