### PR TITLE
fix:修复skill打开目录失效问题

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -2321,7 +2321,18 @@ function registerChromeIpc() {
   ipcMain.handle('dsh:file-open', async (event, { path: p } = {}) => {
     if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'forbidden' };
     if (typeof p !== 'string' || !path.isAbsolute(p)) return { ok: false, error: 'path must be absolute' };
-    if (!isUnderFileRoots(p)) return { ok: false, error: 'path outside session workspace' };
+    // Skills 根目录（~/.dsh/skills、~/.agents/skills）不在会话工作区内，但
+    // 「设置 → Skills 与 MCP → 打开目录」需要放行；严格限定为两个根本身及其
+    // 子路径（白名单，非任意路径），危险扩展名检查仍生效。
+    const skillsRoots = [
+      path.join(dshHome || path.join(os.homedir(), '.dsh'), 'skills'),
+      path.join(process.env.DSH_AGENTS_HOME || path.join(os.homedir(), '.agents'), 'skills'),
+    ];
+    const underSkillsRoot = skillsRoots.some((r) => {
+      const rp = path.resolve(r);
+      return p === rp || p.startsWith(rp + path.sep);
+    });
+    if (!underSkillsRoot && !isUnderFileRoots(p)) return { ok: false, error: 'path outside session workspace' };
     if (DANGEROUS_EXT.test(p)) return { ok: false, error: 'executable files are not openable from the file view' };
     try {
       if (!fs.existsSync(p)) return { ok: false, error: 'file not found' };


### PR DESCRIPTION
## 变更内容

修复「设置 → Skills 与 MCP → 打开目录」在文件视图里打不开的问题。

### 改动（dsh-desktop/main.js，+12/-1）
- 在 `dsh:file-open` IPC 校验中放行 Skills 根目录白名单：
  - `~/.dsh/skills`
  - `~/.agents/skills`（支持 `DSH_AGENTS_HOME` 环境变量）
- 严格限定为这两个根本身及其子路径（白名单，非任意路径）
- 危险扩展名检查（DANGEROUS_EXT）仍然生效

## 说明
- cherry-pick 自本地 feat 分支提交 fd390f6，内容与已验证版本一致
- 语法检查通过（node --check）