### PR TITLE
修复(UI)：设置卡片去重 & 折叠视觉模型高级设置

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js
@@ -568,9 +568,13 @@ window.__ModuleLoader__.load({
     // ── plugin ────────────────────────────────────────────────────────────
     var inject = ["slots", "locale", "remote", "settingsScope", "sessions", "workspaces"];
 
-    function apply(ctx) {
+    function apply(ctx, config) {
       var t = ctx.locale.bind(NS);
       ctx.effect(function () { return ctx.locale.register(NS, { zh: zh, en: en }); }, "dsh-easy-setup: dictionaries");
+
+      // 插件配置 hideSections（默认 []）：隐藏对应的设置栏 section。
+      var hidden = (Array.isArray(config && config.hideSections) && config.hideSections) || [];
+      function shown(id) { return hidden.indexOf(id) < 0; }
 
       var mountPromise = ctx.remote.$mount(REMOTE).then(function (dispose) {
         ctx.effect(function () { return dispose; }, "dsh-easy-setup: remote face");
@@ -590,39 +594,47 @@ window.__ModuleLoader__.load({
       };
 
       var visionScope = ctx.settingsScope.bind({ namespace: "tool-vision" });
-      ctx.slots.inject("settings.section", function () {
-        return ctx.slots.register({
-          name: "settings.section",
-          id: "easy-vision",
-          order: 24,
-          label: function () { return t("visionNav"); },
-          locale: NS
-        }, function (props) {
-          return h(VisionQuick, Object.assign({}, props, { scope: visionScope }));
+      // 官方"视觉模型（快速配置）"卡与 dsh-tool-vision 原生"视觉模型"卡重复 → 写死不注册。
+      if (false && shown("easy-vision")) {
+        ctx.slots.inject("settings.section", function () {
+          return ctx.slots.register({
+            name: "settings.section",
+            id: "easy-vision",
+            order: 24,
+            label: function () { return t("visionNav"); },
+            locale: NS
+          }, function (props) {
+            return h(VisionQuick, Object.assign({}, props, { scope: visionScope }));
+          });
         });
-      });
-      ctx.slots.inject("settings.section", function () {
-        return ctx.slots.register({
-          name: "settings.section",
-          id: "easy-persona",
-          order: 26,
-          label: function () { return t("personaNav"); },
-          locale: NS
-        }, function (props) {
-          return h(PersonaEditor, Object.assign({}, props, { remote: remote }));
+      }
+      // 官方"人设卡"（预设+卡片库+编辑）保留；dsh-soul-md 原生"人设卡"已在 soul-md 侧写死关闭避免重复。
+      if (shown("easy-persona")) {
+        ctx.slots.inject("settings.section", function () {
+          return ctx.slots.register({
+            name: "settings.section",
+            id: "easy-persona",
+            order: 26,
+            label: function () { return t("personaNav"); },
+            locale: NS
+          }, function (props) {
+            return h(PersonaEditor, Object.assign({}, props, { remote: remote }));
+          });
         });
-      });
-      ctx.slots.inject("settings.section", function () {
-        return ctx.slots.register({
-          name: "settings.section",
-          id: "easy-migration",
-          order: 27,
-          label: function () { return t("migrationNav"); },
-          locale: NS
-        }, function (props) {
-          return h(Migration, Object.assign({}, props, { remote: remote, ctx: ctx }));
+      }
+      if (shown("easy-migration")) {
+        ctx.slots.inject("settings.section", function () {
+          return ctx.slots.register({
+            name: "settings.section",
+            id: "easy-migration",
+            order: 27,
+            label: function () { return t("migrationNav"); },
+            locale: NS
+          }, function (props) {
+            return h(Migration, Object.assign({}, props, { remote: remote, ctx: ctx }));
+          });
         });
-      });
+      }
     }
 
     exports.apply = apply;

--- a/dsh-desktop/assets/plugins/dsh-soul-md/client.js
+++ b/dsh-desktop/assets/plugins/dsh-soul-md/client.js
@@ -227,17 +227,20 @@ window.__ModuleLoader__.load({
       var t = ctx.locale.bind(NS);
       ctx.effect(function () { return ctx.locale.register(NS, { zh: zh, en: en }); }, "dsh-soul-md: dictionaries");
       var scope = ctx.settingsScope.bind({ namespace: "soul-md" });
-      ctx.slots.inject("settings.section", function () {
-        return ctx.slots.register({
-          name: "settings.section",
-          id: "soul-md",
-          order: 24,
-          label: function () { return t("nav"); },
-          locale: NS
-        }, function (props) {
-          return h(SoulSection, Object.assign({}, props, { scope: scope }));
+      // 原生"人设卡"（仅路径/顺序/热重载等底层参数）与 easy-setup 官方"人设卡"（预设+卡片库+编辑）重复 → 写死关闭这张。
+      if (false) {
+        ctx.slots.inject("settings.section", function () {
+          return ctx.slots.register({
+            name: "settings.section",
+            id: "soul-md",
+            order: 24,
+            label: function () { return t("nav"); },
+            locale: NS
+          }, function (props) {
+            return h(SoulSection, Object.assign({}, props, { scope: scope }));
+          });
         });
-      });
+      }
     }
 
     exports.apply = apply;

--- a/dsh-desktop/assets/plugins/dsh-tool-vision/client.js
+++ b/dsh-desktop/assets/plugins/dsh-tool-vision/client.js
@@ -33,7 +33,11 @@ window.__ModuleLoader__.load({
       ".__tv_btnPrimary{border-color:var(--dsw-alias-state-business-primary);background:var(--dsw-alias-state-business-primary);color:var(--dsw-alias-label-on-accent)}" +
       ".__tv_status{font-size:12px;color:var(--dsw-alias-label-tertiary)}" +
       ".__tv_error{font-size:12px;color:var(--dsw-alias-state-error-primary)}" +
-      ".__tv_unavailable{font-size:13px;color:var(--dsw-alias-label-tertiary)}";
+      ".__tv_unavailable{font-size:13px;color:var(--dsw-alias-label-tertiary)}" +
+      ".__tv_advanced{margin-top:8px;border-top:1px solid var(--dsw-alias-border-l2);padding-top:6px}" +
+      ".__tv_advancedSummary{cursor:pointer;font-size:13px;font-weight:600;color:var(--dsw-alias-label-secondary);user-select:none;display:flex;align-items:center;gap:5px}" +
+      ".__tv_advancedArrow{display:inline-block;transition:transform .18s ease;font-size:18px;line-height:1;color:var(--dsw-alias-label-secondary);margin-top:-1px}" +
+      ".__tv_advanced[open] .__tv_advancedArrow{transform:rotate(90deg)}";
     var tagId = "dsh-tool-vision/main.css";
     if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
       var tag = document.createElement("style");
@@ -57,6 +61,7 @@ window.__ModuleLoader__.load({
       bridgeExportDir: "桥接图片导出目录（空 = 系统临时目录）",
       multimodalModels: "多模态白名单（逗号分隔，这些模型直收图片块）",
       requestGuard: "请求兜底（发往文本模型的图片块在请求发出前自动降级为 inspect_image 指引，避免整轮失败）",
+      advanced: "高级设置",
       save: "保存",
       reset: "恢复默认",
       saved: "已保存",
@@ -77,6 +82,7 @@ window.__ModuleLoader__.load({
       bridgeExportDir: "Bridge export dir (empty = system temp)",
       multimodalModels: "Multimodal whitelist (comma-separated; these models receive image blocks directly)",
       requestGuard: "Request guard (image blocks headed to a text-only model are downgraded to inspect_image hints before dispatch, so the turn never hard-fails)",
+      advanced: "Advanced settings",
       save: "Save",
       reset: "Reset",
       saved: "Saved",
@@ -224,35 +230,48 @@ window.__ModuleLoader__.load({
         });
       }
 
-      return h("div", { className: "__tv_root" },
-        h("p", { className: "__tv_hint", style: { margin: "0 0 4px" } }, t("intro")),
-        FIELDS.map(function (f) {
-          var overridden = f.key in user;
-          if (f.type === "checkbox") {
-            return h("label", { key: f.key, className: "__tv_field" },
-              h("span", { className: "__tv_row" },
-                h("input", { className: "__tv_check", type: "checkbox", checked: Boolean(fieldDraft(f)), onChange: function (e) { setField(f, e.target.checked); } }),
-                h("span", { className: "__tv_label" }, labelOf(f)),
-                overridden ? h("span", { className: "__tv_override" }, t("overridden")) : null
-              ),
-              f.key in ZH_HINTS ? h("span", { className: "__tv_hint" }, t(ZH_HINTS[f.key])) : null
-            );
-          }
+      var renderField = function (f) {
+        var overridden = f.key in user;
+        if (f.type === "checkbox") {
           return h("label", { key: f.key, className: "__tv_field" },
-            h("span", { className: "__tv_label" },
-              labelOf(f),
+            h("span", { className: "__tv_row" },
+              h("input", { className: "__tv_check", type: "checkbox", checked: Boolean(fieldDraft(f)), onChange: function (e) { setField(f, e.target.checked); } }),
+              h("span", { className: "__tv_label" }, labelOf(f)),
               overridden ? h("span", { className: "__tv_override" }, t("overridden")) : null
             ),
-            h("input", {
-              className: "__tv_input",
-              type: f.type === "password" ? "password" : f.type === "number" ? "number" : "text",
-              value: fieldDraft(f),
-              placeholder: f.type === "password" ? (overridden ? "••••••••" : t("apiKeyHint")) : (f.placeholder || ""),
-              onChange: function (e) { setField(f, e.target.value); }
-            }),
             f.key in ZH_HINTS ? h("span", { className: "__tv_hint" }, t(ZH_HINTS[f.key])) : null
           );
-        }),
+        }
+        return h("label", { key: f.key, className: "__tv_field" },
+          h("span", { className: "__tv_label" },
+            labelOf(f),
+            overridden ? h("span", { className: "__tv_override" }, t("overridden")) : null
+          ),
+          h("input", {
+            className: "__tv_input",
+            type: f.type === "password" ? "password" : f.type === "number" ? "number" : "text",
+            value: fieldDraft(f),
+            placeholder: f.type === "password" ? (overridden ? "••••••••" : t("apiKeyHint")) : (f.placeholder || ""),
+            onChange: function (e) { setField(f, e.target.value); }
+          }),
+          f.key in ZH_HINTS ? h("span", { className: "__tv_hint" }, t(ZH_HINTS[f.key])) : null
+        );
+      };
+      // 基础字段（URL/模型/密钥）常显；其余归入默认折叠的"高级设置"。
+      var primaryKeys = ["baseURL", "model", "apiKey"];
+      var primary = FIELDS.filter(function (f) { return primaryKeys.indexOf(f.key) >= 0; });
+      var advanced = FIELDS.filter(function (f) { return primaryKeys.indexOf(f.key) < 0; });
+
+      return h("div", { className: "__tv_root" },
+        h("p", { className: "__tv_hint", style: { margin: "0 0 4px" } }, t("intro")),
+        primary.map(renderField),
+        advanced.length ? h("details", { className: "__tv_advanced" },
+          h("summary", { className: "__tv_advancedSummary" },
+            h("span", null, t("advanced")),
+            h("span", { className: "__tv_advancedArrow" }, "\u25b8")
+          ),
+          advanced.map(renderField)
+        ) : null,
         h("div", { className: "__tv_actions" },
           h("button", { type: "button", className: "__tv_btn __tv_btnPrimary", onClick: onSave, disabled: busy || !snapshot.writable }, t("save")),
           h("button", { type: "button", className: "__tv_btn", onClick: onReset, disabled: busy || !snapshot.writable }, t("reset")),


### PR DESCRIPTION
修正在 dsh-desktop/assets/plugins 下三个内置插件源码中的问题：消除设置卡片重复，并整理视觉模型设置区。

### 1. dsh-easy-setup（lib/client.js）
- 不再注册“视觉模型（快速配置）”卡片——它与 dsh-tool-vision 的原生“视觉模型”卡重复（操作的是同一个 tool-vision 命名空间）。
- 保留“人设卡”卡片（内置预设 + 卡片库 + 编辑），它功能更完整。

### 2. dsh-soul-md（client.js）
- 不再注册原生“人设卡”设置卡（仅路径/顺序/热重载等底层参数）——它与 easy-setup 的人设卡重复。host 端把 soul.md 注入系统提示词的功能不受影响。

### 3. dsh-tool-vision（client.js）
- 折叠“视觉模型”设置区：API Base URL / 视觉模型 / API Key 直接显示；其余选项收进默认折叠的“高级设置”，右侧带一个指示折叠/展开状态的小箭头。保存/恢复默认行为不变。

背景：easy-setup 官方“快速配置”卡片与 dsh-tool-vision / dsh-soul-md 的原生卡片能力重复，导致设置页出现重复条目。本 PR 让每类能力在设置页只保留一个入口。

改动文件：dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js、dsh-soul-md/client.js、dsh-tool-vision/client.js