### PR TITLE
fix: 会话目录 zstd 与明文日志并存导致web启动失败 退出码1

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -18,6 +18,21 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 ## [4.4.0] — 2026-08-19
 
+### 修复：会话目录同时存在 session.jsonl 与 session.jsonl.zstd 时启动失败（#77）
+- 根因：会话持久化后端（`@deepseek-ai/dsh-session-persistence-jsonl`，
+  `DEFAULT_COMPRESSION = "zstd"`）加载时 `listArtifacts()` → `checkRootEncoding()`
+  发现某会话目录同时存在相反物理编码的文件（zstd 后端下的明文 `session.jsonl`）
+  即抛 `encodingMismatch`，整棵插件树加载失败、`dsh web` 退出码 1，桌面端表现
+  为「Web UI 未在预期时间内就绪」；这是数据层问题，plugin-guard 只看插件/配置
+  层，陷入「体检 → 回滚 → 重试」的无效循环，救不回来。
+- 修复：新增 `session-encoding-heal.js`，接入守护启动的 preRetry 钩子——启动
+  确因该错误失败时，扫描 `<DSH_HOME>/sessions`，对两种编码并存的会话目录把
+  相反格式（明文）文件改名归档为 `session.jsonl.bak-<时间戳>`（**数据无损、不
+  删除**），保留后端在用的权威 zstd 日志后自动重试一次。只在命中该错误时触发，
+  不做任何常态化会话目录写操作。
+- 验证：`test/session-encoding-heal.test.mjs` 覆盖错误识别、并存归档、仅 zstd
+  不动、目录缺失安全返回、多会话独立处理。
+
 ### 修复：设置页「Skills 与 MCP → 打开目录」在文件视图打不开
 - 根因：`dsh:file-open` IPC 校验只放行会话工作区路径（`isUnderFileRoots`），
   而 Skills 根目录（`~/.dsh/skills`、`~/.agents/skills`）是全局目录、永远不在

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -31,6 +31,7 @@ files:
   - plugin-updater.js
   - balance.js
   - session-watcher.js
+  - session-encoding-heal.js
   - profile-module-heal.js
   - patch-row-heal.js
   - builtin-collision.js

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -43,6 +43,7 @@ const { configLinesFor, healSoulMdPatchRow, healRowConfig, removeBundledRowDupli
 const { syncBundledPresets, ensureDefaultAgentPreset } = require('./preset-sync');
 const { buildErrorDetail } = require('./error-detail');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
+const { isEncodingMismatch, healSessionEncodingConflicts } = require('./session-encoding-heal');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
 const { togglePluginInPatch, removePluginFromPatch, hasEntryId } = require('./scripts/plugin-manager-patch');
 const { collectPluginRows } = require('./plugin-manager-state');
@@ -919,8 +920,42 @@ async function startAndShowGuarded(overlays = []) {
     () => '日志文件：' + path.join(logsDir, 'dsh-web.log'),
     // V4.2：pnpm 封锁构建脚本会让整棵 profile 起不来 —— 这是配置级问题，
     // 体检（只扫插件层）发现不了，必须走 preRetry 钩子自动放行后重试。
-    { preRetry: allowBuildsPreRetry }
+    // V4.4：会话目录同时存在 zstd + 明文两种编码时，会话持久化后端会抛
+    // encodingMismatch 让整棵插件树起不来（Issue #77）—— 同样是体检看不到
+    // 的数据层问题，一并走 preRetry 归档相反格式文件后重试。
+    { preRetry: bootRescuePreRetry }
   );
+}
+
+// V4.4：守护启动 preRetry 汇聚 —— 把两类「体检看不到的数据/配置层修复」
+// 合并为一次钩子调用（guardedBoot 只调用 preRetry 一次）。任一命中即返回
+// 合并后的 { applied }，均未命中返回 false（走原失败链路）。
+async function bootRescuePreRetry(errText) {
+  const applied = [];
+  // 1) 会话编码冲突（Issue #77）：归档相反格式的遗留日志文件（数据无损）。
+  try {
+    let text = String(errText || '');
+    if (!isEncodingMismatch(text)) {
+      // 报错详情常只落在 dsh-web.log 里，补充解析尾部。
+      try { text += '\n' + fs.readFileSync(path.join(logsDir, 'dsh-web.log'), 'utf8').slice(-40000); } catch {}
+    }
+    if (isEncodingMismatch(text)) {
+      const home = process.env.DSH_HOME || path.join(os.homedir(), '.dsh');
+      const archived = healSessionEncodingConflicts(path.join(home, 'sessions'), { compression: 'zstd', log });
+      if (archived.length) applied.push('会话编码冲突自愈：已归档 ' + archived.length + ' 个相反格式的遗留会话日志');
+    }
+  } catch (err) {
+    log('session-heal', 'preRetry 会话编码自愈失败: ' + String((err && err.message) || err));
+  }
+  // 2) pnpm allowBuilds 自动放行（原 V4.2 逻辑）。
+  try {
+    const ab = await allowBuildsPreRetry(errText);
+    if (ab && Array.isArray(ab.applied)) applied.push(...ab.applied);
+    else if (ab) applied.push('pnpm allowBuilds 自动放行');
+  } catch (err) {
+    log('guard', 'preRetry allowBuilds 失败: ' + String((err && err.message) || err));
+  }
+  return applied.length ? { applied } : false;
 }
 
 // V4.2：启动失败链的 pnpm allowBuilds 自动放行钩子（preRetry）。

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -19,6 +19,7 @@ const entryFiles = [
   'client-updater.js',
   'balance.js',
   'session-watcher.js',
+  'session-encoding-heal.js',
   'renderer-recovery.js',
   'watchdog.js',
   'stable-port.js',

--- a/dsh-desktop/session-encoding-heal.js
+++ b/dsh-desktop/session-encoding-heal.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// session-encoding-heal.js — 会话编码一致性自愈（启动失败救援）。
+//
+// 背景（Issue #77）：会话持久化后端 @deepseek-ai/dsh-session-persistence-jsonl
+// 以 DEFAULT_COMPRESSION = "zstd" 运行；插件树加载时 listArtifacts() →
+// checkRootEncoding() 会遍历每个会话目录，只要发现同目录里同时存在「相反
+// 物理编码」的文件（当前后端为 zstd 时即明文 session.jsonl）就抛
+// encodingMismatch，导致整个 `dsh web` 进程退出码 1 —— 桌面端表现为
+// 「Web UI 未在预期时间内就绪」，且体检/回滚链路救不回来（它们只看插件层）。
+//
+// 明文快照是权威 zstd 日志的旧前缀（Issue #77 已逐字节确认），因此当两种
+// 格式并存时：保留后端在用的编码文件（zstd），把相反格式文件改名归档
+// （绝不删除，数据无损，用户可手动找回）。此模块只在启动确因 encodingMismatch
+// 失败时经守护启动的 preRetry 钩子触发，不做任何常态化的会话目录写操作。
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// dsh-session-persistence-jsonl 的 encodingMismatch 报错特征（rc.6/rc.7 一致）：
+//   session artifact "…session.jsonl" uses .jsonl, but this backend is
+//   configured for compression "zstd"; use a separate root …
+const ENCODING_MISMATCH_RE = /uses \.jsonl(?:\.zstd)?, but this backend is configured for compression/i;
+
+/** 报错文案（含 dsh-web.log 尾部）是否为会话编码不一致崩溃。 */
+function isEncodingMismatch(errText) {
+  return ENCODING_MISMATCH_RE.test(String(errText || ''));
+}
+
+// 会话目录布局与后端约定一致：<sessionsDir>/<projectKey>/<session-…>/ ，
+// 日志文件名为 session.jsonl（明文）或 session.jsonl.zstd（zstd）。
+const LIVE_SUFFIX = { zstd: '.jsonl.zstd', none: '.jsonl' };
+const STALE_SUFFIX = { zstd: '.jsonl', none: '.jsonl.zstd' };
+
+/**
+ * 扫描会话根目录，归档与后端编码相反的遗留日志文件（仅当同目录两种格式并存）。
+ * 数据无损：保留后端在用编码的文件（权威），相反格式文件改名为
+ * `<name>.bak-<时间戳>`，绝不删除。
+ *
+ * @param {string} sessionsDir  <DSH_HOME>/sessions
+ * @param {{ compression?: 'zstd'|'none', log?: (tag: string, msg: string) => void }} [opts]
+ * @returns {string[]} 已归档（改名后）的文件绝对路径
+ */
+function healSessionEncodingConflicts(sessionsDir, opts = {}) {
+  const compression = opts.compression === 'none' ? 'none' : 'zstd';
+  const log = opts.log || (() => {});
+  const liveSuffix = LIVE_SUFFIX[compression];
+  const staleSuffix = STALE_SUFFIX[compression];
+  const archived = [];
+  if (!sessionsDir || !fs.existsSync(sessionsDir)) return archived;
+
+  let projects;
+  try { projects = fs.readdirSync(sessionsDir, { withFileTypes: true }); } catch { return archived; }
+  for (const project of projects) {
+    if (!project.isDirectory()) continue;
+    const projDir = path.join(sessionsDir, project.name);
+    let sessionDirs;
+    try { sessionDirs = fs.readdirSync(projDir, { withFileTypes: true }); } catch { continue; }
+    for (const sess of sessionDirs) {
+      if (!sess.isDirectory()) continue;
+      const dir = path.join(projDir, sess.name);
+      const live = path.join(dir, 'session' + liveSuffix);
+      const stale = path.join(dir, 'session' + staleSuffix);
+      // 只在两种格式并存时动手：保留 live（权威），归档 stale。
+      if (!fs.existsSync(live) || !fs.existsSync(stale)) continue;
+      const bak = stale + '.bak-' + Date.now();
+      try {
+        fs.renameSync(stale, bak);
+        archived.push(bak);
+        log('session-heal', `会话编码冲突：已归档 ${stale} → ${path.basename(bak)}（保留 ${path.basename(live)}）`);
+      } catch (err) {
+        log('session-heal', `归档 ${stale} 失败: ` + String((err && err.message) || err));
+      }
+    }
+  }
+  return archived;
+}
+
+module.exports = { isEncodingMismatch, healSessionEncodingConflicts };

--- a/dsh-desktop/test/session-encoding-heal.test.mjs
+++ b/dsh-desktop/test/session-encoding-heal.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+// Issue #77：会话目录同时存在 session.jsonl（明文）与 session.jsonl.zstd 时，
+// 会话持久化后端（DEFAULT_COMPRESSION = "zstd"）在 checkRootEncoding 抛
+// encodingMismatch，整棵插件树加载失败、dsh web 退出码 1，桌面端表现为
+// 「Web UI 未在预期时间内就绪」。session-encoding-heal 在守护启动 preRetry
+// 里识别该错误并归档（改名，非删除）相反格式的遗留文件，保留权威的 zstd 日志。
+
+const require = createRequire(import.meta.url);
+const { isEncodingMismatch, healSessionEncodingConflicts } = require('../session-encoding-heal.js');
+
+// 后端 encodingMismatch 的真实报错文案（rc.6/rc.7 一致）。
+const REAL_ERR =
+  'Error: dsh: plugin tree failed to load: ... failed to apply loader entry workspace ' +
+  '(@deepseek-ai/dsh-workspace): session artifact ' +
+  '"C:\\\\Users\\\\x\\\\.dsh\\\\sessions\\\\proj\\\\session-02ab\\\\session.jsonl" uses .jsonl, ' +
+  'but this backend is configured for compression "zstd"; use a separate root or select the matching compression mode';
+
+test('isEncodingMismatch：识别后端 encodingMismatch 报错，忽略无关文案', () => {
+  assert.equal(isEncodingMismatch(REAL_ERR), true);
+  assert.equal(isEncodingMismatch('Ignored build scripts: esbuild'), false);
+  assert.equal(isEncodingMismatch(''), false);
+  assert.equal(isEncodingMismatch(null), false);
+});
+
+function makeSessions(root) {
+  const sessions = join(root, 'sessions');
+  const dir = join(sessions, 'projA', 'session-02ab7066');
+  mkdirSync(dir, { recursive: true });
+  return { sessions, dir };
+}
+
+test('healSessionEncodingConflicts：两种编码并存时归档明文、保留 zstd（数据无损）', () => {
+  const t = mkdtempSync(join(tmpdir(), 'sess-heal-'));
+  try {
+    const { sessions, dir } = makeSessions(t);
+    writeFileSync(join(dir, 'session.jsonl'), 'plaintext stale snapshot');
+    writeFileSync(join(dir, 'session.jsonl.zstd'), 'ZSTD-AUTHORITATIVE');
+    const archived = healSessionEncodingConflicts(sessions, { compression: 'zstd', log: () => {} });
+    assert.equal(archived.length, 1);
+    // 权威 zstd 保留、内容不动。
+    assert.equal(readFileSync(join(dir, 'session.jsonl.zstd'), 'utf8'), 'ZSTD-AUTHORITATIVE');
+    // 明文被归档（改名，非删除）。
+    assert.equal(existsSync(join(dir, 'session.jsonl')), false);
+    const baks = readdirSync(dir).filter((n) => n.startsWith('session.jsonl.bak-'));
+    assert.equal(baks.length, 1);
+    assert.equal(readFileSync(join(dir, baks[0]), 'utf8'), 'plaintext stale snapshot');
+  } finally { rmSync(t, { recursive: true, force: true }); }
+});
+
+test('healSessionEncodingConflicts：只有 zstd 时不动任何文件', () => {
+  const t = mkdtempSync(join(tmpdir(), 'sess-heal-'));
+  try {
+    const { sessions, dir } = makeSessions(t);
+    writeFileSync(join(dir, 'session.jsonl.zstd'), 'ZSTD-ONLY');
+    const archived = healSessionEncodingConflicts(sessions, { compression: 'zstd', log: () => {} });
+    assert.equal(archived.length, 0);
+    assert.deepEqual(readdirSync(dir).sort(), ['session.jsonl.zstd']);
+  } finally { rmSync(t, { recursive: true, force: true }); }
+});
+
+test('healSessionEncodingConflicts：sessions 目录不存在时安全返回空', () => {
+  const t = mkdtempSync(join(tmpdir(), 'sess-heal-'));
+  try {
+    assert.deepEqual(healSessionEncodingConflicts(join(t, 'nope', 'sessions'), { log: () => {} }), []);
+  } finally { rmSync(t, { recursive: true, force: true }); }
+});
+
+test('healSessionEncodingConflicts：多个会话目录各自独立处理', () => {
+  const t = mkdtempSync(join(tmpdir(), 'sess-heal-'));
+  try {
+    const sessions = join(t, 'sessions');
+    const d1 = join(sessions, 'projA', 'session-1');
+    const d2 = join(sessions, 'projB', 'session-2');
+    const d3 = join(sessions, 'projB', 'session-3'); // 只有 zstd，不动
+    for (const d of [d1, d2, d3]) mkdirSync(d, { recursive: true });
+    writeFileSync(join(d1, 'session.jsonl'), 'a');
+    writeFileSync(join(d1, 'session.jsonl.zstd'), 'A');
+    writeFileSync(join(d2, 'session.jsonl'), 'b');
+    writeFileSync(join(d2, 'session.jsonl.zstd'), 'B');
+    writeFileSync(join(d3, 'session.jsonl.zstd'), 'C');
+    const archived = healSessionEncodingConflicts(sessions, { compression: 'zstd', log: () => {} });
+    assert.equal(archived.length, 2);
+    assert.equal(existsSync(join(d1, 'session.jsonl')), false);
+    assert.equal(existsSync(join(d2, 'session.jsonl')), false);
+    assert.deepEqual(readdirSync(d3).sort(), ['session.jsonl.zstd']);
+  } finally { rmSync(t, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## 概述

修复会话目录中 **zstd 与明文日志并存**时 `dsh web` 启动即崩溃、桌面端卡在「Web UI 未在预期时间内就绪」的严重问题，并使守护启动具备该故障的自愈能力。

## 问题背景

会话持久化后端（`@deepseek-ai/dsh-session-persistence-jsonl`，`DEFAULT_COMPRESSION=zstd`）在加载阶段执行 `checkRootEncoding`，一旦发现**同一会话目录同时存在相反编码文件**（zstd 后端下残留的明文 `session.jsonl`），立即抛出 `encodingMismatch`：

- 整棵插件树加载失败，`dsh web` 退出码 1；
- 桌面端表现为「**Web UI 未在预期时间内就绪**」；
- `plugin-guard` 体检只覆盖插件/配置层，**看不到会话数据层**，因此陷入「体检 → 回滚 → 重试」的无效循环，始终救不回来。

## 主要内容

### 新增自愈模块

- 新增 **`session-encoding-heal.js`**，接入守护启动的 **preRetry 钩子**。
- 启动确因该错误失败时，扫描 `<DSH_HOME>/sessions`，对两种编码并存的会话目录：
  - 将相反格式（明文）文件**改名归档**为 `session.jsonl.bak-<时间戳>`；
  - **数据无损、不删除**，保留权威的 zstd 日志；
  - 归档后自动重试一次。
- **仅命中该错误时触发**，无任何常态化的会话目录写操作。

### 测试

- 新增 **`test/session-encoding-heal.test.mjs`**，覆盖：
  - 错误识别
  - 并存归档
  - 仅 zstd 不动
  - 目录缺失
  - 多会话独立处理

## 影响范围

- 复用现有守护启动 preRetry 机制，**不改动整体架构**；
- 已登记到 `electron-builder.yml` files 清单与 `scripts/check-syntax.js` entryFiles；
- 本 PR 仅修复 #77，不涉及错误报告中其余中低优先级项。