### PR TITLE
fix: 修复正式版自更新黑窗和中断问题

### DIFF
--- a/docs/superpowers/specs/2026-08-19-installed-self-update-hang-design.md
+++ b/docs/superpowers/specs/2026-08-19-installed-self-update-hang-design.md
@@ -1,0 +1,128 @@
+# 正式安装版自更新黑窗与中断修复设计
+
+## 背景
+
+正式安装版下载新 Setup 后，会生成 `apply-update.cmd`，由当前 EAC 主进程以 detached 方式启动。脚本先通过 `ping` 延时，再执行：
+
+```cmd
+taskkill /F /T /IM "Deepseek Harness EAC.exe"
+```
+
+随后才会启动新 Setup。
+
+现场日志停在 `force-killing leftover app processes`，没有进入 `running setup`。更新脚本是当前 EAC 启动的子进程，按镜像名配合 `/T` 结束进程树时，可能连同更新脚本自身一起终止。用户因此看到 `ping` 或旧版 `find /i` 黑窗，但安装器没有启动。
+
+开发环境不能稳定复现，因为 `npm start`、便携构建和 NSIS 正式安装版的进程名、父子关系、安装目录、UAC 与安装器接管流程不同。
+
+## 目标
+
+- 正式安装版更新过程中不显示 `ping`、`find` 或其他命令行窗口。
+- 更新辅助进程不得按镜像名结束整个进程树，也不得结束自身。
+- 精确等待当前 EAC 主进程退出；超时后只结束该主进程 PID。
+- 当前主进程退出后启动已下载并校验的 Setup。
+- Setup 成功后删除安装包和辅助脚本；失败时保留诊断材料并重启旧版。
+- 保留便携版现有备份、替换和回滚行为。
+
+## 非目标
+
+- 不修改安装器的安装范围选择界面。
+- 不改变 NSIS 的升级、卸载和用户数据策略。
+- 不修改客户端安装包下载、断点续传或 SHA-256 校验。
+- 不在本次修复中重构 dsh agent 更新流程。
+
+## 方案比较
+
+### 方案 A：仅删除 `taskkill` 的 `/T`
+
+优点是改动最小。缺点是仍然依赖可见风险较高的 CMD、`ping` 延时和按镜像名结束所有同名进程，无法解决黑窗和误杀其他实例。
+
+### 方案 B：保留 CMD，改为按 PID 等待和结束
+
+可以避免按镜像名误杀，但批处理需要借助 `tasklist/find` 或其他外部命令判断 PID，容易重新引入管道挂死和窗口闪现问题。
+
+### 方案 C：安装版改用隐藏 PowerShell 辅助脚本
+
+安装版生成 `apply-update.ps1`，直接使用 PowerShell 的进程 API：
+
+- 按当前主进程 PID 有界等待；
+- 超时只对该 PID 执行 `Stop-Process -Force`；
+- 使用 `Start-Process -Wait -PassThru` 启动 Setup；
+- 全程写入 `apply-update.log`；
+- PowerShell 窗口通过 `-WindowStyle Hidden` 与 Node `windowsHide: true` 双重隐藏。
+
+该方案不需要 `ping`、`find`、`tasklist` 或 `taskkill /T`，选择此方案。
+
+## 更新流程
+
+### 正式安装版
+
+1. 下载 Setup 并完成大小及 SHA-256 校验。
+2. 写入 `apply-update.ps1`。
+3. 将以下参数直接传给 PowerShell，不通过字符串拼接：
+   - Setup 完整路径；
+   - 当前安装版 exe 完整路径；
+   - 当前 EAC 主进程 PID；
+   - 日志完整路径。
+4. 以 detached、隐藏窗口方式启动 PowerShell。
+5. EAC 主进程按现有流程执行 `app.exit(0)`。
+6. PowerShell 最多等待主进程退出 20 秒。
+7. 若超时，仅执行 `Stop-Process -Id <当前主进程 PID> -Force`，再短暂等待。
+8. 启动 Setup 并等待退出。
+9. Setup 返回 0：
+   - 写入成功日志；
+   - 删除 Setup；
+   - 删除 PowerShell 辅助脚本。
+10. Setup 返回非 0 或启动失败：
+    - 写入失败日志；
+    - 保留 Setup 和日志；
+    - 如果旧版 exe 仍存在，重新启动旧版；
+    - 辅助脚本退出非 0。
+
+### 便携版
+
+便携版继续使用现有 `apply-update.cmd` 备份、替换和回滚流程。本次只修复正式安装版，避免扩大风险面。
+
+## 安全与错误处理
+
+- 只允许结束调用方传入的数字 PID，不按镜像名批量结束进程。
+- PID 参数必须在生成和测试层验证为正整数。
+- Setup 和旧版 exe 路径通过 PowerShell 参数传递，不拼接进命令字符串。
+- Setup 不存在时立即记录失败，不执行任何删除。
+- 等待和强制结束均有明确上限，不允许无限循环。
+- 失败路径不删除 Setup，便于用户手动安装和排查。
+- 日志使用 UTF-8，避免当前 `cmd` 日志中的本地化日期乱码。
+
+## 代码调整
+
+- `client-updater.js`
+  - 新增 `buildInstalledApplyScript()`，生成 PowerShell 脚本。
+  - 安装版 `applyUpdate()` 改为启动隐藏 PowerShell。
+  - 便携版继续使用现有 CMD 生成与启动逻辑。
+  - 删除安装版脚本中的 `ping`、`taskkill /T` 和 `call Setup`。
+- `test/client-updater-apply.test.mjs`
+  - 更新安装版静态约束。
+  - 增加 PowerShell 脚本参数、安全和清理测试。
+  - Windows 下执行端到端测试：等待指定 PID、启动伪 Setup、完成清理。
+
+## 测试
+
+至少覆盖：
+
+1. 安装版脚本不包含 `ping`、`find`、`tasklist`、`taskkill`。
+2. 只按传入 PID 等待和强制结束。
+3. 等待时间有上限。
+4. Setup 在旧主进程退出之后启动。
+5. Setup 成功时删除 Setup 和辅助脚本。
+6. Setup 失败时保留 Setup、写日志并重启旧版。
+7. 路径包含空格和中文时参数保持完整。
+8. PowerShell 辅助进程使用隐藏窗口参数。
+9. 便携版原有备份、替换和回滚测试继续通过。
+10. 完整 `npm test` 与构建语法检查通过。
+
+## 验收标准
+
+- 从已安装旧版点击“立即重启并更新”后，不出现 CMD、`ping` 或 `find` 黑窗。
+- 旧版主进程退出后，Setup 安装界面正常出现。
+- `apply-update.log` 包含等待主进程、启动 Setup、Setup 退出码和最终结果。
+- 更新失败时安装包仍保留，可手动运行。
+- 正式安装版端到端测试能够复现并防止原先的更新辅助进程自终止问题。

--- a/docs/superpowers/specs/2026-08-19-installed-self-update-hang-design.md
+++ b/docs/superpowers/specs/2026-08-19-installed-self-update-hang-design.md
@@ -40,24 +40,29 @@ taskkill /F /T /IM "Deepseek Harness EAC.exe"
 
 可以避免按镜像名误杀，但批处理需要借助 `tasklist/find` 或其他外部命令判断 PID，容易重新引入管道挂死和窗口闪现问题。
 
-### 方案 C：安装版改用隐藏 PowerShell 辅助脚本
+### 方案 C：隐藏 PowerShell 等待进程，再调用安装动作 CMD
 
-安装版生成 `apply-update.ps1`，直接使用 PowerShell 的进程 API：
+安装版生成 `apply-update.ps1` 和 `apply-update.cmd`。PowerShell 只负责进程
+生命周期，CMD 保留 v4.4 已有的四目录备份、manifest、静默安装和失败回滚：
 
 - 按当前主进程 PID 有界等待；
 - 超时只对该 PID 执行 `Stop-Process -Force`；
-- 使用 `Start-Process -Wait -PassThru` 启动 Setup；
+- 主进程退出后，在隐藏控制台中同步调用安装动作 CMD；
+- 安装动作 CMD 不再包含 `ping`、`tasklist` 或 `taskkill`；
 - 全程写入 `apply-update.log`；
 - PowerShell 窗口通过 `-WindowStyle Hidden` 与 Node `windowsHide: true` 双重隐藏。
 
-该方案不需要 `ping`、`find`、`tasklist` 或 `taskkill /T`，选择此方案。
+该方案不需要 `ping`、`find`、`tasklist` 或 `taskkill /T`，同时不回退 v4.4
+新增的更新前备份与安装失败回滚能力，选择此方案。
 
 ## 更新流程
 
 ### 正式安装版
 
 1. 下载 Setup 并完成大小及 SHA-256 校验。
-2. 写入 `apply-update.ps1`。
+2. 写入两个辅助脚本：
+   - `apply-update.ps1`：等待并精确结束当前主进程；
+   - `apply-update.cmd`：执行四目录备份、manifest、Setup 与失败回滚。
 3. 将以下参数直接传给 PowerShell，不通过字符串拼接：
    - Setup 完整路径；
    - 当前安装版 exe 完整路径；
@@ -67,16 +72,19 @@ taskkill /F /T /IM "Deepseek Harness EAC.exe"
 5. EAC 主进程按现有流程执行 `app.exit(0)`。
 6. PowerShell 最多等待主进程退出 20 秒。
 7. 若超时，仅执行 `Stop-Process -Id <当前主进程 PID> -Force`，再短暂等待。
-8. 启动 Setup 并等待退出。
-9. Setup 返回 0：
+8. PowerShell 同步调用隐藏的安装动作 CMD。
+9. CMD 完成四目录备份后，以 `/S` 启动 Setup 并等待退出。
+10. Setup 返回 0：
    - 写入成功日志；
    - 删除 Setup；
-   - 删除 PowerShell 辅助脚本。
-10. Setup 返回非 0 或启动失败：
+   - 删除 CMD 与 PowerShell 辅助脚本；
+   - 写入 `.backup-ts` 供新版确认备份清理。
+11. Setup 返回非 0 或启动失败：
     - 写入失败日志；
     - 保留 Setup 和日志；
+    - 从备份回滚四个目录；
     - 如果旧版 exe 仍存在，重新启动旧版；
-    - 辅助脚本退出非 0。
+    - 两个辅助脚本退出或保留为非成功状态。
 
 ### 便携版
 
@@ -98,11 +106,13 @@ taskkill /F /T /IM "Deepseek Harness EAC.exe"
   - 新增 `buildInstalledApplyScript()`，生成 PowerShell 脚本。
   - 安装版 `applyUpdate()` 改为启动隐藏 PowerShell。
   - 便携版继续使用现有 CMD 生成与启动逻辑。
-  - 删除安装版脚本中的 `ping`、`taskkill /T` 和 `call Setup`。
+  - 安装动作 CMD 保留备份/回滚和 `call Setup /S`，删除其中的进程等待、
+    `ping` 与 `taskkill /T`。
 - `test/client-updater-apply.test.mjs`
   - 更新安装版静态约束。
   - 增加 PowerShell 脚本参数、安全和清理测试。
-  - Windows 下执行端到端测试：等待指定 PID、启动伪 Setup、完成清理。
+  - Windows 下执行端到端测试：等待指定 PID、四目录备份、启动伪 Setup、
+    成功清理与失败回滚。
 
 ## 测试
 
@@ -112,12 +122,13 @@ taskkill /F /T /IM "Deepseek Harness EAC.exe"
 2. 只按传入 PID 等待和强制结束。
 3. 等待时间有上限。
 4. Setup 在旧主进程退出之后启动。
-5. Setup 成功时删除 Setup 和辅助脚本。
+5. Setup 成功时删除 Setup 和两个辅助脚本。
 6. Setup 失败时保留 Setup、写日志并重启旧版。
 7. 路径包含空格和中文时参数保持完整。
 8. PowerShell 辅助进程使用隐藏窗口参数。
-9. 便携版原有备份、替换和回滚测试继续通过。
-10. 完整 `npm test` 与构建语法检查通过。
+9. 安装版四目录备份、manifest 和失败回滚继续通过。
+10. 便携版原有备份、替换和回滚测试继续通过。
+11. 完整 `npm test` 与构建语法检查通过。
 
 ## 验收标准
 

--- a/dsh-desktop/client-updater.js
+++ b/dsh-desktop/client-updater.js
@@ -11,8 +11,9 @@
 //      *-portable-x64.exe；安装版选 Setup-*-x64.exe。Gitee 因单文件 100MB
 //      限制把安装包拆成 .part1/.part2 分片，此时自动按序下载并拼接。
 //   3. downloadRelease(): 流式下载（带进度回调）到 <userData>/updates/。
-//   4. applyUpdate(): 写一个纯 ASCII 的 cmd 脚本并以 detached 方式启动，随后
-//      主进程退出。启动方式是整行引用 + /d /s /c：spawn('cmd.exe',
+//   4. applyUpdate(): 便携版写纯 ASCII cmd 做原地替换；安装版写纯 ASCII
+//      PowerShell 辅助脚本，按当前主进程 PID 等待/兜底结束后启动 Setup。
+//      便携版启动方式是整行引用 + /d /s /c：spawn('cmd.exe',
 //      ['/c', script, a1, a2]) 让 Node 给每个含空格参数加引号，cmd /c 的
 //      剥引号规则会把首尾引号剥掉，路径在空格处断开 → "'C:\...\Deepseek'
 //      is not recognized" 且被 stdio:'ignore' 吞掉 → 脚本静默不执行，
@@ -21,9 +22,8 @@
 //      用户名不受 cmd 文件 ANSI 编码影响：
 //      · 便携版：等旧 exe 解锁 → 备份 → 用新 exe 原地替换 → 重新启动；
 //        若旧 exe 所在目录只读，则退化为直接启动新 exe（保留旧文件）。
-//      · 安装版：固定短等待 → 无条件兜底强杀残留进程（不做 tasklist 轮询
-//        检测，管道在隐藏控制台下偶发挂死）→ 以向导方式启动新 Setup 安装包
-//        （安装器会记录原安装目录并在完成后自动启动新版本）。
+//      · 安装版：隐藏 PowerShell 按当前主进程 PID 有界等待；超时只结束该
+//        PID（不按镜像名、不杀进程树）→ 以向导方式启动新 Setup 安装包。
 
 const https = require('node:https');
 const http = require('node:http');
@@ -587,21 +587,88 @@ async function downloadRelease(ctx, release, { onProgress, onSourceChange, fallb
   return { filePath: finalPath, size: stat.size, sha256Verified: !!expected };
 }
 
-// --- 应用更新（detached 脚本 + 主进程退出） ---------------------------------
+// --- 应用更新（detached 辅助进程 + 主进程退出） -----------------------------
 
 /**
- * 生成 apply-update.cmd 的行内容（纯 ASCII，join('\r\n') 后落盘）。
+ * 安装版使用隐藏 PowerShell 辅助进程等待当前主进程退出，再调用负责
+ * 备份/回滚/安装的 CMD。CMD 不再执行 ping/taskkill，也不再负责进程等待。
  *
- * issue #8 回归约束（对应 test/client-updater-apply.test.mjs）：
- *   1. 安装版分支：不得用 tasklist|find 管道轮询旧进程（detached 隐藏控制台
- *      下偶发挂死，用户看到黑窗卡住、Setup 永不执行）；也不得有无界等待。
- *      改为固定短等待（ping）→ 无条件 taskkill /F /T 兜底强杀 → 运行 Setup，
- *      线性推进、总时长有界（主进程 spawn 后约 0.4s 即 app.exit(0)，且
- *      killTreeAndWait 已在 spawn 前等完 dsh web 进程树，检测本是冗余）。
- *   2. 全程写 apply-update.log（与脚本同目录），记录等待/强杀/运行/退出码。
- *   3. Setup 失败：保留安装包与日志供诊断，并拉起旧版应用，用户不被困住。
- *   4. 清理（删安装包+自删）仅在成功路径发生。
- *   5. 便携版分支保留 备份→替换→失败回滚 语义，同样有界等待并写日志。
+ * 旧实现由 EAC 生成 apply-update.cmd，再执行 taskkill /F /T /IM。正式安装
+ * 环境中更新 CMD 是 EAC 派生的进程，/T 可能把更新助手一并结束；外部
+ * ping/find 也可能暴露控制台窗口。新实现只等待/结束调用方传入的主进程
+ * PID，进程退出后才进入备份与 Setup 流程。
+ */
+function buildInstalledApplyScript() {
+  return [
+    'param(',
+    '  [Parameter(Mandatory = $true)][string]$ActionScriptPath,',
+    '  [Parameter(Mandatory = $true)][string]$SetupPath,',
+    '  [Parameter(Mandatory = $true)][string]$OldExePath,',
+    '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$UserDataDir,',
+    '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$DshHome,',
+    '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$InstallDir,',
+    '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$ProfileDir,',
+    '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$CurrentVersion,',
+    '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$NewVersion,',
+    '  [Parameter(Mandatory = $true)][int]$AppPid,',
+    '  [Parameter(Mandatory = $true)][string]$LogPath,',
+    '  [int]$WaitTimeoutSeconds = 20',
+    ')',
+    "$ErrorActionPreference = 'Stop'",
+    '$ScriptPath = $MyInvocation.MyCommand.Path',
+    'function Write-ApplyLog([string]$Message) {',
+    "  $Stamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'",
+    '  Add-Content -LiteralPath $LogPath -Value ("[" + $Stamp + "] " + $Message) -Encoding UTF8',
+    '}',
+    'function Get-AppProcess {',
+    '  Get-Process -Id $AppPid -ErrorAction SilentlyContinue',
+    '}',
+    'try {',
+    '  if ($AppPid -le 0) { throw "Invalid app PID" }',
+    '  if ($WaitTimeoutSeconds -lt 1 -or $WaitTimeoutSeconds -gt 120) { throw "Invalid wait timeout" }',
+    '  $LogDir = Split-Path -Parent $LogPath',
+    '  if ($LogDir) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }',
+    '  Set-Content -LiteralPath $LogPath -Value "" -Encoding UTF8',
+    '  Write-ApplyLog ("installed apply-update start; appPid=" + $AppPid)',
+    '  if (-not (Test-Path -LiteralPath $SetupPath -PathType Leaf)) { throw "Setup not found" }',
+    '  if (-not (Test-Path -LiteralPath $ActionScriptPath -PathType Leaf)) { throw "Action script not found" }',
+    '  Write-ApplyLog "waiting for app exit"',
+    '  $Deadline = [DateTime]::UtcNow.AddSeconds($WaitTimeoutSeconds)',
+    '  while ((Get-AppProcess) -and [DateTime]::UtcNow -lt $Deadline) {',
+    '    Start-Sleep -Milliseconds 200',
+    '  }',
+    '  if (Get-AppProcess) {',
+    '    Write-ApplyLog "app exit wait timed out; stopping exact PID"',
+    '    try {',
+    '      Stop-Process -Id $AppPid -Force -ErrorAction Stop',
+    '    } catch {',
+    '      if (Get-AppProcess) { throw }',
+    '    }',
+    '    for ($i = 0; $i -lt 25 -and (Get-AppProcess); $i++) { Start-Sleep -Milliseconds 200 }',
+    '  }',
+    '  if (Get-AppProcess) { throw "App process did not exit" }',
+    '  Write-ApplyLog "running hidden update action"',
+    '  & $ActionScriptPath $SetupPath $OldExePath $UserDataDir $DshHome $InstallDir $ProfileDir $CurrentVersion $NewVersion',
+    '  $ActionExitCode = [int]$LASTEXITCODE',
+    '  Write-ApplyLog ("update action exit code " + $ActionExitCode)',
+    '  if ($ActionExitCode -ne 0) { exit $ActionExitCode }',
+    '  Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue',
+    '  exit 0',
+    '} catch {',
+    '  try { Write-ApplyLog ("update failed: " + $_.Exception.Message) } catch {}',
+    '  if (Test-Path -LiteralPath $OldExePath -PathType Leaf) {',
+    '    try { Start-Process -FilePath $OldExePath | Out-Null } catch {}',
+    '  }',
+    '  exit 1',
+    '}',
+  ];
+}
+
+/**
+ * 生成 apply-update.cmd：便携版负责原地替换，安装版负责备份/回滚/Setup。
+ *
+ * 安装版 CMD 由 PowerShell 在旧主进程退出后调用，不再自行等待或结束进程；
+ * 便携版保留原地替换与回滚语义。脚本保持纯 ASCII，路径通过参数传递。
  */
 function buildApplyScript({ newExe, oldExe, portable, userDataDir, dshHome, installDir, profileDir, currentVersion, newVersion, nodeExe }) {
   const lines = ['@echo off'];
@@ -646,12 +713,8 @@ function buildApplyScript({ newExe, oldExe, portable, userDataDir, dshHome, inst
       'exit /b 0'
     );
   } else {
-    // 安装版：不做进程检测。主进程 spawn 本脚本约 0.4s 后 app.exit(0)，
-    // 且 spawn 前 killTreeAndWait 已等完 dsh web 进程树，单实例锁保证没有
-    // 其他实例 —— 检测是冗余保险，而 tasklist|find 管道在 detached 隐藏
-    // 控制台下偶发挂死（黑窗反馈的根源）。固定短等待给主进程留优雅退出
-    // 时间，然后无条件兜底强杀（正常情况下进程已不在，taskkill 记一条
-    // not found 到日志即通过），线性推进到 Setup，全程无管道无循环。
+    // 安装版 CMD 只负责备份、Setup 与回滚。主进程等待由隐藏 PowerShell
+    // 助手完成，因此这里不得再加入 ping/tasklist/find/taskkill。
     //
     // V4.3 增量更新 PR（独有价值保留）：
     //   1) 备份 4 目录（userData / dshHome / profile / installDir）到
@@ -664,21 +727,20 @@ function buildApplyScript({ newExe, oldExe, portable, userDataDir, dshHome, inst
     //      新版健康启动后主进程 cleanupClientBackupIfHealthy →
     //      offerBackupCleanupConfirm 询问是否清理备份（保留 24h，超过不自动弹）。
     //   4) 失败路径：从备份目录反向 robocopy /MIR 回 4 目录，再拉起旧版。
-    //   5) manifest.json 的内联 JS 用「应用自带 node」执行（第 10 参传入，
+    //   5) manifest.json 的内联 JS 用「应用自带 node」执行（生成时内联，
     //      打包在 resources\node\node.exe）：目标用户机器普遍没有系统 Node，
     //      裸调 PATH 上的 node 会 errorlevel 9009 → BAD=2 → 更新永远中止
     //      回滚（更新死循环，v3.0.1 自举陷阱同类）。nodeExe 缺失/不存在时
     //      降级 SKIP_BACKUP（回到 v4.3 无备份语义），绝不依赖 PATH。
     lines.push(
       'set "SETUP=%~1"',
-      'set "EXENAME=%~2"',
-      'set "OLD=%~3"',
-      'set "UD=%~4"',
-      'set "DSH=%~5"',
-      'set "INST=%~6"',
-      'set "PROF=%~7"',
-      'set "OLDVER=%~8"',
-      'set "NEWVER=%~9"',
+      'set "OLD=%~2"',
+      'set "UD=%~3"',
+      'set "DSH=%~4"',
+      'set "INST=%~5"',
+      'set "PROF=%~6"',
+      'set "OLDVER=%~7"',
+      'set "NEWVER=%~8"',
       // nodeExe 不能经命令行传：batch 直接引用只到 %9（`%~10` 被解析成
       // `%~1` 后跟字面量 `0`，实测 NODEEXE 接成 "<第1参>0" → 备份被静默
       // 跳过）。曾怀疑 shift 接第 10 参导致脚本静默死亡 —— 2x2 矩阵探针
@@ -688,7 +750,7 @@ function buildApplyScript({ newExe, oldExe, portable, userDataDir, dshHome, inst
       // `%` 转义为 `%%` 防止变量展开破坏路径。
       `set "NODEEXE=${String(nodeExe || '').replace(/%/g, '%%')}"`,
       'set "LOG=%~dp0apply-update.log"',
-      'echo [%date% %time%] apply-update start > "%LOG%"',
+      'echo [%date% %time%] installed update action start >> "%LOG%"',
       'echo [%date% %time%] oldVer=%OLDVER% newVer=%NEWVER% >> "%LOG%"',
       'echo [%date% %time%] userData=%UD% >> "%LOG%"',
       'echo [%date% %time%] dsh=%DSH% >> "%LOG%"',
@@ -703,10 +765,6 @@ function buildApplyScript({ newExe, oldExe, portable, userDataDir, dshHome, inst
       'if "%NODEEXE%"=="" set SKIP_BACKUP=1',
       'if not exist "%NODEEXE%" set SKIP_BACKUP=1',
       'if "%SKIP_BACKUP%"=="1" echo [%date% %time%] WARN: one of UD/DSH/INST/PROF/NODEEXE empty or missing, skipping backup (fallback semantics) >> "%LOG%"',
-      'ping -n 4 127.0.0.1 >nul',
-      'echo [%date% %time%] force-killing leftover app processes >> "%LOG%"',
-      'taskkill /F /T /IM "%EXENAME%" >> "%LOG%" 2>&1',
-      'ping -n 2 127.0.0.1 >nul',
       // --- 阶段 0：查注册表 InstallLocation（供 manifest 对比，不影响实际动作）---
       'if "%SKIP_BACKUP%"=="0" set "REG_INST="',
       'if "%SKIP_BACKUP%"=="0" for /f "tokens=2*" %%a in (\'reg query "HKCU\\Software\\Deepseek Harness EAC" /v InstallLocation 2^>nul ^| findstr /i InstallLocation\') do set "REG_INST=%%b"',
@@ -848,40 +906,105 @@ function buildSpawnCommandLine(script, args) {
   return '"' + [script, ...args].map((a) => `"${a}"`).join(' ') + '"';
 }
 
+function buildInstalledPowerShellArgs(script, {
+  actionScript,
+  newExe,
+  oldExe,
+  userDataDir,
+  dshHome,
+  installDir,
+  profileDir,
+  currentVersion,
+  newVersion,
+  appPid,
+  logPath,
+  waitTimeoutSeconds = 20,
+}) {
+  if (!Number.isInteger(appPid) || appPid <= 0) throw new Error('安装版更新 PID 无效');
+  return [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-WindowStyle', 'Hidden',
+    '-File', script,
+    '-ActionScriptPath', actionScript,
+    '-SetupPath', newExe,
+    '-OldExePath', oldExe,
+    '-UserDataDir', userDataDir || '',
+    '-DshHome', dshHome || '',
+    '-InstallDir', installDir || '',
+    '-ProfileDir', profileDir || '',
+    '-CurrentVersion', currentVersion || '',
+    '-NewVersion', newVersion || '',
+    '-AppPid', String(appPid),
+    '-LogPath', logPath,
+    '-WaitTimeoutSeconds', String(waitTimeoutSeconds),
+  ];
+}
+
 function applyUpdate(ctx, pending, opts) {
   const newExe = pending.path;
   const portable = isPortable();
   const oldExe = process.env.PORTABLE_EXECUTABLE_FILE || process.execPath;
-  const exeBase = path.basename(oldExe);
-  const script = path.join(ctx.userDataDir, 'updates', 'apply-update.cmd');
+  const updateDir = path.join(ctx.userDataDir, 'updates');
+  const logPath = path.join(updateDir, 'apply-update.log');
   const userDataDir = (opts && opts.userDataDir) || ctx.userDataDir || '';
   const dshHome = (opts && opts.dshHome) || process.env.DSH_HOME || '';
   const installDir = (opts && opts.installDir) || path.dirname(oldExe);
   const profileDir = (opts && opts.profileDir) || '';
   const currentVersion = (opts && opts.currentVersion) || '';
   const newVersion = (opts && opts.newVersion) || (pending && pending.version) || '';
-  // 应用自带的 node 运行时（打包在 resources\node\node.exe）：manifest.json
-  // 的内联 JS 用它执行 —— 用户机器没有系统 Node，绝不能依赖 PATH。
   const nodeExe = (opts && opts.nodeExe) || '';
-  const lines = buildApplyScript({
-    newExe, oldExe, portable,
-    userDataDir, dshHome, installDir, profileDir, currentVersion, newVersion, nodeExe,
-  });
-  // 结尾必须带 CRLF：缺行尾的最后一行在 cmd 批解析器里行为不稳定
-  // （实测 self-delete 收尾行偶发不被执行）。
-  fs.writeFileSync(script, lines.join('\r\n') + '\r\n');
-  ctx.log('client-update', `启动更新脚本: ${script}（新: ${newExe}，旧: ${oldExe}，备份根: ${userDataDir}\\backups\\<ts>，node: ${nodeExe || '(无，跳过备份)'}）`);
-  const args = portable
-    ? [newExe, oldExe]
-    : [newExe, exeBase, oldExe, userDataDir, dshHome, installDir, profileDir, currentVersion, newVersion];
-  const child = spawn('cmd.exe', ['/d', '/s', '/c', buildSpawnCommandLine(script, args)], {
-    detached: true,
-    stdio: 'ignore',
-    windowsHide: true,
-    windowsVerbatimArguments: true,
-  });
+  let script;
+  let child;
+  if (portable) {
+    script = path.join(updateDir, 'apply-update.cmd');
+    fs.writeFileSync(script, buildApplyScript({ newExe, oldExe, portable: true }).join('\r\n') + '\r\n');
+    const args = [newExe, oldExe];
+    child = spawn('cmd.exe', ['/d', '/s', '/c', buildSpawnCommandLine(script, args)], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    });
+  } else {
+    const actionScript = path.join(updateDir, 'apply-update.cmd');
+    script = path.join(updateDir, 'apply-update.ps1');
+    const actionLines = buildApplyScript({
+      newExe, oldExe, portable: false,
+      userDataDir, dshHome, installDir, profileDir, currentVersion, newVersion, nodeExe,
+    });
+    fs.writeFileSync(actionScript, actionLines.join('\r\n') + '\r\n');
+    fs.writeFileSync(script, buildInstalledApplyScript().join('\r\n') + '\r\n', 'ascii');
+    const powershell = path.join(
+      process.env.SystemRoot || 'C:\\Windows',
+      'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'
+    );
+    if (!fs.existsSync(powershell)) throw new Error('找不到 Windows PowerShell: ' + powershell);
+    const args = buildInstalledPowerShellArgs(script, {
+      actionScript,
+      newExe,
+      oldExe,
+      userDataDir,
+      dshHome,
+      installDir,
+      profileDir,
+      currentVersion,
+      newVersion,
+      appPid: process.pid,
+      logPath,
+    });
+    child = spawn(powershell, args, {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+  }
+  ctx.log('client-update', `启动更新助手: ${script}（新: ${newExe}，旧: ${oldExe}，备份根: ${userDataDir}\\backups\\<ts>，node: ${nodeExe || '(无，跳过备份)'}）`);
+  child.once('error', (err) => ctx.log('client-update', '更新助手启动失败: ' + err.message));
   child.unref();
   return script;
 }
 
-module.exports = { checkLatest, selectAsset, downloadFile, downloadWithSourceSwitch, downloadRelease, releaseFallbacks, applyUpdate, buildApplyScript, buildSpawnCommandLine, isPortable, resolveRepos, normalizeRelease, computeSha256, fetchSumsMap, expectedSha256, isNoSpaceError, DEFAULT_REPOS };
+module.exports = { checkLatest, selectAsset, downloadFile, downloadWithSourceSwitch, downloadRelease, releaseFallbacks, applyUpdate, buildApplyScript, buildInstalledApplyScript, buildInstalledPowerShellArgs, buildSpawnCommandLine, isPortable, resolveRepos, normalizeRelease, computeSha256, fetchSumsMap, expectedSha256, isNoSpaceError, DEFAULT_REPOS };

--- a/dsh-desktop/test/client-updater-apply.test.mjs
+++ b/dsh-desktop/test/client-updater-apply.test.mjs
@@ -1,18 +1,9 @@
-// TDD regression tests for the apply-update.cmd script generation (issue #8).
+// TDD regression tests for the client self-update helper.
 //
-// Bug: the installer-branch script waited for the app process to exit with NO
-// timeout and NO force-kill. Tray apps keep the process alive after the window
-// closes, so :wait never ended, the new Setup never ran, and the 174 MB
-// installer plus script leaked forever in updates\. Users saw "重启以应用"
-// do nothing in a loop.
-//
-// The fix, tested here:
-//   1. bounded wait (~30s) then force-kill via taskkill /F /T
-//   2. every phase appends to a log file next to the script
-//   3. the Setup exit code is checked; on failure the old app is relaunched
-//      and the installer + log are KEPT for diagnosis (no silent residue loop)
-//   4. cleanup only happens on success
-//   5. script lines are CRLF-joined pure ASCII
+// Installed builds use a hidden PowerShell helper that waits for the exact
+// Electron PID, force-stops only that PID after a bounded timeout, and then
+// invokes the existing backup/rollback/install CMD in the hidden console.
+// Portable builds keep the existing CMD backup/replace/rollback flow.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -20,104 +11,321 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { buildApplyScript, buildSpawnCommandLine } from '../client-updater.js';
+import {
+  buildApplyScript,
+  buildInstalledApplyScript,
+  buildInstalledPowerShellArgs,
+  buildSpawnCommandLine,
+} from '../client-updater.js';
 
-const CTX = { userDataDir: 'C:\\userData' };
+const SYSTEM_ROOT = process.env.SystemRoot || 'C:\\Windows';
+const POWERSHELL = path.join(
+  SYSTEM_ROOT,
+  'System32',
+  'WindowsPowerShell',
+  'v1.0',
+  'powershell.exe'
+);
 
-// 黑窗卡死反馈（v3.0.1/v4.0.0 存量用户）：安装版分支用
-// tasklist | find 管道轮询旧进程是否退出。detached 控制台下该管道偶发挂死
-// （find 等不到写端 EOF），脚本停在等待循环里永远走不到运行 Setup ——
-// 用户看到一个纯黑 cmd 窗口反复弹出且无反应；主进程 spawn 本脚本约 0.4s
-// 后 app.exit(0)，且 spawn 前 killTreeAndWait 已等完 dsh web 进程树，
-// 轮询检测本就是冗余保险。修复 = 去掉检测：固定短等待 → 无条件兜底强杀
-// → 线性推进到 Setup，全程无管道、无回跳循环，总时长有界（约 6s）。
-test('installer branch is hang-proof: no tasklist|find pipe, no wait loop, bounded linear flow', () => {
-  const lines = buildApplyScript({ ctx: CTX, newExe: 'C:\\updates\\setup.exe', oldExe: 'C:\\Programs\\app\\app.exe', portable: false });
-  const joined = lines.join('\n');
+function waitForExit(child, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    if (child.exitCode !== null) {
+      resolve(child.exitCode);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try { child.kill(); } catch { /* already gone */ }
+      reject(new Error(`process ${child.pid} did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.once('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
 
-  // 不得再出现管道式进程检测（挂死根源）
-  assert.doesNotMatch(joined, /tasklist/i, 'must not use tasklist detection');
-  assert.doesNotMatch(joined, /\bfind\b/i, 'must not pipe into find.exe');
-  // 不得存在回跳等待循环：脚本必须线性推进到 Setup
-  assert.doesNotMatch(joined, /goto\s+:?wait/i, 'no wait loop may exist');
-  // 兜底强杀必须在运行 Setup 之前
-  const killIdx = lines.findIndex((l) => /taskkill\s+\/F\s+\/T\s+\/IM/.test(l));
-  const setupIdx = lines.findIndex((l) => /^call "%SETUP%"/.test(l.trim()));
-  assert.ok(killIdx >= 0, 'must force-kill leftover app processes');
-  assert.ok(setupIdx > killIdx, 'setup must run after the force-kill');
-  // 延时只能用自终止的 ping -n，且次数必须小而有界
-  const pings = [...joined.matchAll(/ping\s+-n\s+(\d+)/g)].map((m) => Number(m[1]));
-  assert.ok(pings.length >= 1, 'settle delays expected');
-  for (const n of pings) assert.ok(n > 0 && n <= 10, 'ping delays must be small and bounded, got ' + n);
+async function waitForFile(file, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(file)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`file was not created within ${timeoutMs}ms: ${file}`);
+}
+
+function startSleepingPowerShell(seconds = 60) {
+  return spawn(POWERSHELL, [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    `Start-Sleep -Seconds ${seconds}`,
+  ], {
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+}
+
+function runInstalledHelper({
+  script,
+  actionScript,
+  setup,
+  oldExe,
+  appPid,
+  log,
+  userDataDir,
+  dshHome,
+  installDir,
+  profileDir,
+  currentVersion = '4.4.0',
+  newVersion = '4.4.1',
+  waitTimeoutSeconds = 20,
+  env = process.env,
+}) {
+  return spawn(POWERSHELL, buildInstalledPowerShellArgs(script, {
+    actionScript,
+    newExe: setup,
+    oldExe,
+    userDataDir,
+    dshHome,
+    installDir,
+    profileDir,
+    currentVersion,
+    newVersion,
+    appPid,
+    logPath: log,
+    waitTimeoutSeconds,
+  }), {
+    stdio: 'ignore',
+    windowsHide: true,
+    env,
+  });
+}
+
+function writeInstalledScripts(dir, {
+  setup,
+  oldExe,
+  userDataDir = dir,
+  dshHome = dir,
+  installDir = dir,
+  profileDir = dir,
+  currentVersion = '4.4.0',
+  newVersion = '4.4.1',
+  nodeExe = '',
+} = {}) {
+  const actionScript = path.join(dir, 'apply-update.cmd');
+  const script = path.join(dir, 'apply-update.ps1');
+  fs.writeFileSync(actionScript, buildApplyScript({
+    newExe: setup,
+    oldExe,
+    portable: false,
+    userDataDir,
+    dshHome,
+    installDir,
+    profileDir,
+    currentVersion,
+    newVersion,
+    nodeExe,
+  }).join('\r\n') + '\r\n');
+  fs.writeFileSync(script, buildInstalledApplyScript().join('\r\n') + '\r\n', 'ascii');
+  return { script, actionScript };
+}
+
+test('installed helper and action avoid the console utilities that caused the hang', () => {
+  const helper = buildInstalledApplyScript().join('\n');
+  const action = buildApplyScript({
+    newExe: 'C:\\updates\\setup.exe',
+    oldExe: 'C:\\Programs\\app\\app.exe',
+    portable: false,
+  }).join('\n');
+
+  for (const content of [helper, action]) {
+    assert.doesNotMatch(content, /\bping(?:\.exe)?\b/i);
+    assert.doesNotMatch(content, /\bfind(?:\.exe)?\b/i);
+    assert.doesNotMatch(content, /\btasklist(?:\.exe)?\b/i);
+    assert.doesNotMatch(content, /\btaskkill(?:\.exe)?\b/i);
+  }
+  assert.match(helper, /Get-Process -Id \$AppPid/);
+  assert.match(helper, /Stop-Process -Id \$AppPid -Force/);
+  assert.doesNotMatch(helper, /-Name\b|MainModule|ProcessName/i);
 });
 
-test('script writes a log file and records the setup exit code', () => {
-  const lines = buildApplyScript({ ctx: CTX, newExe: 'C:\\updates\\setup.exe', oldExe: 'C:\\Programs\\app\\app.exe', portable: false });
-  const joined = lines.join('\n');
-  assert.match(joined, /apply-update\.log/, 'must reference a log file');
-  // log lines are appended with >>
-  const logLines = lines.filter((l) => l.includes('>>'));
-  assert.ok(logLines.length >= 3, 'must log wait/kill/run phases, got ' + logLines.length);
-  // setup exit code recorded into the log
-  assert.match(joined, /errorlevel/i);
-  const exitLogLine = lines.find((l) => /exit code/.test(l));
-  assert.ok(exitLogLine, 'must have an exit-code log line');
-  assert.match(exitLogLine, />>\s*"%LOG%"/, 'exit code must be appended to the log');
+test('installed helper has bounded waits and synchronously invokes the hidden action', () => {
+  const helper = buildInstalledApplyScript().join('\n');
+  const action = buildApplyScript({
+    newExe: 'C:\\updates\\setup.exe',
+    oldExe: 'C:\\Programs\\app\\app.exe',
+    portable: false,
+  }).join('\n');
+
+  assert.match(helper, /AddSeconds\(\$WaitTimeoutSeconds\)/);
+  assert.match(helper, /\$i -lt 25/);
+  assert.match(helper, /& \$ActionScriptPath \$SetupPath \$OldExePath/);
+  assert.match(helper, /\$LASTEXITCODE/);
+  assert.match(helper, /waiting for app exit/);
+  assert.match(helper, /update action exit code/);
+  assert.match(action, /call "%SETUP%" \/S/);
+  assert.match(action, /setup exit code %errorlevel%/);
+  assert.match(action, /update applied/);
 });
 
-test('on setup failure the old app is relaunched and artifacts are kept', () => {
-  const lines = buildApplyScript({ ctx: CTX, newExe: 'C:\\updates\\setup.exe', oldExe: 'C:\\Programs\\app\\app.exe', portable: false });
-  const joined = lines.join('\n');
-  const failIdx = lines.findIndex((l) => /^:failed$/i.test(l.trim()));
-  assert.ok(failIdx >= 0, 'must have a :failed label');
-  const afterFail = lines.slice(failIdx).join('\n');
-  assert.match(afterFail, /start\s+""\s+"%OLD%"/i, 'failed update must relaunch the old app');
-  // and must NOT delete the setup in the failure path
-  assert.doesNotMatch(afterFail, /del\s+"%SETUP%"/i, 'failure path must keep the installer for diagnosis');
+test('installed failure paths keep artifacts and relaunch the old executable', () => {
+  const helperLines = buildInstalledApplyScript();
+  const catchIdx = helperLines.lastIndexOf('} catch {');
+  assert.ok(catchIdx >= 0, 'helper must have a catch block');
+  const helperFailure = helperLines.slice(catchIdx).join('\n');
+  const actionLines = buildApplyScript({
+    newExe: 'C:\\updates\\setup.exe',
+    oldExe: 'C:\\Programs\\app\\app.exe',
+    portable: false,
+  });
+  const failedIdx = actionLines.indexOf(':failed');
+  assert.ok(failedIdx >= 0, 'action must have a failed label');
+  const actionFailure = actionLines.slice(failedIdx).join('\n');
+
+  assert.match(helperFailure, /Start-Process -FilePath \$OldExePath/);
+  assert.doesNotMatch(helperFailure, /Remove-Item -LiteralPath \$ScriptPath/);
+  assert.match(actionFailure, /start "" "%OLD%"/i);
+  assert.doesNotMatch(actionFailure, /del "%SETUP%"/i);
+  assert.doesNotMatch(actionFailure, /del "%~f0"/i);
 });
 
-test('cleanup of setup+script only happens on the success path', () => {
-  const lines = buildApplyScript({ ctx: CTX, newExe: 'C:\\updates\\setup.exe', oldExe: 'C:\\Programs\\app\\app.exe', portable: false });
-  const successIdx = lines.findIndex((l) => /^:success$/i.test(l.trim()));
-  assert.ok(successIdx >= 0, 'must have a :success label');
-  const afterSuccess = lines.slice(successIdx).join('\n');
-  assert.match(afterSuccess, /del\s+"%SETUP%"/i, 'success path must delete the installer');
-  assert.match(afterSuccess, /del\s+"%~f0"/i, 'success path must delete the script itself');
+test('installed success paths remove Setup and both helper scripts', () => {
+  const helper = buildInstalledApplyScript().join('\n');
+  const actionLines = buildApplyScript({
+    newExe: 'C:\\updates\\setup.exe',
+    oldExe: 'C:\\Programs\\app\\app.exe',
+    portable: false,
+  });
+  const successIdx = actionLines.indexOf(':success');
+  const failedIdx = actionLines.indexOf(':failed');
+  assert.ok(successIdx >= 0 && failedIdx > successIdx, 'action success block must precede failure');
+  const actionSuccess = actionLines.slice(successIdx, failedIdx).join('\n');
+
+  assert.match(helper, /Remove-Item -LiteralPath \$ScriptPath/);
+  assert.match(actionSuccess, /del "%SETUP%"/i);
+  assert.match(actionSuccess, /del "%~f0"/i);
 });
 
-test('portable branch keeps backup/replace/restore semantics and gains the same bounded wait', () => {
-  const lines = buildApplyScript({ ctx: CTX, newExe: 'C:\\updates\\new.exe', oldExe: 'D:\\portable\\app.exe', portable: true });
-  const joined = lines.join('\n');
-  assert.match(joined, /OLD%\.bak/, 'portable branch must still back up the old exe');
-  assert.match(joined, /copy\s+\/y\s+"%NEW%"\s+"%OLD%"/i, 'portable branch must still replace in place');
-  assert.match(joined, /gtr\s+\d+/, 'portable wait must be bounded too');
-  assert.match(joined, /apply-update\.log/, 'portable branch must log too');
+test('installed PowerShell arguments preserve paths and request a hidden non-interactive window', () => {
+  const script = 'C:\\用户 A\\Deepseek Harness EAC\\updates\\apply-update.ps1';
+  const setup = 'C:\\用户 A\\Deepseek Harness EAC\\updates\\Setup x64.exe';
+  const oldExe = 'C:\\Program Files\\Deepseek Harness EAC\\Deepseek Harness EAC.exe';
+  const actionScript = 'C:\\用户 A\\Deepseek Harness EAC\\updates\\apply-update.cmd';
+  const log = 'C:\\用户 A\\Deepseek Harness EAC\\updates\\apply-update.log';
+  const args = buildInstalledPowerShellArgs(script, {
+    actionScript,
+    newExe: setup,
+    oldExe,
+    userDataDir: 'C:\\用户 A\\Deepseek Harness EAC',
+    dshHome: 'C:\\用户 A\\.dsh',
+    installDir: 'C:\\Program Files\\Deepseek Harness EAC',
+    profileDir: 'C:\\用户 A\\.dsh\\profiles\\web-desktop',
+    currentVersion: '4.4.0',
+    newVersion: '4.4.1',
+    appPid: 4321,
+    logPath: log,
+  });
+
+  assert.deepEqual(args.slice(0, 7), [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-WindowStyle',
+    'Hidden',
+  ]);
+  assert.equal(args[args.indexOf('-File') + 1], script);
+  assert.equal(args[args.indexOf('-ActionScriptPath') + 1], actionScript);
+  assert.equal(args[args.indexOf('-SetupPath') + 1], setup);
+  assert.equal(args[args.indexOf('-OldExePath') + 1], oldExe);
+  assert.equal(args[args.indexOf('-CurrentVersion') + 1], '4.4.0');
+  assert.equal(args[args.indexOf('-NewVersion') + 1], '4.4.1');
+  assert.equal(args[args.indexOf('-AppPid') + 1], '4321');
+  assert.equal(args[args.indexOf('-LogPath') + 1], log);
+  assert.equal(args[args.indexOf('-WaitTimeoutSeconds') + 1], '20');
 });
 
-test('all generated lines are ASCII with no bare CRLF inside line content', () => {
-  for (const variant of [true, false]) {
-    const lines = buildApplyScript({ ctx: CTX, newExe: 'C:\\updates\\setup.exe', oldExe: 'C:\\Programs\\app\\app.exe', portable: variant });
+test('installed PowerShell arguments reject an invalid app PID', () => {
+  const input = {
+    actionScript: 'C:\\updates\\apply-update.cmd',
+    newExe: 'C:\\updates\\setup.exe',
+    oldExe: 'C:\\Program Files\\app.exe',
+    userDataDir: 'C:\\userData',
+    dshHome: 'C:\\Users\\u\\.dsh',
+    installDir: 'C:\\Program Files',
+    profileDir: 'C:\\Users\\u\\.dsh\\profiles\\web-desktop',
+    currentVersion: '4.4.0',
+    newVersion: '4.4.1',
+    logPath: 'C:\\updates\\apply-update.log',
+  };
+  for (const appPid of [undefined, null, 0, -1, 1.5, '42']) {
+    assert.throws(
+      () => buildInstalledPowerShellArgs('C:\\updates\\apply-update.ps1', { ...input, appPid }),
+      /PID/
+    );
+  }
+});
+
+test('buildApplyScript keeps installed backup/rollback and portable replacement semantics', () => {
+  const installed = buildApplyScript({
+    newExe: 'C:\\updates\\setup.exe',
+    oldExe: 'C:\\app.exe',
+    portable: false,
+  }).join('\n');
+  assert.match(installed, /SKIP_BACKUP/);
+  assert.match(installed, /rolling back 4 directories/);
+  assert.doesNotMatch(installed, /force-killing leftover app processes/);
+
+  const portable = buildApplyScript({
+    newExe: 'C:\\updates\\new.exe',
+    oldExe: 'D:\\portable\\app.exe',
+    portable: true,
+  }).join('\n');
+  assert.match(portable, /OLD%\.bak/);
+  assert.match(portable, /copy\s+\/y\s+"%NEW%"\s+"%OLD%"/i);
+  assert.match(portable, /gtr\s+\d+/);
+  assert.match(portable, /apply-update\.log/);
+});
+
+test('all generated helper-script lines are ASCII without embedded newlines', () => {
+  const variants = [
+    buildInstalledApplyScript(),
+    buildApplyScript({
+      newExe: 'C:\\updates\\setup.exe',
+      oldExe: 'C:\\Programs\\app.exe',
+      portable: false,
+      nodeExe: 'C:\\Programs\\node.exe',
+    }),
+    buildApplyScript({
+      newExe: 'C:\\updates\\new.exe',
+      oldExe: 'D:\\portable\\app.exe',
+      portable: true,
+    }),
+  ];
+  for (const lines of variants) {
     for (const line of lines) {
-      assert.ok(/^[\x20-\x7E]*$/.test(line), 'non-ASCII line in script: ' + JSON.stringify(line));
-      assert.doesNotMatch(line, /\r|\n/, 'embedded newline in line: ' + JSON.stringify(line));
+      assert.ok(/^[\x20-\x7E]*$/.test(line), 'non-ASCII line: ' + JSON.stringify(line));
+      assert.doesNotMatch(line, /\r|\n/, 'embedded newline: ' + JSON.stringify(line));
     }
   }
 });
 
-// v2.0.x 回归（蓝七反馈“点立即重启没反应”）：spawn('cmd.exe', ['/c', script,
-// ...args]) 让 Node 给含空格参数加引号，cmd /c 剥掉首尾引号后路径在空格处
-// 断开（'C:\...\Deepseek' is not recognized），且 stdio:'ignore' 吞掉报错 →
-// apply-update.cmd 静默不执行。修复 = /d /s /c + windowsVerbatimArguments +
-// 整行外层再包一对引号（/s 剥外层后还原标准参数行）。
-test('spawn command line wraps the whole arg row in an extra outer quote pair', () => {
+// Portable update regression: cmd /s strips the outer pair and leaves every
+// path argument quoted, including paths containing spaces.
+test('portable spawn command line wraps the whole argument row in an outer quote pair', () => {
   const script = 'C:\\Users\\a b\\AppData\\Roaming\\Deepseek Harness EAC\\updates\\apply-update.cmd';
   const args = [
-    'C:\\Users\\a b\\AppData\\Roaming\\Deepseek Harness EAC\\updates\\Deepseek-Harness-EAC-Setup-x64.exe',
-    'Deepseek Harness EAC.exe',
+    'C:\\Users\\a b\\AppData\\Roaming\\Deepseek Harness EAC\\updates\\portable-x64.exe',
+    'C:\\Users\\a b\\Desktop\\Deepseek Harness EAC.exe',
   ];
   const line = buildSpawnCommandLine(script, args);
-  // 期望形式：""script" "arg1" "arg2"" —— /s 剥外层后还原为每参数带引号的标准行
-  assert.equal(line, '"' + [script, ...args].map((a) => `"${a}"`).join(' ') + '"');
+  assert.equal(line, '"' + [script, ...args].map((arg) => `"${arg}"`).join(' ') + '"');
 });
 
 // ---------------------------------------------------------------------------
@@ -128,7 +336,7 @@ test('spawn command line wraps the whole arg row in an extra outer quote pair', 
 // 解析失败 errorlevel 9009 → BAD=2 → 「backup failed, aborting update」
 // → 永远回滚重弹旧版，更新死循环（与 v3.0.1 applyUpdate 自举陷阱同类：
 // 更新通道自身的缺陷无法借更新修复）。修复 = applyUpdate 把应用自带
-// nodeExe 作为第 10 参数传给脚本，脚本用带引号的 "%NODEEXE%" 调用；
+// nodeExe 在生成脚本时安全内联，脚本用带引号的 "%NODEEXE%" 调用；
 // nodeExe 缺失/不存在时降级 SKIP_BACKUP（回到 v4.3 无备份语义），
 // 绝不裸调 PATH 上的 node。
 // ---------------------------------------------------------------------------
@@ -174,6 +382,7 @@ test('backup branch must not invoke bare `node` from PATH (inlines %NODEEXE% or 
 // 安装 + .backup-ts marker + 成功清理，全程 PATH 剥掉 node。
 test('backup flow e2e: 4-dir backup + manifest + /S setup + marker, node stripped from PATH', { skip: process.platform !== 'win32' }, async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-apply-bk-'));
+  let appProc;
   try {
     const ud = path.join(dir, 'userdata');
     const dsh = path.join(dir, 'dshhome');
@@ -190,34 +399,45 @@ test('backup flow e2e: 4-dir backup + manifest + /S setup + marker, node strippe
     fs.writeFileSync(path.join(inst, 'app.exe'), 'OLD-APP-BYTES');
     fs.writeFileSync(path.join(inst, 'resources.txt'), 'RES');
 
-    // 伪装存活应用（脚本须强杀）+ 伪装 Setup（写标记退出 0）
+    // 伪装存活应用（PowerShell 助手须精确结束）+ 伪装 Setup（写标记退出 0）
     const fakeExeName = 'fake-dsh-eac-bk.exe';
     const fakeAppExe = path.join(dir, fakeExeName);
     fs.copyFileSync(path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'ping.exe'), fakeAppExe);
-    const appProc = spawn(fakeAppExe, ['-n', '60', '127.0.0.1'], { stdio: 'ignore', windowsHide: true });
+    appProc = spawn(fakeAppExe, ['-n', '60', '127.0.0.1'], { stdio: 'ignore', windowsHide: true });
     const appExited = new Promise((r) => appProc.once('exit', r));
     const marker = path.join(dir, 'setup-ran.ok');
     const fakeSetup = path.join(dir, 'fake-setup.cmd');
     fs.writeFileSync(fakeSetup, `@echo off\r\necho ran> "${marker}"\r\nexit /b 0\r\n`);
 
-    const script = path.join(dir, 'apply-update.cmd');
-    fs.writeFileSync(script, buildApplyScript({
-      newExe: fakeSetup, oldExe: fakeAppExe, portable: false,
+    const { script, actionScript } = writeInstalledScripts(dir, {
+      setup: fakeSetup,
+      oldExe: fakeAppExe,
       userDataDir: ud, dshHome: dsh, installDir: inst, profileDir: prof,
       currentVersion: '4.3.0', newVersion: '4.4.0',
       nodeExe: process.execPath,
-    }).join('\r\n') + '\r\n');
+    });
     await new Promise((r) => setTimeout(r, 500)); // 等伪装应用真正跑起来
 
-    const line = buildSpawnCommandLine(script, [fakeSetup, fakeExeName, fakeAppExe, ud, dsh, inst, prof, '4.3.0', '4.4.0']);
     // PATH 剥掉 node（保留系统工具），模拟普通用户机器
     const sysRoot = process.env.SystemRoot || 'C:\\Windows';
     const cleanEnv = {
       ...process.env,
       PATH: `${sysRoot}\\System32;${sysRoot};${sysRoot}\\System32\\WindowsPowerShell\\v1.0\\`,
     };
-    const run = spawn('cmd.exe', ['/d', '/s', '/c', line], {
-      stdio: 'ignore', windowsHide: true, windowsVerbatimArguments: true, env: cleanEnv,
+    const run = runInstalledHelper({
+      script,
+      actionScript,
+      setup: fakeSetup,
+      oldExe: fakeAppExe,
+      appPid: appProc.pid,
+      log: path.join(dir, 'apply-update.log'),
+      userDataDir: ud,
+      dshHome: dsh,
+      installDir: inst,
+      profileDir: prof,
+      currentVersion: '4.3.0',
+      newVersion: '4.4.0',
+      env: cleanEnv,
     });
     const code = await new Promise((resolve, reject) => {
       const killer = setTimeout(() => {
@@ -256,8 +476,12 @@ test('backup flow e2e: 4-dir backup + manifest + /S setup + marker, node strippe
     if (appProc.exitCode === null) await Promise.race([appExited, new Promise((r) => setTimeout(r, 2000))]);
     assert.ok(appProc.exitCode !== null, 'the live fake app must have been force-killed');
     assert.ok(!fs.existsSync(fakeSetup), 'success path must delete the installer');
-    assert.ok(!fs.existsSync(script), 'success path must self-delete the script');
+    assert.ok(!fs.existsSync(actionScript), 'success path must self-delete the action script');
+    assert.ok(!fs.existsSync(script), 'success path must self-delete the PowerShell helper');
   } finally {
+    if (appProc?.exitCode === null) {
+      try { appProc.kill(); } catch { /* best effort */ }
+    }
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
   }
 });
@@ -266,6 +490,7 @@ test('backup flow e2e: 4-dir backup + manifest + /S setup + marker, node strippe
 // 被删掉的安装文件被恢复 → 不写 marker → 拉起旧版 → 脚本退出 1。
 test('backup flow e2e: setup failure rolls back the 4 directories from the backup', { skip: process.platform !== 'win32' }, async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-apply-rb-'));
+  let appProc;
   try {
     const ud = path.join(dir, 'userdata');
     const dsh = path.join(dir, 'dshhome');
@@ -279,7 +504,7 @@ test('backup flow e2e: setup failure rolls back the 4 directories from the backu
     const fakeExeName = 'fake-dsh-eac-rb.exe';
     const fakeAppExe = path.join(dir, fakeExeName);
     fs.copyFileSync(path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'ping.exe'), fakeAppExe);
-    const appProc = spawn(fakeAppExe, ['-n', '60', '127.0.0.1'], { stdio: 'ignore', windowsHide: true });
+    appProc = spawn(fakeAppExe, ['-n', '60', '127.0.0.1'], { stdio: 'ignore', windowsHide: true });
     const appExited = new Promise((r) => appProc.once('exit', r));
 
     // 伪装 Setup：写标记 → 删安装目录文件（模拟半途失败）→ 退出 1
@@ -287,17 +512,29 @@ test('backup flow e2e: setup failure rolls back the 4 directories from the backu
     const fakeSetup = path.join(dir, 'fake-setup.cmd');
     fs.writeFileSync(fakeSetup, `@echo off\r\necho ran> "${marker}"\r\ndel "${path.join(inst, 'doomed.txt')}"\r\ndel "${path.join(inst, 'app.exe')}"\r\nexit /b 1\r\n`);
 
-    const script = path.join(dir, 'apply-update.cmd');
-    fs.writeFileSync(script, buildApplyScript({
-      newExe: fakeSetup, oldExe: fakeAppExe, portable: false,
+    const { script, actionScript } = writeInstalledScripts(dir, {
+      setup: fakeSetup,
+      oldExe: fakeAppExe,
       userDataDir: ud, dshHome: dsh, installDir: inst, profileDir: prof,
       currentVersion: '4.3.0', newVersion: '4.4.0',
       nodeExe: process.execPath,
-    }).join('\r\n') + '\r\n');
+    });
     await new Promise((r) => setTimeout(r, 500));
 
-    const line = buildSpawnCommandLine(script, [fakeSetup, fakeExeName, fakeAppExe, ud, dsh, inst, prof, '4.3.0', '4.4.0']);
-    const run = spawn('cmd.exe', ['/d', '/s', '/c', line], { stdio: 'ignore', windowsHide: true, windowsVerbatimArguments: true });
+    const run = runInstalledHelper({
+      script,
+      actionScript,
+      setup: fakeSetup,
+      oldExe: fakeAppExe,
+      appPid: appProc.pid,
+      log: path.join(dir, 'apply-update.log'),
+      userDataDir: ud,
+      dshHome: dsh,
+      installDir: inst,
+      profileDir: prof,
+      currentVersion: '4.3.0',
+      newVersion: '4.4.0',
+    });
     const code = await new Promise((resolve, reject) => {
       const killer = setTimeout(() => {
         try { run.kill(); } catch { /* already gone */ }
@@ -317,60 +554,180 @@ test('backup flow e2e: setup failure rolls back the 4 directories from the backu
     // 失败不写成功 marker，不删安装包（诊断保留）
     assert.ok(!fs.existsSync(path.join(ud, 'updates', '.backup-ts')), 'no success marker on failure');
     assert.ok(fs.existsSync(fakeSetup), 'failure path must keep the installer for diagnosis');
+    assert.ok(fs.existsSync(actionScript), 'failure path must keep the action script');
+    assert.ok(fs.existsSync(script), 'failure path must keep the PowerShell helper');
     if (appProc.exitCode === null) await Promise.race([appExited, new Promise((r) => setTimeout(r, 2000))]);
     assert.ok(appProc.exitCode !== null, 'the live fake app must have been force-killed');
   } finally {
+    if (appProc?.exitCode === null) {
+      try { appProc.kill(); } catch { /* best effort */ }
+    }
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
   }
 });
 
-// 端到端验证「能正常更新」：用生成的真实脚本 + 伪装存活应用（复制的
-// ping.exe 改名后跑 60s）+ 伪装 Setup（写标记文件退出 0），走生产同款
-// spawn 路径（cmd /d /s /c + 整行引用）。断言：强杀残留进程 → Setup 被
-// 执行 → 成功路径清理（删安装包 + 自删）→ 日志完整 → 全程有界不挂死。
-test('installer script end-to-end: kills a live fake app, runs the setup, cleans up on success', { skip: process.platform !== 'win32' }, async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-apply-'));
+test('installed helper waits for graceful app exit before running the update action', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-installed-graceful-'));
+  let appProc;
   try {
-    const fakeExeName = 'fake-dsh-eac-test.exe';
-    const fakeAppExe = path.join(dir, fakeExeName);
-    fs.copyFileSync(path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'ping.exe'), fakeAppExe);
-    const appProc = spawn(fakeAppExe, ['-n', '60', '127.0.0.1'], { stdio: 'ignore', windowsHide: true });
-    const appExited = new Promise((r) => appProc.once('exit', r));
+    const runningMarker = path.join(dir, 'app-running.flag');
+    const setupMarker = path.join(dir, 'setup-result.txt');
+    const appScript = path.join(dir, 'fake-app.ps1');
+    const setup = path.join(dir, 'fake-setup.cmd');
+    const oldExe = path.join(dir, 'old-app.cmd');
+    const log = path.join(dir, 'apply-update.log');
 
-    const marker = path.join(dir, 'setup-ran.ok');
-    const fakeSetup = path.join(dir, 'fake-setup.cmd');
-    fs.writeFileSync(fakeSetup, `@echo off\r\necho ran> "${marker}"\r\nexit /b 0\r\n`);
-    const script = path.join(dir, 'apply-update.cmd');
-    fs.writeFileSync(script, buildApplyScript({ newExe: fakeSetup, oldExe: 'C:\\Programs\\app\\app.exe', portable: false }).join('\r\n'));
-    await new Promise((r) => setTimeout(r, 500)); // 等伪装应用真正跑起来
+    fs.writeFileSync(appScript, [
+      `Set-Content -LiteralPath '${runningMarker.replaceAll("'", "''")}' -Value running`,
+      'Start-Sleep -Milliseconds 1200',
+      `Remove-Item -LiteralPath '${runningMarker.replaceAll("'", "''")}' -Force`,
+    ].join('\r\n'));
+    fs.writeFileSync(setup, [
+      '@echo off',
+      `if exist "${runningMarker}" (echo too-early>"${setupMarker}") else (echo ran>"${setupMarker}")`,
+      'exit /b 0',
+    ].join('\r\n'));
+    fs.writeFileSync(oldExe, '@echo off\r\nexit /b 0\r\n');
+    const { script, actionScript } = writeInstalledScripts(dir, { setup, oldExe });
 
-    const t0 = Date.now();
-    const line = buildSpawnCommandLine(script, [fakeSetup, fakeExeName, 'C:\\Programs\\app\\app.exe']);
-    const run = spawn('cmd.exe', ['/d', '/s', '/c', line], {
-      stdio: 'ignore',
-      windowsHide: true,
-      windowsVerbatimArguments: true,
+    appProc = spawn(POWERSHELL, [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      appScript,
+    ], { stdio: 'ignore', windowsHide: true });
+    await waitForFile(runningMarker);
+
+    const helper = runInstalledHelper({
+      script,
+      actionScript,
+      setup,
+      oldExe,
+      appPid: appProc.pid,
+      log,
+      userDataDir: dir,
+      dshHome: dir,
+      installDir: dir,
+      profileDir: dir,
+      waitTimeoutSeconds: 5,
     });
-    const code = await new Promise((resolve, reject) => {
-      const killer = setTimeout(() => {
-        try { run.kill(); } catch { /* already gone */ }
-        reject(new Error('apply-update script did not exit within 45s (hang regression)'));
-      }, 45000);
-      run.on('exit', (c) => { clearTimeout(killer); resolve(c); });
-    });
-
-    assert.equal(code, 0, 'script must exit 0 on the success path');
-    assert.ok(fs.existsSync(marker), 'the setup must have been executed');
-    if (appProc.exitCode === null) await Promise.race([appExited, new Promise((r) => setTimeout(r, 2000))]);
-    assert.ok(appProc.exitCode !== null, 'the live fake app must have been force-killed');
-    assert.ok(!fs.existsSync(fakeSetup), 'success path must delete the installer');
-    assert.ok(!fs.existsSync(script), 'success path must self-delete the script');
-    const log = fs.readFileSync(path.join(dir, 'apply-update.log'), 'utf8');
-    assert.match(log, /apply-update start/);
-    assert.match(log, /running setup/);
-    assert.match(log, /update applied/);
-    assert.ok(Date.now() - t0 < 20000, 'whole flow must stay bounded and quick, took ' + (Date.now() - t0) + 'ms');
+    assert.equal(await waitForExit(helper), 0);
+    assert.equal(fs.readFileSync(setupMarker, 'utf8').trim(), 'ran');
+    assert.ok(!fs.existsSync(setup), 'successful Setup must be deleted');
+    assert.ok(!fs.existsSync(actionScript), 'successful action must delete itself');
+    assert.ok(!fs.existsSync(script), 'successful PowerShell helper must delete itself');
+    const logText = fs.readFileSync(log, 'utf8');
+    assert.match(logText, /running hidden update action/);
+    assert.match(logText, /running setup \/S/);
+    assert.match(logText, /setup exit code 0/);
+    assert.match(logText, /update applied/);
   } finally {
-    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    if (appProc?.exitCode === null) {
+      try { appProc.kill(); } catch { /* best effort */ }
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installed helper timeout stops only the requested PID', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-installed-timeout-'));
+  let target;
+  let sibling;
+  try {
+    target = startSleepingPowerShell();
+    sibling = startSleepingPowerShell();
+    const setupMarker = path.join(dir, 'setup-ran.txt');
+    const setup = path.join(dir, 'fake-setup.cmd');
+    const oldExe = path.join(dir, 'old-app.cmd');
+    const log = path.join(dir, 'apply-update.log');
+
+    fs.writeFileSync(setup, `@echo off\r\necho ran>"${setupMarker}"\r\nexit /b 0\r\n`);
+    fs.writeFileSync(oldExe, '@echo off\r\nexit /b 0\r\n');
+    const { script, actionScript } = writeInstalledScripts(dir, { setup, oldExe });
+
+    const helper = runInstalledHelper({
+      script,
+      actionScript,
+      setup,
+      oldExe,
+      appPid: target.pid,
+      log,
+      userDataDir: dir,
+      dshHome: dir,
+      installDir: dir,
+      profileDir: dir,
+      waitTimeoutSeconds: 1,
+    });
+    assert.equal(await waitForExit(helper), 0);
+    await waitForExit(target, 3000);
+
+    assert.ok(fs.existsSync(setupMarker), 'Setup must run after the target exits');
+    assert.equal(sibling.exitCode, null, 'sibling process must not be killed');
+    assert.match(fs.readFileSync(log, 'utf8'), /stopping exact PID/);
+  } finally {
+    for (const child of [target, sibling]) {
+      if (child?.exitCode === null) {
+        try { child.kill(); } catch { /* best effort */ }
+      }
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installed helper keeps artifacts and relaunches the old app when Setup fails', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-installed-failure-'));
+  try {
+    const oldAppMarker = path.join(dir, 'old-app-ran.txt');
+    const setup = path.join(dir, 'failing-setup.cmd');
+    const oldExe = path.join(dir, 'old-app.cmd');
+    const log = path.join(dir, 'apply-update.log');
+
+    fs.writeFileSync(setup, '@echo off\r\nexit /b 7\r\n');
+    fs.writeFileSync(oldExe, `@echo off\r\necho ran>"${oldAppMarker}"\r\nexit /b 0\r\n`);
+    const { script, actionScript } = writeInstalledScripts(dir, { setup, oldExe });
+
+    const alreadyExited = spawn(POWERSHELL, [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      'exit 0',
+    ], { stdio: 'ignore', windowsHide: true });
+    const exitedPid = alreadyExited.pid;
+    await waitForExit(alreadyExited);
+
+    const helper = runInstalledHelper({
+      script,
+      actionScript,
+      setup,
+      oldExe,
+      appPid: exitedPid,
+      log,
+      userDataDir: dir,
+      dshHome: dir,
+      installDir: dir,
+      profileDir: dir,
+      waitTimeoutSeconds: 1,
+    });
+    assert.equal(await waitForExit(helper), 1);
+    await waitForFile(oldAppMarker);
+
+    assert.ok(fs.existsSync(setup), 'failed Setup must be kept for diagnosis');
+    assert.ok(fs.existsSync(actionScript), 'failed action must be kept for diagnosis');
+    assert.ok(fs.existsSync(script), 'failed PowerShell helper must be kept for diagnosis');
+    const logText = fs.readFileSync(log, 'utf8');
+    assert.match(logText, /setup exit code 7/);
+    assert.match(logText, /update action exit code 1/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/dsh-desktop/test/client-updater-node-arg.test.mjs
+++ b/dsh-desktop/test/client-updater-node-arg.test.mjs
@@ -41,8 +41,7 @@ test('applyUpdate inlines the bundled node exe into the script body', () => {
   // 生产环境中 updates/ 由下载器创建（Setup 就躺在里面）；applyUpdate 只写文件不建目录
   fs.mkdirSync(path.join(dir, 'updates'), { recursive: true });
   const prevFile = process.env.PORTABLE_EXECUTABLE_FILE;
-  // oldExe 取 PORTABLE_EXECUTABLE_FILE → taskkill 只会打不存在的假名，
-  // 不会误杀正在跑测试的 node.exe（process.execPath 默认值的风险）。
+  // oldExe 取 PORTABLE_EXECUTABLE_FILE，便于断言安装版参数与脚本内容。
   process.env.PORTABLE_EXECUTABLE_FILE = path.join(dir, 'FakeOldApp.exe');
   try {
     const ctx = { userDataDir: dir, log() {} };
@@ -59,7 +58,12 @@ test('applyUpdate inlines the bundled node exe into the script body', () => {
     });
     assert.ok(recordedSpawns.length >= 1, 'spawn must have been called');
     const last = recordedSpawns[recordedSpawns.length - 1];
-    assert.equal(last.cmd, 'cmd.exe');
+    assert.equal(path.basename(last.cmd).toLowerCase(), 'powershell.exe');
+    assert.equal(last.args[last.args.indexOf('-WindowStyle') + 1], 'Hidden');
+    assert.equal(
+      last.args[last.args.indexOf('-ActionScriptPath') + 1],
+      path.join(dir, 'updates', 'apply-update.cmd')
+    );
     // 写盘的脚本必须内联 node 路径（% 转义 %%），且不得依赖 PATH node，
     // 也不得用 %~10 / shift 接参数（两条均已实测会坏）。
     const scriptText = fs.readFileSync(path.join(dir, 'updates', 'apply-update.cmd'), 'utf8');


### PR DESCRIPTION
## 修改内容

- 正式安装版改用隐藏 PowerShell，按当前 EAC 主进程 PID 有界等待
- 超时只结束指定 PID，不再使用 ping、find、tasklist 或 taskkill /T
- 保留 v4.4 的四目录备份、manifest、静默安装和失败回滚流程
- 成功后清理安装包与辅助脚本，失败时保留诊断文件并重启旧版

## 验证

- node scripts/check-syntax.js
- npm test：454/454 通过
- Windows 更新专项测试：15/15 通过