### PR TITLE
ci(linux): run package checks after linux branch pushes

### DIFF
--- a/.github/workflows/build-arch-pacman.yml
+++ b/.github/workflows/build-arch-pacman.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - linux
       - codex/arch-linux
     tags:
       - "v*"


### PR DESCRIPTION
## Summary\n- run the Linux packaging workflow after pushes to the maintained `linux` branch\n- retain existing `main` and legacy `codex/arch-linux` triggers\n\n## Why\nThe Linux release line is maintained on `linux`. Without this trigger, a merged Linux pull request does not receive the post-merge Linux CI run.\n\n## Verification\n- YAML parsed successfully with Ruby Psych\n- `git diff --check` passed\n\nThis is a workflow-only change; release assets remain generated by GitHub Actions, not local builds.