### PR TITLE
fix(linux): stabilize window and service startup recovery

### DIFF
--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -49,6 +49,7 @@ files:
   - shortcut-maintenance.js
   - profile-closure-extras.js
   - window-frame.js
+  - linux-update-guidance.js
   - preload.js
   - assets/**/*
   # 运行时脚本：koffi 预检探针（scripts/koffi-preflight.cjs）、会话删除补丁与

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -47,6 +47,8 @@ files:
   - renderer-recovery.js
   - watchdog.js
   - shortcut-maintenance.js
+  - profile-closure-extras.js
+  - window-frame.js
   - preload.js
   - assets/**/*
   # 运行时脚本：koffi 预检探针（scripts/koffi-preflight.cjs）、会话删除补丁与

--- a/dsh-desktop/linux-update-guidance.js
+++ b/dsh-desktop/linux-update-guidance.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const fs = require('node:fs');
+
+function parseOsRelease(text) {
+  const values = {};
+  for (const rawLine of String(text || '').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!match) continue;
+    let value = match[2].trim();
+    if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+      value = value.slice(1, -1);
+    } else if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\([\\"$`])/g, '$1');
+    }
+    values[match[1]] = value;
+  }
+  return values;
+}
+
+function distroTokens(info) {
+  return new Set(
+    [info.ID, ...(info.ID_LIKE || '').split(/\s+/)]
+      .map((value) => String(value || '').trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function hasAny(tokens, candidates) {
+  return candidates.some((candidate) => tokens.has(candidate));
+}
+
+function linuxUpdateGuidance(options = {}) {
+  const env = options.env || process.env;
+  const readFileSync = options.readFileSync || fs.readFileSync;
+  const osReleasePath = options.osReleasePath || '/etc/os-release';
+
+  if (env.APPIMAGE) {
+    return {
+      message: 'AppImage 版本需要手动替换。',
+      detail: '请下载新的 AppImage 文件，然后运行：\n\nchmod +x ./Deepseek-Harness-EAC-*.AppImage\n./Deepseek-Harness-EAC-*.AppImage',
+    };
+  }
+
+  let info = {};
+  try {
+    info = parseOsRelease(readFileSync(osReleasePath, 'utf8'));
+  } catch {}
+  const tokens = distroTokens(info);
+  const distroName = info.PRETTY_NAME || info.NAME || info.ID || '当前 Linux 发行版';
+
+  if (hasAny(tokens, ['ubuntu', 'debian', 'linuxmint', 'pop'])) {
+    return {
+      message: 'Linux 版本由 APT 软件包管理器更新。',
+      detail: `${distroName}\n\n请下载新的 .deb 包后运行：\n\nsudo apt install ./Deepseek-Harness-EAC-*.deb`,
+    };
+  }
+  if (hasAny(tokens, ['fedora', 'rhel', 'centos', 'rocky', 'almalinux'])) {
+    return {
+      message: 'Linux 版本由 DNF 软件包管理器更新。',
+      detail: `${distroName}\n\n请下载新的 .rpm 包后运行：\n\nsudo dnf install ./Deepseek-Harness-EAC-*.rpm`,
+    };
+  }
+  if (hasAny(tokens, ['opensuse', 'opensuse-leap', 'opensuse-tumbleweed', 'suse', 'sles'])) {
+    return {
+      message: 'Linux 版本由 Zypper 软件包管理器更新。',
+      detail: `${distroName}\n\n请下载新的 .rpm 包后运行：\n\nsudo zypper install ./Deepseek-Harness-EAC-*.rpm`,
+    };
+  }
+  if (hasAny(tokens, ['arch', 'manjaro', 'endeavouros', 'cachyos'])) {
+    return {
+      message: 'Linux 版本由 Pacman 软件包管理器更新。',
+      detail: `${distroName}\n\n请下载新的 .pacman 包后运行：\n\nsudo pacman -U ./Deepseek-Harness-EAC-*.pacman`,
+    };
+  }
+
+  return {
+    message: 'Linux 客户端需要通过安装包手动更新。',
+    detail: `${distroName}\n\n请选择发行版支持的 .deb、.rpm 或 .pacman 包；也可以下载 AppImage，赋予执行权限后直接运行。`,
+  };
+}
+
+module.exports = { parseOsRelease, linuxUpdateGuidance };

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -37,6 +37,7 @@ const { RendererRecovery } = require('./renderer-recovery');
 const { restrictedPortOf, chooseStableWebPort } = require('./stable-port');
 const { customFrameOptions } = require('./window-frame');
 const { ensureProfileClosureExtras } = require('./profile-closure-extras');
+const { linuxUpdateGuidance } = require('./linux-update-guidance');
 const {
   STANDARD_SHORTCUT_NAME,
   RUNTIME_SHORTCUT_DESCRIPTION,
@@ -906,10 +907,14 @@ function watchServerProc(proc, out, opts = {}) {
       // 原地重启（插件市场）或已替换为新进程时，不打扰用户、也不清掉新进程的句柄。
       const intentional = restartingServer || serverProc !== proc;
       if (serverProc === proc) serverProc = null;
+      const wasServing = Boolean(webUrl);
+      if (!intentional && !handedOff) webUrl = null;
       if (!handedOff) {
         finish(reject, new Error(`dsh web 启动失败（退出码 ${code}）。日志: ${path.join(logsDir, 'dsh-web.log')}`));
       }
-      if (!quitting && !intentional && !handedOff && webUrl && mainWindow && !mainWindow.isDestroyed()) {
+      if (!quitting && !intentional && !handedOff && wasServing && mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.loadFile(path.join(__dirname, 'assets', 'loading.html'))
+          .catch((err) => log('boot', '服务退出后加载本地等待页失败: ' + err.message));
         const detail = buildErrorDetail(new Error(`dsh web 进程退出（code=${code} signal=${signal}）`), logsDir, ['dsh-web.log']);
         showBox({
           type: 'error',
@@ -961,6 +966,10 @@ function waitUntilUp(url, timeoutMs = 120000) {
 }
 
 function startAndShow(overlays = []) {
+  if (quitting) return Promise.reject(new Error('应用正在退出'));
+  // 新一轮启动期间旧地址已经不可依赖。先清空，避免启动失败后 exit 处理器
+  // 同时弹出“服务已停止”，也避免恢复逻辑继续请求失效端口。
+  webUrl = null;
   // koffi 预检失败注入的目录选择器降级 overlay 一并交给 dsh web（--patch）。
   const merged = [];
   if (pickerBrowseOverlay && fs.existsSync(pickerBrowseOverlay)) merged.push(pickerBrowseOverlay);
@@ -970,11 +979,16 @@ function startAndShow(overlays = []) {
   return startServer(4, merged)
     .then(waitUntilUp)
     .then((url) => {
-      webUrl = url;
       log('boot', 'Web UI 就绪: ' + url);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        return mainWindow.loadURL(url).then(() => url);
+        // 只有页面真正加载成功后才标记为 serving。若服务在 loadURL 期间
+        // 退出，应只走启动失败链路，不能再并发弹“服务已停止”。
+        return mainWindow.loadURL(url).then(() => {
+          webUrl = url;
+          return url;
+        });
       }
+      webUrl = url;
       return url;
     });
 }
@@ -1203,7 +1217,9 @@ function handleBootFailure(err) {
 // 互相干扰；网络失败不打扰（runClientUpdateFlow 的 manual 弹窗已够）。
 let clientUpdateRescueArmed = false;
 function scheduleClientUpdateRescue() {
-  if (clientUpdateRescueArmed || process.env.DSH_DESKTOP_SKIP_CLIENT_UPDATE) return;
+  // Linux 包由 apt/dnf/pacman/zypper 或 AppImage 文件管理，无法在应用内
+  // 自动更新。启动失败时再弹一次安装说明只会遮住真正的错误对话框。
+  if (!IS_WIN || clientUpdateRescueArmed || process.env.DSH_DESKTOP_SKIP_CLIENT_UPDATE) return;
   clientUpdateRescueArmed = true;
   setTimeout(() => {
     runClientUpdateFlow(true).catch((e) => log('client-update', '救援检查失败: ' + e.message));
@@ -4251,11 +4267,12 @@ async function runClientUpdateFlow(manual) {
   if (quitting) return;
   if (!IS_WIN) {
     if (manual) {
+      const guidance = linuxUpdateGuidance();
       await showBox({
         type: 'info',
         title: '客户端更新',
-        message: 'Linux 版本由系统包管理器更新。',
-        detail: 'Arch Linux 请下载新的 .pacman 包后运行：\n\nsudo pacman -U ./Deepseek-Harness-EAC-*.pacman',
+        message: guidance.message,
+        detail: guidance.detail,
         buttons: ['确定'],
       });
     }
@@ -4675,7 +4692,9 @@ async function boot() {
         setInterval(() => runPluginUpdateCheck(false), 6 * 3600 * 1000).unref();
       }
     })
-    .catch((err) => handleBootFailure(err));
+    .catch((err) => {
+      if (!quitting) handleBootFailure(err);
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -35,6 +35,8 @@ const { createGuard } = require('./plugin-guard');
 const bundleIntegrity = require('./bundle-integrity');
 const { RendererRecovery } = require('./renderer-recovery');
 const { restrictedPortOf, chooseStableWebPort } = require('./stable-port');
+const { customFrameOptions } = require('./window-frame');
+const { ensureProfileClosureExtras } = require('./profile-closure-extras');
 const {
   STANDARD_SHORTCUT_NAME,
   RUNTIME_SHORTCUT_DESCRIPTION,
@@ -1262,8 +1264,8 @@ function createWindow({ startHidden = false } = {}) {
     title: 'Deepseek Harness EAC',
     backgroundColor: '#0b1220',
     icon: path.join(__dirname, 'assets', 'icon.png'),
-    // 风格化无边框窗口：去掉原生标题栏/菜单栏，自绘玻璃栏 + Win11 原生圆角。
-    ...(IS_WIN ? { frame: false, roundedCorners: true } : {}),
+    // Windows / Linux 使用自绘栏；macOS 保留原生窗口框架与菜单栏。
+    ...customFrameOptions(),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -1402,7 +1404,7 @@ function createFloatWindow(sessionId, { title } = {}) {
     backgroundColor: '#0b1220',
     icon: path.join(__dirname, 'assets', 'icon.png'),
     // 与主窗一致的无边框；浮窗 preload 注入一条更细的纯拖拽条。
-    ...(IS_WIN ? { frame: false, roundedCorners: true } : {}),
+    ...customFrameOptions(),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -1515,7 +1517,7 @@ function openPluginWizard({ mode = 'first' } = {}) {
       title: '内置插件选择向导',
       backgroundColor: '#0b1220',
       icon: path.join(__dirname, 'assets', 'icon.png'),
-      ...(IS_WIN ? { frame: false, roundedCorners: true } : {}),
+      ...customFrameOptions(),
       webPreferences: {
         preload: path.join(__dirname, 'assets', 'onboarding-preload.js'),
         contextIsolation: true,
@@ -3631,6 +3633,13 @@ function syncCompanionPlugins() {
     const home = dshHomePath();
     // 桌面专属 profile 必须先存在（未知 profile 不会被 dsh 自动初始化）。
     ensureDesktopProfileInit();
+    const extras = ensureProfileClosureExtras(
+      home,
+      path.join(__dirname, 'node_modules'),
+      ['schemastery'],
+      (message) => log('boot', message)
+    );
+    if (extras.linked.length) log('boot', '已补齐 profile 安装闭包依赖: ' + extras.linked.join(', '));
     // V4 运行时补丁（幂等，随启动 / 服务重启 / agent 更新后重放）：
     //  · 对话删除/归档 —— dsh-session-manager 插件的全链路前置依赖；
     applySessionManageFix();

--- a/dsh-desktop/profile-closure-extras.js
+++ b/dsh-desktop/profile-closure-extras.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function packageDir(root, name) {
+  return path.join(root, ...String(name).split('/'));
+}
+
+function healthyPackage(dir) {
+  try {
+    return fs.statSync(path.join(dir, 'package.json')).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// dsh-app-boot builds <DSH_HOME>/profiles/node_modules from the dependency
+// closure rooted at @deepseek-ai/dsh. App-level companion dependencies are
+// outside that closure during source runs, so expose the small explicit set
+// required by copied profile plugins before dsh starts.
+function ensureProfileClosureExtras(home, appModulesDir, names, log = () => {}) {
+  const fallbackRoot = path.join(home, 'profiles', 'node_modules');
+  const linked = [];
+  const unavailable = [];
+
+  for (const name of names || []) {
+    const source = packageDir(appModulesDir, name);
+    if (!healthyPackage(source)) {
+      unavailable.push(name);
+      log(`profile closure extra unavailable: ${name}`);
+      continue;
+    }
+
+    const destination = packageDir(fallbackRoot, name);
+    if (healthyPackage(destination)) continue;
+
+    try {
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      try {
+        const stat = fs.lstatSync(destination);
+        if (stat.isSymbolicLink()) fs.unlinkSync(destination);
+        else fs.rmSync(destination, { recursive: true, force: true });
+      } catch {}
+      fs.symlinkSync(source, destination, process.platform === 'win32' ? 'junction' : 'dir');
+      linked.push(name);
+      log(`profile closure extra linked: ${name}`);
+    } catch (err) {
+      unavailable.push(name);
+      log(`profile closure extra failed (${name}): ${err.message}`);
+    }
+  }
+
+  return { linked, unavailable };
+}
+
+module.exports = { ensureProfileClosureExtras };

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -25,6 +25,8 @@ const entryFiles = [
   'renderer-recovery.js',
   'watchdog.js',
   'shortcut-maintenance.js',
+  'profile-closure-extras.js',
+  'window-frame.js',
   'stable-port.js',
   'koffi-preflight.js',
   'profile-module-heal.js',

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -27,6 +27,7 @@ const entryFiles = [
   'shortcut-maintenance.js',
   'profile-closure-extras.js',
   'window-frame.js',
+  'linux-update-guidance.js',
   'stable-port.js',
   'koffi-preflight.js',
   'profile-module-heal.js',

--- a/dsh-desktop/test/linux-startup-recovery-wiring.test.mjs
+++ b/dsh-desktop/test/linux-startup-recovery-wiring.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
+const mainSrc = readFileSync(join(ROOT, 'main.js'), 'utf8');
+
+test('Linux 启动失败不触发自动客户端更新弹窗', () => {
+  assert.match(
+    mainSrc,
+    /function scheduleClientUpdateRescue\(\) \{[\s\S]*?if \(!IS_WIN \|\|/,
+    'Linux rescue must return before scheduling runClientUpdateFlow(true)',
+  );
+});
+
+test('每轮服务启动前清空旧 webUrl', () => {
+  const start = mainSrc.indexOf('function startAndShow(overlays = []) {');
+  const launch = mainSrc.indexOf('return startServer(4, merged)', start);
+  const clear = mainSrc.indexOf('webUrl = null;', start);
+  assert.ok(start >= 0 && clear > start && clear < launch, 'startAndShow must clear webUrl before startServer');
+});
+
+test('页面加载成功后才把服务标记为 serving，避免启动/退出双弹窗', () => {
+  assert.match(
+    mainSrc,
+    /return mainWindow\.loadURL\(url\)\.then\(\(\) => \{\s*webUrl = url;\s*return url;/,
+  );
+  assert.doesNotMatch(
+    mainSrc,
+    /\.then\(\(url\) => \{\s*webUrl = url;\s*log\('boot', 'Web UI 就绪:/,
+  );
+});
+
+test('应用退出期间禁止启动新服务和启动失败恢复', () => {
+  assert.match(
+    mainSrc,
+    /function startAndShow\(overlays = \[\]\) \{\s*if \(quitting\) return Promise\.reject/,
+  );
+  assert.match(
+    mainSrc,
+    /\.catch\(\(err\) => \{\s*if \(!quitting\) handleBootFailure\(err\);\s*\}\);\s*\}\s*\/\/ -+\s*\/\/ App lifecycle/,
+  );
+});
+
+test('服务意外退出后清空地址并加载本地等待页', () => {
+  assert.match(mainSrc, /const wasServing = Boolean\(webUrl\);\s*if \(!intentional && !handedOff\) webUrl = null;/);
+  assert.match(
+    mainSrc,
+    /if \(!quitting && !intentional && !handedOff && wasServing[\s\S]*?mainWindow\.loadFile\(path\.join\(__dirname, 'assets', 'loading\.html'\)\)/,
+  );
+});

--- a/dsh-desktop/test/linux-update-guidance.test.mjs
+++ b/dsh-desktop/test/linux-update-guidance.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { parseOsRelease, linuxUpdateGuidance } = require('../linux-update-guidance.js');
+
+function guidance(osRelease, env = {}) {
+  return linuxUpdateGuidance({ env, readFileSync: () => osRelease });
+}
+
+test('解析 os-release 的引号和 ID_LIKE', () => {
+  assert.deepEqual(parseOsRelease('ID=ubuntu\nPRETTY_NAME="Ubuntu 26.04 LTS"\nID_LIKE="debian"\n'), {
+    ID: 'ubuntu', PRETTY_NAME: 'Ubuntu 26.04 LTS', ID_LIKE: 'debian',
+  });
+});
+
+test('Ubuntu 和 Debian 系显示 apt + deb，不再显示 pacman', () => {
+  const result = guidance('ID=ubuntu\nPRETTY_NAME="Ubuntu 26.04 LTS"\nID_LIKE=debian\n');
+  assert.match(result.detail, /Ubuntu 26\.04 LTS/);
+  assert.match(result.detail, /sudo apt install .*\.deb/);
+  assert.doesNotMatch(result.detail, /pacman/);
+});
+
+test('Fedora/RHEL 系显示 dnf + rpm', () => {
+  const result = guidance('ID=rocky\nPRETTY_NAME="Rocky Linux 10"\nID_LIKE="rhel centos fedora"\n');
+  assert.match(result.detail, /sudo dnf install .*\.rpm/);
+});
+
+test('openSUSE 显示 zypper + rpm', () => {
+  assert.match(guidance('ID="opensuse-tumbleweed"\n').detail, /sudo zypper install .*\.rpm/);
+});
+
+test('Arch 系显示 pacman 包命令', () => {
+  assert.match(guidance('ID=manjaro\nID_LIKE=arch\n').detail, /sudo pacman -U .*\.pacman/);
+});
+
+test('AppImage 环境优先显示替换和执行说明', () => {
+  const result = guidance('ID=ubuntu\n', { APPIMAGE: '/opt/Deepseek.AppImage' });
+  assert.match(result.message, /AppImage/);
+  assert.match(result.detail, /chmod \+x/);
+});
+
+test('未知发行版和缺失 os-release 时提供通用安装包说明', () => {
+  assert.match(guidance('ID=gentoo\nPRETTY_NAME=Gentoo\n').detail, /\.deb、\.rpm 或 \.pacman/);
+  const missing = linuxUpdateGuidance({ env: {}, readFileSync: () => { throw new Error('missing'); } });
+  assert.match(missing.detail, /AppImage/);
+});

--- a/dsh-desktop/test/profile-closure-extras.test.mjs
+++ b/dsh-desktop/test/profile-closure-extras.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { ensureProfileClosureExtras } = require('../profile-closure-extras.js');
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-profile-extra-'));
+  const home = join(root, 'home');
+  const modules = join(root, 'app', 'node_modules');
+  mkdirSync(join(modules, 'schemastery'), { recursive: true });
+  writeFileSync(join(modules, 'schemastery', 'package.json'), JSON.stringify({ name: 'schemastery' }));
+  return { root, home, modules };
+}
+
+test('links app-level dependencies into the profile fallback closure', () => {
+  const f = fixture();
+  try {
+    const result = ensureProfileClosureExtras(f.home, f.modules, ['schemastery']);
+    const link = join(f.home, 'profiles', 'node_modules', 'schemastery');
+    assert.deepEqual(result, { linked: ['schemastery'], unavailable: [] });
+    assert.equal(lstatSync(link).isSymbolicLink(), true);
+    assert.equal(existsSync(join(link, 'package.json')), true);
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('is idempotent and preserves an existing healthy fallback package', () => {
+  const f = fixture();
+  try {
+    ensureProfileClosureExtras(f.home, f.modules, ['schemastery']);
+    const second = ensureProfileClosureExtras(f.home, f.modules, ['schemastery']);
+    assert.deepEqual(second, { linked: [], unavailable: [] });
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
+test('reports a missing app dependency without creating a dangling link', () => {
+  const f = fixture();
+  try {
+    const result = ensureProfileClosureExtras(f.home, f.modules, ['missing-package']);
+    assert.deepEqual(result, { linked: [], unavailable: ['missing-package'] });
+    assert.equal(existsSync(join(f.home, 'profiles', 'node_modules', 'missing-package')), false);
+  } finally {
+    rmSync(f.root, { recursive: true, force: true });
+  }
+});

--- a/dsh-desktop/test/window-frame.test.mjs
+++ b/dsh-desktop/test/window-frame.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const { customFrameOptions } = require('../window-frame.js');
+
+test('Windows and Linux use the custom frameless chrome', () => {
+  assert.deepEqual(customFrameOptions('win32'), {
+    frame: false,
+    roundedCorners: true,
+  });
+  assert.deepEqual(customFrameOptions('linux'), { frame: false });
+});
+
+test('macOS keeps its native frame and application menu', () => {
+  assert.deepEqual(customFrameOptions('darwin'), {});
+});
+
+test('all custom-chrome BrowserWindows share the platform frame policy', () => {
+  const main = readFileSync(join(root, 'main.js'), 'utf8');
+  for (const functionName of ['createWindow', 'createFloatWindow', 'openPluginWizard']) {
+    const start = main.indexOf(`function ${functionName}`);
+    assert.ok(start >= 0, `${functionName} must exist`);
+    const windowOptions = main.slice(start, start + 1600);
+    assert.match(
+      windowOptions,
+      /new BrowserWindow\s*\([\s\S]*?\.\.\.customFrameOptions\(\)/,
+      `${functionName} must use the shared custom frame policy`,
+    );
+  }
+});
+
+test('the updater modal keeps native window controls', () => {
+  const main = readFileSync(join(root, 'main.js'), 'utf8');
+  const start = main.indexOf('function showUpdateWindow');
+  assert.ok(start >= 0, 'showUpdateWindow must exist');
+  const windowOptions = main.slice(start, start + 700);
+  assert.doesNotMatch(windowOptions, /customFrameOptions/);
+});

--- a/dsh-desktop/window-frame.js
+++ b/dsh-desktop/window-frame.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function customFrameOptions(platform = process.platform) {
+  if (platform === 'win32') {
+    return { frame: false, roundedCorners: true };
+  }
+  if (platform === 'linux') {
+    return { frame: false };
+  }
+  return {};
+}
+
+module.exports = { customFrameOptions };


### PR DESCRIPTION
## Summary

- use the existing custom Electron chrome on Linux so KDE and GNOME no longer show duplicate native/custom title bars
- expose app-level schemastery in the profile fallback closure so copied plugins start correctly with a clean DSH_HOME
- clear stale service URLs and show the local loading page when dsh exits, avoiding Chromium ERR_CONNECTION_REFUSED
- keep startup failures and runtime service exits on separate dialog paths, and suppress automatic Linux update prompts during boot failure
- show distro-aware manual update commands for Ubuntu/Debian, Fedora/RHEL, openSUSE, Arch derivatives, AppImage, and unknown distributions
- prevent shutdown-time recovery from spawning orphan dsh processes

## Verification

- npm test: 517 passed, 5 Windows-only skipped, 0 failed (522 total)
- npm run predist: passed
- npm run pack: passed, including node-pty load and GLIBC_2.34 baseline audit
- clean linux-unpacked launch: Web UI HTTP 200
- clean shutdown: dsh exit code 0, cleanup completed in 202ms, no test child-process leftovers
- native Wayland visual check: one custom title bar, no compositor-provided duplicate frame
- git diff --check: passed