### PR TITLE
fix(tdai)：tdai缺少 BM25 依赖时降级处理，避免客户端启动崩溃

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-tdai-memory/vendor/tdai/core/store/bm25-local.js
+++ b/dsh-desktop/assets/plugins/dsh-tdai-memory/vendor/tdai/core/store/bm25-local.js
@@ -8,7 +8,16 @@
  * - `encodeTexts(texts)` — encode documents for upsert (TF-based)
  * - `encodeQueries(texts)` — encode queries for search (IDF-based)
  */
-import { BM25Encoder } from "@tencentdb-agent-memory/tcvdb-text";
+// BM25 is an optional acceleration layer. Keep a missing/incomplete bundled
+// package from preventing the whole memory plugin from loading.
+let BM25Encoder;
+let bm25LoadError;
+try {
+    ({ BM25Encoder } = await import("@tencentdb-agent-memory/tcvdb-text"));
+}
+catch (error) {
+    bm25LoadError = error;
+}
 const TAG = "[memory-tdai][bm25-local]";
 // ============================
 // Implementation
@@ -62,6 +71,10 @@ export class BM25LocalEncoder {
 export function createBM25Encoder(config, logger) {
     if (!config.enabled) {
         logger?.debug?.(`${TAG} BM25 sparse encoding disabled`);
+        return undefined;
+    }
+    if (!BM25Encoder) {
+        logger?.warn?.(`${TAG} BM25 unavailable; continuing without sparse encoding: ${bm25LoadError instanceof Error ? bm25LoadError.message : String(bm25LoadError)}`);
         return undefined;
     }
     return new BM25LocalEncoder(config.language ?? "zh", logger);


### PR DESCRIPTION
## 问题说明

当 `@tencentdb-agent-memory/tcvdb-text` 包缺少
`dist/index.js` 编译入口时，`dsh-tdai-memory` 会在静态加载阶段抛出
`ERR_MODULE_NOT_FOUND`。

该异常会导致 Cordis 插件树初始化失败，最终使桌面客户端启动进程以退出码
1 结束并发生崩溃。

## 修复内容

对 BM25 编码器加载增加容错处理：

- 依赖完整时，继续使用原有 BM25 功能；
- 依赖包缺失或编译入口缺失时，仅关闭本地 BM25 稀疏编码；
- `tdai-memory` 插件继续加载；
- 通过日志输出警告，便于后续排查和补齐依赖。

## 修改范围

- 不修改安装器逻辑；
- 不修改更新逻辑；
- 不修改卸载逻辑；
- 不修改依赖树；
- 不新增大型构建产物；
- 不影响依赖完整时的原有行为。

## 验证结果

- `bm25-local.js` 语法检查通过；
- 缺少 `tcvdb-text/dist/index.js` 时不再抛出启动级异常；
- BM25 能够自动降级为关闭状态；
- 当前修改仅涉及 `bm25-local.js` 一个文件。

## 后续建议

该修复用于避免客户端因可选 BM25 组件缺失而整体崩溃。后续仍建议在正式
发布流程中补齐 `@tencentdb-agent-memory/tcvdb-text/dist/` 编译产物，并在
构建阶段增加入口文件完整性检查。