### PR TITLE
fix: AI 自动修复链路加固（非流式/模型可配/max_tokens）+ 演示与 e2e 修复

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -14,7 +14,45 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 影响治理 + 内置接管同名市场包）→
 4.3.0（本版：内置插件更新 + 插件市场「更新」标签 + 市场插件更新）→
 4.4.0（本版：修复设置页「Skills 与 MCP → 打开目录」失效 + 安装版更新
-4 目录备份/回滚 + 结构化日志 + 插件自写 patch 行保护）。
+4 目录备份/回滚 + 结构化日志 + 插件自写 patch 行保护）→
+4.6.0（本版：AI 主动修复 —— 救援页一键自动诊断、自动执行修复、自动重启）→
+
+## [4.6.0] · 2026-08-20
+
+### 新增：AI 主动修复（一键全自动）
+- 救援页新增「AI 自动修复」按钮：一键串联 诊断 → AI 分析 → 自动执行修复 →
+  自动重启 全链路，最多迭代两轮；高风险动作（回滚/卸载）自动跳过，多轮
+  修复后仍无法启动则自动兜底（回滚最后良好快照 + 开启安全模式），过程
+  逐轮展示在救援页。
+- AI 可直接编辑白名单配置文件修复根因（`edit-file`）：仅限
+  `settings.yaml` 与 profile 的 `package.json`、`pnpm-lock.yaml`、
+  `pnpm-workspace.yaml`、`cordis.patch.yml`、`.dsh-builtin-plugins.json`，
+  支持最小化行级编辑（replace-line / delete-line / insert-after）与整文件
+  重建；写前快照备份、写后强制校验 YAML/JSON 可解析，非法内容绝不落盘。
+- 新增 `resync` 动作：一键重装/修复 profile 模块树（内置插件树同步 +
+  模块遮蔽清理）。
+- 诊断上下文新增全局 `settings.yaml`（快照与规则体检都不覆盖的配置面，
+  AI 主动修复的主要作战对象），纳入发送清单可选勾选。
+- 验证：`test/rescue-auto-repair.test.mjs`（自动修复循环）、
+  `test/rescue-agent.test.mjs`（编辑白名单/行级编辑/可解析校验）、
+  `test/rescue-integration.test.mjs`（IPC/桥接/救援页接线）覆盖。
+
+4.5.0（本版：崩溃救援模式 + 内置识图引擎更换为 picturereader）。
+
+## [4.5.0] — 2026-08-20
+
+### 新增：崩溃救援模式（日志/快照/安全模式/AI 诊断修复）
+- 启动失败不再束手无策：自动收集诊断包（日志尾部 / 事故报告 / profile 快照 /
+  插件清单），一键进入安全模式（禁用问题插件后再启动），并提供 AI 诊断修复
+  建议；完整视图可逐项查看与修复，事故现场全程留痕。
+- 验证：`test/rescue-agent.test.mjs`、`test/rescue-integration.test.mjs` 覆盖
+  诊断收集、安全模式降级、修复链路与看门狗集成。
+
+### 更换：内置识图引擎（dsh-tool-vision → picturereader）
+- 原内置 `dsh-tool-vision` 由社区成熟插件 `picturereader` 接管（PR #105）：
+  保留 `inspect_image` 工具语义，能力扩展为图片批量处理、文档转图、视觉问答，
+  并提供独立的视觉模型设置入口。
+- 配套测试：`tool-vision-stream-guard` 相应迁移至 picturereader 链路。
 
 ## [4.4.1] — 2026-08-20
 

--- a/dsh-desktop/assets/recovery.html
+++ b/dsh-desktop/assets/recovery.html
@@ -137,6 +137,12 @@
     <h2>AI 诊断与修复</h2>
     <div class="row"><span class="tag" id="ai-tag">—</span><span class="muted" id="ai-note"></span></div>
     <div class="hr"></div>
+    <div class="row" style="margin:10px 0 4px 0">
+      <button class="primary" id="btn-autorepair" type="button">AI 自动修复</button>
+      <span class="muted">一键全自动：诊断 → 自动执行低/中风险修复 → 自动重启；高风险动作自动跳过，多轮失败自动回滚并进入安全模式。诊断内容按上方清单全量发送。</span>
+    </div>
+    <pre class="details" id="auto-progress" style="text-align:left;margin-top:8px;white-space:pre-wrap"></pre>
+    <div class="hr"></div>
     <div id="ai-confirm" hidden>
       <p class="hint">发送给 AI 前请确认内容清单（取消勾选 = 不发送，版本环境始终保留）：</p>
       <div class="list" id="manifest" style="max-height:180px;margin:10px 0"></div>
@@ -186,7 +192,7 @@
 
       function setAiBusy(on) {
         busy = on;
-        ['btn-prepare', 'btn-diagnose', 'btn-apply', 'btn-retry', 'btn-safemode', 'btn-export', 'reload', 'restart'].forEach(function (id) {
+        ['btn-prepare', 'btn-diagnose', 'btn-apply', 'btn-retry', 'btn-safemode', 'btn-export', 'btn-autorepair', 'reload', 'restart'].forEach(function (id) {
           var b = $(id); if (b) b.disabled = on;
         });
       }
@@ -232,6 +238,8 @@
         var btn = $('btn-safemode');
         if (s.safeMode) { btn.textContent = '退出安全模式并恢复'; btn.className = 'danger'; }
         else { btn.textContent = '开启安全模式（只留核心插件）'; btn.className = ''; }
+        var ar = $('btn-autorepair');
+        if (ar) ar.disabled = !s.aiReady;
       }
 
       function renderAttribution() {
@@ -438,6 +446,43 @@
         });
       }
 
+      function runAutoRepair() {
+        var box = $('auto-progress');
+        box.textContent = 'AI 自动修复开始：收集诊断上下文 → AI 分析 → 自动执行低/中风险修复 → 自动重启服务（最多两轮）…';
+        setAiBusy(true);
+        setStatus('AI 自动修复进行中…');
+        bridge.rescue.autoRepair().then(function (r) {
+          setAiBusy(false);
+          if (!r) throw new Error('无响应');
+          var lines = [];
+          var rounds = (r && r.rounds) || [];
+          rounds.forEach(function (round) {
+            lines.push('— 第 ' + (round.round + 1) + ' 轮 —');
+            if (round.analysis) lines.push('分析: ' + round.analysis);
+            (round.applied || []).forEach(function (a) {
+              if (a.skipped) lines.push('  跳过（高风险）: ' + (a.action || '?'));
+              else if (a.ok) lines.push('  ✓ ' + (a.action || '?') + '：' + (a.result || '成功'));
+              else lines.push('  ✗ ' + (a.action || '?') + '：' + ((a.error && String(a.error)) || '失败'));
+            });
+            if (typeof round.retryOk === 'boolean') {
+              lines.push(round.retryOk ? '  ✓ 服务已重启成功' : '  ✗ 重启仍未成功');
+            }
+          });
+          if (!r.ok) {
+            lines.push('自动修复未成功：' + ((r.error && String(r.error)) || '未知原因'));
+            if (r.fallback && r.fallback.result) lines.push('兜底: ' + r.fallback.result);
+            lines.push('仍可手动尝试上方「重新启动 Web 服务」或「快照回滚」。');
+          }
+          box.textContent = lines.join('\n');
+          setStatus(r.ok ? 'AI 自动修复完成：服务已恢复正常。' : 'AI 自动修复未完成，请查看下方过程或手动操作。');
+          loadState();
+        }).catch(function (e) {
+          setAiBusy(false);
+          box.textContent = 'AI 自动修复失败：' + String(e && e.message || e);
+          showError(String(e && e.message || e));
+        });
+      }
+
       function init() {
         if (!bridge || !bridge.recovery || !bridge.rescue) {
           setStatus('无法连接桌面客户端桥接，请重启客户端。');
@@ -496,6 +541,7 @@
           $('btn-prepare').hidden = false;
         });
         $('btn-apply').addEventListener('click', applySelected);
+        $('btn-autorepair').addEventListener('click', runAutoRepair);
         loadState();
       }
 

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -1105,6 +1105,36 @@ async function rescueExecuteSuggestion(s) {
       const applied = (r && r.applied) || [];
       return { ok: true, result: applied.length ? '已应用修复: ' + applied.join('；') : '体检未发现可修复项' };
     }
+    case 'edit-file': {
+      // AI 主动修复：白名单文件结构化编辑。写前快照（ai-edit-before），
+      // rescue-agent 校验目标与可解析性后原子落盘，失败不动原文件。
+      const snap = g.snapshot('ai-edit-before');
+      const ctx = {
+        home: dshHome || path.join(os.homedir(), '.dsh'),
+        profileDir: desktopProfileDir(),
+        readFile: (f) => { try { return fs.readFileSync(f, 'utf8'); } catch { return null; } },
+        writeFile: (f, text) => { fs.writeFileSync(f, text, 'utf8'); },
+        backup: (f) => { try { fs.copyFileSync(f, f + '.ai-bak'); } catch {} },
+      };
+      const r = rescueAgent.applyProfileEdit(s.params, ctx);
+      if (!r.ok) return { ok: false, error: r.error };
+      return { ok: true, result: `已编辑 ${r.file}（${r.opsApplied} 处改动）`, restartRequired: true, snapshotId: snap && snap.id };
+    }
+    case 'resync': {
+      // 重装/修复 profile 模块树：补齐内置插件依赖与补丁（syncCompanionPlugins）
+      // 后修模块遮蔽（healProfileModules）。两者幂等；需服务停止时执行。
+      if (serverProc && serverProc.exitCode === null && !serverProc.killed && !restartingServer) {
+        return { ok: false, error: 'service-running', hint: '请先重启服务（模块树重装需在重启间隙执行）' };
+      }
+      const notes = [];
+      try { syncCompanionPlugins(); notes.push('内置插件树已同步'); } catch (err) {
+        return { ok: false, error: '内置插件同步失败: ' + String((err && err.message) || err) };
+      }
+      try { healProfileModules(); notes.push('模块遮蔽已清理'); } catch (err) {
+        return { ok: false, error: '模块树修复失败: ' + String((err && err.message) || err) };
+      }
+      return { ok: true, result: notes.join('；'), restartRequired: true };
+    }
     case 'safe-mode': {
       const r = safeModeSet(s.params.on);
       return r.ok
@@ -1255,93 +1285,98 @@ function handleBootFailure(err) {
     return;
   }
   const ov = updater.overlayBinPath(updCtx());
-  if (ov && fs.existsSync(ov)) {
-    // V4.1 更新保障②：上次更新保留的上一版本备份可用时，优先提供
-    // 「回退到上一版本」（比退回内置版更贴近用户原状态）。
-    const prev = updater.previousAgentInfo(updCtx());
-    // V4.2 插件即时提醒：报错文案归因到 profile 里的插件时，提供
-    // 「停用插件 X 并重试」（写盘停用，重启不还原）；另有最后良好快照时
-    // 提供「回滚到最后良好快照并重试」。两项都失败才轮到版本级回退。
-    // V4.4：第一按钮永远是「进入救援模式」（完整查看/修复/AI 诊断）。
-    let blame = null;
-    let blameRow = null;
-    try {
-      const g = ensureGuard();
-      if (typeof g.attributeBootFailure === 'function') {
-        blame = g.attributeBootFailure(String((err && err.message) || err));
-      }
-      if (blame) {
-        try {
-          blameRow = pluginManagerCollect().find((r) => r.id === blame.rowId) || null;
-        } catch { blameRow = null; }
-      }
-    } catch {}
-    const lastGood = (() => { try { return ensureGuard().lastGoodSnapshot(); } catch { return null; } })();
-    const btnDisable = blameRow && blameRow.toggleable ? '停用插件 ' + blameRow.name + ' 并重试' : null;
-    const btnRollback = lastGood ? '回滚到最后良好快照并重试' : null;
-    const buttons = [
-      '进入救援模式',
-      ...(btnDisable ? [btnDisable] : []),
-      ...(btnRollback ? [btnRollback] : []),
-      ...(prev ? ['回退到上一版本并重试', '回退到内置版本', '重试', '退出'] : ['回退到内置版本并重试', '重试', '退出']),
-    ];
-    const detailLines = [String((err && err.message) || err)];
+  const hasOverlay = !!(ov && fs.existsSync(ov));
+  // V4.1 更新保障②：上次更新保留的上一版本备份可用时，优先提供
+  // 「回退到上一版本」（比退回内置版更贴近用户原状态）。
+  const prev = hasOverlay ? updater.previousAgentInfo(updCtx()) : null;
+  // V4.2 插件即时提醒：报错文案归因到 profile 里的插件时，提供
+  // 「停用插件 X 并重试」（写盘停用，重启不还原）；另有最后良好快照时
+  // 提供「回滚到最后良好快照并重试」。两项都失败才轮到版本级回退。
+  // V4.4：第一按钮永远是「进入救援模式」（完整查看/修复/AI 诊断）——
+  // 无上一版本备份（普通崩溃/坏插件）时同样弹此对话框，不再裸弹 fatal。
+  let blame = null;
+  let blameRow = null;
+  try {
+    const g = ensureGuard();
+    if (typeof g.attributeBootFailure === 'function') {
+      blame = g.attributeBootFailure(String((err && err.message) || err));
+    }
     if (blame) {
-      detailLines.push('', `报错指向插件「${blame.name}」（${blame.kind === 'patchRow' ? 'patch 行 ' + blame.rowId : blame.kind}），可先停用该插件后重试。`);
+      try {
+        blameRow = pluginManagerCollect().find((r) => r.id === blame.rowId) || null;
+      } catch { blameRow = null; }
     }
-    if (lastGood) {
-      detailLines.push(`存在最后良好快照（${lastGood.reason || lastGood.id}），可一键回滚后重试。`);
-    }
-    if (prev) detailLines.push('', `可回退到上一版本（v${prev.version}）或内置版本继续使用。`);
-    else detailLines.push('', '可回退到内置版本继续使用。');
-    detailLines.push('', '也可进入救援模式：查看日志/快照/事故报告，或让 AI 诊断后按建议修复。');
-    showBox({
-      type: 'error',
-      title: 'DeepSeek Harness 启动失败',
-      message: prev ? '更新后的 agent 无法启动。' : 'DeepSeek Harness 无法启动。',
-      detail: detailLines.join('\n'),
-      buttons,
-      defaultId: 0,
-      cancelId: buttons.length - 1,
-    }).then(({ response }) => {
-      let i = 0;
-      const take = () => i++;
-      // 第一按钮：进入救援模式（完整修复能力 + AI 诊断）。
-      if (response === take()) {
-        showRescuePage();
-        return;
-      }
-      // 归因到插件时，优先给「停用插件」——
-      if (btnDisable && response === take()) {
-        try {
-          pluginManagerSetEnabled(blameRow.id, false);
-          log('plugin-manager', `启动失败后停用插件: ${blameRow.id}`);
-        } catch (e2) { log('plugin-manager', '停用插件失败: ' + ((e2 && e2.message) || e2)); }
-        startAndShow().catch((e2) => handleBootFailure(e2));
-        return;
-      }
-      if (btnRollback && response === take()) {
-        try {
-          ensureGuard().restore(lastGood.id);
-        } catch (e2) { log('guard', '回滚快照失败: ' + ((e2 && e2.message) || e2)); }
-        startAndShow().catch((e2) => handleBootFailure(e2));
-        return;
-      }
-      if (prev && response === take()) {
-        updater.rollbackToPrevious(updCtx());
-        startAndShow().catch((e2) => fatal('DeepSeek Harness 启动失败', e2));
-      } else if ((prev && response === take()) || (!prev && response === take())) {
-        updater.rollback(updCtx());
-        startAndShow().catch((e2) => fatal('DeepSeek Harness 启动失败', e2));
-      } else if ((prev && response === take()) || (!prev && response === take())) {
-        startAndShow().catch((e2) => handleBootFailure(e2));
-      } else {
-        app.quit();
-      }
-    });
-  } else {
-    fatal('Deepseek Harness 启动失败', err);
+  } catch {}
+  const lastGood = (() => { try { return ensureGuard().lastGoodSnapshot(); } catch { return null; } })();
+  const btnDisable = blameRow && blameRow.toggleable ? '停用插件 ' + blameRow.name + ' 并重试' : null;
+  const btnRollback = lastGood ? '回滚到最后良好快照并重试' : null;
+  const buttons = [
+    '进入救援模式',
+    ...(btnDisable ? [btnDisable] : []),
+    ...(btnRollback ? [btnRollback] : []),
+    ...(prev ? ['回退到上一版本并重试'] : []),
+    '回退到内置版本并重试',
+    '重试',
+    '退出',
+  ];
+  const detailLines = [String((err && err.message) || err)];
+  if (blame) {
+    detailLines.push('', `报错指向插件「${blame.name}」（${blame.kind === 'patchRow' ? 'patch 行 ' + blame.rowId : blame.kind}），可先停用该插件后重试。`);
   }
+  if (lastGood) {
+    detailLines.push(`存在最后良好快照（${lastGood.reason || lastGood.id}），可一键回滚后重试。`);
+  }
+  if (prev) detailLines.push('', `可回退到上一版本（v${prev.version}）或内置版本继续使用。`);
+  else detailLines.push('', '可回退到内置版本继续使用。');
+  detailLines.push('', '也可进入救援模式：查看日志/快照/事故报告，或让 AI 诊断后按建议修复。');
+  showBox({
+    type: 'error',
+    title: 'DeepSeek Harness 启动失败',
+    message: prev ? '更新后的 agent 无法启动。' : 'DeepSeek Harness 无法启动。',
+    detail: detailLines.join('\n'),
+    buttons,
+    defaultId: 0,
+    cancelId: buttons.length - 1,
+  }).then(({ response }) => {
+    let i = 0;
+    const take = () => i++;
+    // 第一按钮：进入救援模式（完整修复能力 + AI 诊断）。
+    if (response === take()) {
+      showRescuePage();
+      return;
+    }
+    // 归因到插件时，优先给「停用插件」——
+    if (btnDisable && response === take()) {
+      try {
+        pluginManagerSetEnabled(blameRow.id, false);
+        log('plugin-manager', `启动失败后停用插件: ${blameRow.id}`);
+      } catch (e2) { log('plugin-manager', '停用插件失败: ' + ((e2 && e2.message) || e2)); }
+      startAndShow().catch((e2) => handleBootFailure(e2));
+      return;
+    }
+    if (btnRollback && response === take()) {
+      try {
+        ensureGuard().restore(lastGood.id);
+      } catch (e2) { log('guard', '回滚快照失败: ' + ((e2 && e2.message) || e2)); }
+      startAndShow().catch((e2) => handleBootFailure(e2));
+      return;
+    }
+    if (prev && response === take()) {
+      updater.rollbackToPrevious(updCtx());
+      startAndShow().catch((e2) => fatal('DeepSeek Harness 启动失败', e2));
+      return;
+    }
+    if (response === take()) {
+      updater.rollback(updCtx()); // 无上一版本备份时为空操作（返回 null）
+      startAndShow().catch((e2) => fatal('DeepSeek Harness 启动失败', e2));
+      return;
+    }
+    if (response === take()) {
+      startAndShow().catch((e2) => handleBootFailure(e2));
+      return;
+    }
+    app.quit();
+  });
   // dsh web 起不来（如 v3.0.0 schemastery 闭包缺陷）的用户永远走不到
   // 成功链上的自动更新定时器，只能手动重装。主动查一次客户端更新，
   // manual=true 绕过 skip/稍后 抑制，让修复版本能下载并自愈。
@@ -2439,6 +2474,69 @@ function registerChromeIpc() {
     rescueBusy = true;
     try {
       return await rescueExecuteSuggestion({ action: 'retry', params: {}, reason: '用户手动重试', risk: 'low' });
+    } finally {
+      rescueBusy = false;
+    }
+  });
+
+  // ── V4.6 一键 AI 自动修复：诊断 → 自动执行低/中风险建议 → 自动重启 → 迭代。
+  // 全量发送诊断上下文（用户在清单页已确认的内容）；高风险动作自动跳过，
+  // 多轮修复后仍无法启动则兜底（回滚最后良好快照 + 开启安全模式）。
+  ipcMain.handle('rescue:auto-repair', async (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    if (rescueBusy) return { ok: false, error: 'busy' };
+    const home = dshHome || path.join(os.homedir(), '.dsh');
+    const apiKey = balance.readApiKey(home);
+    if (!apiKey) {
+      return { ok: false, error: 'no-key', hint: '未找到 DEEPSEEK_API_KEY（环境变量或 ~/.dsh/.credentials.yaml）' };
+    }
+    rescueBusy = true;
+    try {
+      const g = ensureGuard();
+      const result = await rescueAgent.runAutoRepair({
+        diagnose: () => {
+          const diag = buildRescueDiagnosis();
+          if (!diag) return { ok: false, error: '诊断上下文收集失败' };
+          // 空 selections = 全量发送（用户确认的完整清单）。
+          return { ok: true, payload: rescueAgent.filterDiagnosisPayload(diag.payload, diag.sendManifest, []) };
+        },
+        analyze: async (payload) => {
+          const r = await rescueAgent.chatCompletions({
+            apiKey,
+            model: rescueAgent.DEFAULT_OPTS.MODEL,
+            messages: [{ role: 'system', content: rescueAgent.buildDiagnosisPrompt(payload) }],
+            timeoutMs: rescueAgent.DEFAULT_OPTS.AI_TIMEOUT_MS,
+          });
+          if (!r.ok) return r;
+          return rescueAgent.parseAiResponse(r.content);
+        },
+        execute: (s) => rescueAgent.applySuggestion(s, (x) => rescueExecuteSuggestion(x), (t, m) => log(t, m)),
+        retry: () => rescueExecuteSuggestion({ action: 'retry', params: {}, reason: 'AI 修复后自动重试', risk: 'low' }),
+        fallback: async () => {
+          const notes = [];
+          try {
+            const good = g.lastGoodSnapshot();
+            if (good && good.id) {
+              const rr = g.restore(good.id);
+              notes.push(rr.ok ? '已回滚最后良好快照 ' + good.id : '回滚失败: ' + String((rr && rr.error) || '?'));
+            } else {
+              notes.push('无最后良好快照可回滚');
+            }
+          } catch (err) {
+            notes.push('回滚异常: ' + String((err && err.message) || err));
+          }
+          try {
+            const sm = safeModeSet(true);
+            notes.push(sm.ok ? '已开启安全模式' : '安全模式开启失败');
+          } catch (err) {
+            notes.push('安全模式异常: ' + String((err && err.message) || err));
+          }
+          return { ok: true, result: notes.join('；') };
+        },
+        log: (t, m) => log(t, m),
+      });
+      log('rescue', '一键 AI 自动修复结束: ' + JSON.stringify({ ok: result.ok, rounds: result.rounds && result.rounds.length, error: result.error || null }));
+      return result;
     } finally {
       rescueBusy = false;
     }

--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "name": "dsh-desktop",
   "productName": "Deepseek Harness EAC",
-  "version": "4.4.1",
-  "description": "DeepSeek Harness (dsh) 开箱即用的 Windows 桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI",
+  "version": "4.6.0",
+  "description": "DeepSeek Harness (dsh) 寮€绠卞嵆鐢ㄧ殑 Windows 妗岄潰瀹㈡埛绔細鍐呯疆 dsh CLI 涓?Node 杩愯鏃讹紝涓€閿惎鍔?Web UI",
   "main": "main.js",
   "author": "DSH Desktop",
   "license": "MIT",

--- a/dsh-desktop/preload.js
+++ b/dsh-desktop/preload.js
@@ -118,6 +118,7 @@ const dshDesktop = {
     apply: (suggestion) => ipcRenderer.invoke('rescue:apply', { suggestion }),
     setSafeMode: (on) => ipcRenderer.invoke('safe-mode:set', { on }),
     retry: () => ipcRenderer.invoke('rescue:retry'),
+    autoRepair: () => ipcRenderer.invoke('rescue:auto-repair'),
   },
 };
 

--- a/dsh-desktop/rescue-agent.js
+++ b/dsh-desktop/rescue-agent.js
@@ -27,7 +27,9 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const http = require('node:http');
 const https = require('node:https');
+const yaml = require('js-yaml');
 const { removePluginFromPatch } = require('./scripts/plugin-manager-patch');
 
 const DEFAULT_OPTS = {
@@ -129,6 +131,9 @@ function collectDiagnosis(ctx, opts = {}) {
     workspaceYaml: readProfileFile('pnpm-workspace.yaml'),
     builtinList: readProfileFile('.dsh-builtin-plugins.json'),
   };
+  // 全局 settings.yaml（快照不覆盖、规则体检不扫的配置面 —— AI 主动修复的
+  // 主要作战对象之一），限长读取，损坏字节不影响收集。
+  const settingsYaml = home ? readTail(path.join(home, 'settings.yaml'), o.PROFILE_TEXT_MAX) : '';
   const logs = {
     'dsh-web.log': readTail(path.join(logsDir, 'dsh-web.log'), o.LOG_TAIL_BYTES),
     'desktop.log': readTail(path.join(logsDir, 'desktop.log'), o.LOG_TAIL_BYTES),
@@ -157,6 +162,7 @@ function collectDiagnosis(ctx, opts = {}) {
     lastGood: lastGood ? { id: lastGood.id, reason: lastGood.reason || '' } : null,
     incidents,
     profile,
+    settingsYaml,
     logs,
   };
 
@@ -168,6 +174,7 @@ function collectDiagnosis(ctx, opts = {}) {
     ...(snapshots.length ? [{ kind: '快照', name: `${snapshots.length} 份快照（含最后良好）`, size: JSON.stringify(snapshots).length }] : []),
     ...incidents.map((i) => ({ kind: '事故报告', name: i.title, size: i.body.length })),
     ...Object.entries(profile).filter(([, v]) => v).map(([k, v]) => ({ kind: '配置面', name: k, size: v.length })),
+    ...(settingsYaml ? [{ kind: '配置面', name: 'settings.yaml', size: settingsYaml.length }] : []),
     ...Object.entries(logs).filter(([, v]) => v).map(([k, v]) => ({ kind: '日志尾部', name: k, size: v.length })),
   ];
 
@@ -208,16 +215,19 @@ function filterDiagnosisPayload(payload, manifest, selectedNames) {
       if (manifest.some((m) => m.kind === '配置面' && m.name === k && sel.has(m.name))) out.profile[k] = v;
     }
   }
+  out.settingsYaml = kinds.has('配置面') && sel.has('settings.yaml') ? payload.settingsYaml : '';
   return out;
 }
 
 // ── 提示词构建（buildDiagnosisPrompt）──────────────────────────────────
 // 系统提示词约束：只诊断、只输出动作白名单内的 JSON 建议、绝不虚构文件内容。
 const ACTION_SPEC = [
-  { action: 'restore', params: { snapshotId: '快照 id（来自诊断上下文 snapshots 列表）' }, desc: '回滚 profile 配置到指定快照' },
+  { action: 'restore', params: { snapshotId: '快照 id（来自诊断上下文 snapshots 列表）' }, desc: '回滚 profile 配置到指定快照（高风险，最后手段）' },
   { action: 'disable', params: { pluginId: '插件 id（来自 plugins 列表）' }, desc: '停用某个插件（写盘停用，重启不还原）' },
-  { action: 'remove', params: { pluginId: '插件 id' }, desc: '卸载某个内置插件（清 patch 行与包副本）' },
+  { action: 'remove', params: { pluginId: '插件 id' }, desc: '卸载某个内置插件（高风险，清 patch 行与包副本）' },
   { action: 'repair', params: {}, desc: '执行规则体检修复（patch 行 / 模块遮蔽 / junction）' },
+  { action: 'resync', params: {}, desc: '重装/修复 profile 模块树（node_modules 损坏时使用）' },
+  { action: 'edit-file', params: { file: '白名单文件名（settings.yaml 或 profile 的 package.json / pnpm-lock.yaml / pnpm-workspace.yaml / cordis.patch.yml / .dsh-builtin-plugins.json）', ops: '[{op:"replace-line"|"delete-line"|"insert-after", anchor:"现有行锚点", with:"替换/插入内容（可选）"}] 或 newContent:"整体替换内容"' }, desc: '直接编辑白名单配置文件修复根因（写前快照、写后校验可解析）' },
   { action: 'safe-mode', params: { on: 'true=开启安全模式（只留核心插件裸启动），false=恢复' }, desc: '壳层安全模式开关' },
   { action: 'retry', params: {}, desc: '重新启动 Web 服务（走守护启动全链路）' },
   { action: 'export', params: {}, desc: '建议用户导出诊断 zip（不自动执行）' },
@@ -231,7 +241,7 @@ function buildDiagnosisPrompt(diag) {
     `    desc: ${a.desc}`
   )).join('\n');
   return [
-    '你是 DeepSeek Harness 桌面客户端的救援诊断助手。你的任务是根据下方诊断上下文判断客户端无法工作的原因。',
+    '你是 DeepSeek Harness 桌面客户端的救援修复助手。你的任务是根据下方诊断上下文判断客户端无法工作的原因，并给出可自动执行的修复方案。',
     '',
     '规则：',
     '1. 只做只读诊断，绝不臆造文件内容或日志中不存在的事实。',
@@ -244,8 +254,13 @@ function buildDiagnosisPrompt(diag) {
     '   }',
     '3. suggestions 只能从以下动作白名单中选择，params 必须与规格一致：',
     spec,
-    '4. 若无法确定根因，analysis 说明疑点，suggestions 只给最保守的项（如 retry 或 export）。',
-    '5. 最多给出 4 条建议，按实施顺序排列。',
+    '4. 优先主动修复根因：先考虑 edit-file / resync / repair（低/中风险，会被自动执行），',
+    '   不要一上来就 disable 或 restore；restore / remove 风险高，只在规则链与编辑都无法修复时给出。',
+    '5. edit-file 纪律：只编辑白名单文件；用最小改动（优先 replace-line / delete-line，避免整文件重写）；',
+    '   anchor 必须取诊断上下文里真实存在的行内容；改后文件必须仍是合法 YAML/JSON；',
+    '   若无法给出精确编辑，宁可不给 edit-file。',
+    '6. 若无法确定根因，analysis 说明疑点，suggestions 只给最保守的项（如 retry 或 export）。',
+    '7. 最多给出 4 条建议，按实施顺序排列。',
     '',
     '=== 诊断上下文（JSON） ===',
     JSON.stringify(diag, null, 2),
@@ -296,9 +311,10 @@ function parseAiResponse(text, opts = {}) {
 }
 
 // ── 建议校验（validateSuggestion）─────────────────────────────────────
-const SUGGESTION_ACTIONS = new Set(['restore', 'disable', 'remove', 'repair', 'safe-mode', 'retry', 'export']);
+const SUGGESTION_ACTIONS = new Set(['restore', 'disable', 'remove', 'repair', 'resync', 'edit-file', 'safe-mode', 'retry', 'export']);
 const ID_RE = /^[A-Za-z0-9_.-]+$/;
 const SNAPSHOT_ID_RE = /^[\w.-]+$/;
+const EDIT_OPS = new Set(['replace-line', 'delete-line', 'insert-after']);
 
 function validateSuggestion(item) {
   if (!item || typeof item !== 'object') return { ok: false, error: '建议项不是对象' };
@@ -319,8 +335,190 @@ function validateSuggestion(item) {
     out.params.pluginId = id;
   } else if (action === 'safe-mode') {
     out.params.on = params.on === true;
+  } else if (action === 'edit-file') {
+    // AI 主动修复：只接受白名单文件名 + 结构化行编辑（ops）或整体替换
+    // （newContent）。文件名不得含路径分隔符 / .. / :，杜绝越权与路径穿越。
+    const file = String(params.file || '');
+    if (!file || file.includes('\\') || file.includes('/') || file.includes('..') || file.includes(':')) {
+      return { ok: false, error: 'edit-file 缺少合法 file（只允许白名单文件名本身）' };
+    }
+    if (!EDITABLE_PROFILE_FILES.includes(file) && !EDITABLE_HOME_FILES.includes(file)) {
+      return { ok: false, error: 'edit-file 文件不在可编辑白名单内: ' + file };
+    }
+    const ops = Array.isArray(params.ops) ? params.ops : null;
+    const newContent = typeof params.newContent === 'string' ? params.newContent : null;
+    if (!ops && newContent === null) return { ok: false, error: 'edit-file 缺少 ops 或 newContent' };
+    if (ops) {
+      if (!ops.length) return { ok: false, error: 'edit-file ops 不能为空' };
+      const clean = [];
+      for (const op of ops) {
+        if (!op || typeof op !== 'object') return { ok: false, error: 'edit-file 操作项必须是对象' };
+        const kind = String(op.op || '');
+        if (!EDIT_OPS.has(kind)) return { ok: false, error: '未知编辑操作: ' + kind };
+        const anchor = String(op.anchor || '');
+        if (!anchor) return { ok: false, error: '编辑操作缺少 anchor' };
+        if ((kind === 'replace-line' || kind === 'insert-after') && typeof op.with !== 'string') {
+          return { ok: false, error: kind + ' 缺少 with' };
+        }
+        clean.push({ op: kind, anchor, ...(typeof op.with === 'string' ? { with: op.with } : {}) });
+      }
+      out.params = { file, ops: clean };
+    } else {
+      out.params = { file, newContent };
+    }
   }
   return { ok: true, suggestion: out };
+}
+
+// ── 可编辑文件白名单（AI 主动修复的唯一落笔范围）────────────────────
+const EDITABLE_PROFILE_FILES = ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'cordis.patch.yml', '.dsh-builtin-plugins.json'];
+const EDITABLE_HOME_FILES = ['settings.yaml'];
+
+// 校验编辑目标：文件名必须本身在白名单内，解析后落在 profileDir / home 根下。
+function validateEditTarget(file, ctx = {}) {
+  const name = String(file || '');
+  if (!name || name.includes('\\') || name.includes('/') || name.includes('..') || name.includes(':')) {
+    return { ok: false, error: '越权路径：只允许编辑白名单文件本身' };
+  }
+  const ext = path.extname(name).toLowerCase();
+  if (EDITABLE_PROFILE_FILES.includes(name)) {
+    const profileDir = String(ctx.profileDir || '');
+    if (!profileDir) return { ok: false, error: 'profileDir 缺失' };
+    return { ok: true, abs: path.join(profileDir, name), kind: 'profile', ext };
+  }
+  if (EDITABLE_HOME_FILES.includes(name)) {
+    const home = String(ctx.home || '');
+    if (!home) return { ok: false, error: 'home 缺失' };
+    return { ok: true, abs: path.join(home, name), kind: 'home', ext };
+  }
+  return { ok: false, error: '文件不在可编辑白名单内' };
+}
+
+function lineMatches(line, anchor) {
+  const t = String(line).trim();
+  return t === anchor || t.startsWith(anchor + ':') || t.startsWith(anchor + ' ');
+}
+
+function applyEditOp(text, op) {
+  const kind = String(op && op.op || '');
+  const anchor = String(op && op.anchor || '');
+  if (!anchor) return { ok: false, error: '行编辑缺少 anchor' };
+  const lines = String(text || '').split('\n');
+  const idx = lines.findIndex((l) => lineMatches(l, anchor));
+  if (idx < 0) return { ok: false, error: '锚点未找到: ' + anchor };
+  if (kind === 'replace-line') {
+    if (typeof op.with !== 'string') return { ok: false, error: 'replace-line 缺少 with' };
+    lines[idx] = op.with;
+    return { ok: true, text: lines.join('\n') };
+  }
+  if (kind === 'delete-line') {
+    lines.splice(idx, 1);
+    return { ok: true, text: lines.join('\n') };
+  }
+  if (kind === 'insert-after') {
+    if (typeof op.with !== 'string') return { ok: false, error: 'insert-after 缺少 with' };
+    lines.splice(idx + 1, 0, op.with);
+    return { ok: true, text: lines.join('\n') };
+  }
+  return { ok: false, error: '未知编辑操作: ' + kind };
+}
+
+function verifyContentParses(ext, text) {
+  try {
+    if (ext === '.json') {
+      JSON.parse(text);
+      return null;
+    }
+    if (ext === '.yaml' || ext === '.yml') {
+      yaml.load(text);
+      return null;
+    }
+    return null;
+  } catch (err) {
+    return '编辑后内容无法解析（' + (ext === '.json' ? 'JSON' : 'YAML') + '）: ' + String((err && err.message) || err);
+  }
+}
+
+// 应用一次白名单文件编辑。副作用（备份/写盘）经 ctx 注入，核心纯逻辑可测。
+// 顺序：目标校验 → 行编辑 → 可解析校验 → 备份 → 写盘。
+function applyProfileEdit(edit, ctx = {}) {
+  const target = validateEditTarget(edit && edit.file, ctx);
+  if (!target.ok) return { ok: false, error: target.error };
+  const ops = Array.isArray(edit && edit.ops) ? edit.ops : null;
+  const newContent = typeof (edit && edit.newContent) === 'string' ? edit.newContent : null;
+  if (!ops && newContent === null) return { ok: false, error: '缺少编辑内容（ops 或 newContent）' };
+
+  let raw = null;
+  try { raw = typeof ctx.readFile === 'function' ? ctx.readFile(target.abs) : null; } catch { raw = null; }
+  if (raw === null && newContent === null) {
+    return { ok: false, error: '目标文件不存在，无法做行级编辑（可改用 newContent 重建）' };
+  }
+  if (raw === null) raw = '';
+
+  let result = raw;
+  let applied = 0;
+  if (ops) {
+    for (const op of ops) {
+      const step = applyEditOp(result, op);
+      if (!step.ok) return { ok: false, error: step.error };
+      result = step.text;
+      applied += 1;
+    }
+  } else {
+    result = newContent;
+    applied = 1;
+  }
+
+  const parseErr = verifyContentParses(target.ext, result);
+  if (parseErr) return { ok: false, error: parseErr };
+
+  try {
+    if (typeof ctx.backup === 'function') ctx.backup(target.abs);
+    if (typeof ctx.writeFile === 'function') ctx.writeFile(target.abs, result);
+  } catch (err) {
+    return { ok: false, error: '写入失败: ' + String((err && err.message) || err) };
+  }
+  return { ok: true, file: edit.file, opsApplied: applied, backupTaken: true };
+}
+
+// ── 一键 AI 自动修复循环（runAutoRepair）──────────────────────────────
+// 所有副作用注入：diagnose（收集上下文）、analyze（调 AI 返回建议）、
+// execute（执行单条白名单建议）、retry（重启 Web 服务）、fallback（兜底
+// 回滚+安全模式）。自动跳过 risk=high 的动作；无进展不重试；超过轮次
+// 或修复后仍无法启动 → 兜底并返回完整轮次记录。
+async function runAutoRepair({ diagnose, analyze, execute, retry, fallback, maxRounds = 2, log = () => {} } = {}) {
+  const safe = (fn) => Promise.resolve().then(fn).catch((err) => ({ ok: false, error: String((err && err.message) || err) }));
+  const rounds = [];
+  const max = Math.max(1, Number(maxRounds) || 2);
+  for (let round = 0; round < max; round++) {
+    const diag = await safe(diagnose);
+    if (!diag || !diag.ok) return { ok: false, error: (diag && diag.error) || '诊断上下文收集失败', rounds };
+    const ai = await safe(() => analyze(diag.payload));
+    if (!ai || !ai.ok) return { ok: false, error: (ai && ai.error) || 'AI 诊断失败', rounds };
+    const suggestions = Array.isArray(ai.suggestions) ? ai.suggestions : [];
+    const applied = [];
+    for (const s of suggestions) {
+      if (s && s.risk === 'high') {
+        applied.push({ action: s.action, skipped: 'high-risk' });
+        continue;
+      }
+      const r = await safe(() => execute(s));
+      applied.push({ action: s && s.action, ok: !!(r && r.ok), result: r && r.result, error: r && r.error });
+    }
+    const progressed = applied.some((a) => a.ok);
+    const roundRec = { round, analysis: ai.analysis || '', applied };
+    if (!progressed) {
+      rounds.push(roundRec);
+      return { ok: false, rounds, error: 'AI 未给出可自动执行的修复', fallback: await safe(fallback) };
+    }
+    const retryRes = await safe(retry);
+    roundRec.retryOk = !!(retryRes && retryRes.ok);
+    roundRec.retryResult = retryRes && retryRes.result;
+    rounds.push(roundRec);
+    if (roundRec.retryOk) return { ok: true, rounds };
+    log('rescue', `AI 自动修复第 ${round + 1} 轮已应用但启动仍失败，进入下一轮`);
+  }
+  return { ok: false, rounds, error: '多轮 AI 修复后仍未启动成功', fallback: await safe(fallback) };
 }
 
 // ── 白名单分发（applySuggestion，副作用经 exec 注入）──────────────────
@@ -391,16 +589,21 @@ function chatCompletions({ apiKey, model, messages, timeoutMs, baseUrl, httpFn }
   const base = String(baseUrl || process.env.DEEPSEEK_API_BASE || 'https://api.deepseek.com').replace(/\/+$/, '');
   const url = base + '/chat/completions';
   const body = JSON.stringify({
-    model: model || DEFAULT_OPTS.MODEL,
+    model: model || process.env.DSH_RESCUE_MODEL || DEFAULT_OPTS.MODEL,
     messages: Array.isArray(messages) ? messages : [],
-    max_tokens: 2000,
+    max_tokens: Number(process.env.DSH_RESCUE_MAX_TOKENS) || 8192,
     temperature: 0.2,
+    // 显式非流式：部分本地路由网关（如 9router）未指定 stream 时默认返回
+    // SSE 流式响应，JSON.parse 会失败。
+    stream: false,
   });
   const timeout = timeoutMs || DEFAULT_OPTS.AI_TIMEOUT_MS;
+  // 兼容本地 http 网关（LLM 路由/聚合端点常为 http://localhost:port）。
+  const transport = base.startsWith('http://') ? http : https;
   const doFetch = typeof httpFn === 'function'
     ? httpFn
     : (url2, reqBody, headers) => new Promise((resolve, reject) => {
-      const req = https.request(url2, {
+      const req = transport.request(url2, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -458,4 +661,7 @@ module.exports = {
   recordBootFailure,
   shouldEnterRescue,
   chatCompletions,
+  validateEditTarget,
+  applyProfileEdit,
+  runAutoRepair,
 };

--- a/dsh-desktop/scripts/demo-rescue-ai.cjs
+++ b/dsh-desktop/scripts/demo-rescue-ai.cjs
@@ -1,0 +1,236 @@
+'use strict';
+
+// demo-rescue-ai.cjs — 模拟真实用户环境的「插件冲突崩溃 → AI 自动修复」演示。
+//
+// 流程：
+//   1) 在隔离 DSH_HOME 里用真实 profile（web-desktop，去 node_modules）启动
+//      4.6.0 便携版，确认首次正常启动（AI 可用，走本地路由网关）；
+//   2) 退出后把 cordis.patch.yml 里一个「非 bundle」插件行整块复制一份
+//      （duplicate loader entry id → dsh web exit 1 崩溃，PATCH_DUP_ID）；
+//   3) 重新启动 → 崩溃窗口/救援页弹出 —— 由你（用户）亲自点击
+//      「进入救援模式」→「AI 自动修复」，观察逐轮过程；
+//   4) 脚本实时输出日志，直到「一键 AI 自动修复结束」且 Web UI 恢复就绪；
+//   5) app 保持运行，展示修复结果。
+//
+// 环境：AI 调用走 settings 里配置的本地路由网关（llm-pi-ai.providers.router
+// 的 baseURL + ROUTER_API_KEY），不经官方 api.deepseek.com。
+//
+// 用法：node scripts/demo-rescue-ai.cjs [--keep] [--exe=dist/...x64.exe]
+//   --keep        结束时不清理演示目录（默认清理）
+//   --model=xxx   路由模型 id（默认 oc/deepseek-v4-flash-free(max)）
+
+const { spawn, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ARGS = Object.fromEntries(process.argv.slice(2).map((a) => {
+  const m = a.match(/^--([^=]+)=(.*)$/);
+  return m ? [m[1], m[2]] : [a.replace(/^--/, ''), true];
+}));
+const EXE = path.resolve(ARGS.exe || 'dist/Deepseek-Harness-EAC-Portable-x64.exe');
+// 模型默认取自客户端已配置的路由模型列表；优先选非推理档（更快更稳，
+// 推理档如 xxx(max) 会把 token 全花在思考上，max_tokens 需给足）。
+const DEFAULT_MODEL = (() => {
+  try {
+    const doc = require('js-yaml').load(fs.readFileSync(path.join(os.homedir(), '.dsh', 'settings.yaml'), 'utf8'));
+    const models = doc && doc['llm-pi-ai'] && doc['llm-pi-ai'].providers && doc['llm-pi-ai'].providers.router && doc['llm-pi-ai'].providers.router.models;
+    if (Array.isArray(models) && models.length) {
+      const ids = models.map((x) => x && x.id).filter(Boolean);
+      return String(ids.find((id) => !/\(max\)|reasoning|^r1|think/i.test(id)) || ids[0]);
+    }
+  } catch {}
+  return 'oc/mimo-v2.5-free';
+})();
+const MODEL = ARGS.model || DEFAULT_MODEL;
+const KEEP = !!ARGS.keep;
+const PROFILE = 'web-desktop';
+const DEBUG_PORT = 9341;
+const ROOT_BASE = process.env.DSH_E2E_ROOT || os.tmpdir();
+const TMP_DIR = path.join(ROOT_BASE, 'tmp');
+
+const realHome = path.join(os.homedir(), '.dsh');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function mask(s) { return s && s.length > 8 ? s.slice(0, 4) + '***' : s; }
+function readApiKeyFrom(file) {
+  try {
+    const t = fs.readFileSync(file, 'utf8');
+    const m = t.match(/^\s*ROUTER_API_KEY\s*:\s*["']?([^"'\s#]+)/m);
+    return m ? m[1] : '';
+  } catch { return ''; }
+}
+function killApp() {
+  spawnSync('taskkill', ['/IM', 'Deepseek Harness EAC.exe', '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+}
+function procAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function main() {
+  killApp();
+  await sleep(1500);
+  const root = fs.mkdtempSync(path.join(ROOT_BASE, 'dsh-rescue-demo-'));
+  const home = path.join(root, 'dsh-home');
+  const runDir = path.join(root, 'run');
+  const userData = path.join(runDir, 'data');
+  const logFile = path.join(userData, 'logs', 'desktop.log');
+  const profDir = path.join(home, 'profiles', PROFILE);
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  const routerKey = readApiKeyFrom(path.join(realHome, '.credentials.yaml'));
+  console.log(`[demo] 演示目录: ${root}`);
+  console.log(`[demo] 路由网关 key=${mask(routerKey)} 模型=${MODEL}`);
+
+  // 0) 前置：路由网关必须在线（用户侧启动）。
+  if (!routerKey) { console.error('[demo] 未找到 ROUTER_API_KEY（%USERPROFILE%\\.dsh\\.credentials.yaml）'); process.exit(2); }
+  try {
+    const r = spawnSync(process.execPath, ['-e', `
+      const http = require('node:http');
+      const req = http.request('http://localhost:20128/v1/models', { method: 'GET', headers: { Authorization: 'Bearer ' + process.argv[1] }, timeout: 6000 }, (res) => {
+        let b = ''; res.on('data', (c) => b += c);
+        res.on('end', () => { console.log('HTTP ' + res.statusCode); process.exit(res.statusCode === 200 ? 0 : 3); });
+      });
+      req.on('error', () => process.exit(1)); req.on('timeout', () => process.exit(4)); req.end();
+    `, routerKey], { encoding: 'utf8', timeout: 15000 });
+    if (r.status !== 0) {
+      console.error(`[demo] 路由网关 http://localhost:20128 未就绪（status=${r.status}）。请先启动你的路由网关，再重跑本脚本。`);
+      process.exit(2);
+    }
+  } catch { console.error('[demo] 路由网关探测失败'); process.exit(2); }
+
+  // 1) 隔离 home：复制真实 profile（去 node_modules）+ 配置 + 凭据。
+  fs.mkdirSync(path.dirname(profDir), { recursive: true });
+  const srcProf = path.join(realHome, 'profiles', PROFILE);
+  if (!fs.existsSync(srcProf)) { console.error(`[demo] 真实 profile 不存在: ${srcProf}`); process.exit(2); }
+  // 连同 node_modules 一起复制（真实用户环境：老插件包如 dsh-tool-vision 在
+  // 里面；跳过会导致「Cannot find package」启动崩溃，掩盖要演示的冲突场景）。
+  fs.cpSync(srcProf, profDir, { recursive: true });
+  for (const f of ['settings.yaml', '.credentials.yaml', '.env']) {
+    try { fs.copyFileSync(path.join(realHome, f), path.join(home, f)); } catch {}
+  }
+  // 预写老用户标记：跳过内置插件选择向导（否则阻塞 boot）。
+  fs.mkdirSync(userData, { recursive: true });
+  fs.writeFileSync(path.join(userData, 'settings.json'), JSON.stringify({
+    pluginOnboardingDone: true,
+    builtinPluginSelection: [
+      'balance', 'file-changes', 'client-file-changes', 'terminal',
+      'dsh-market-plugin', 'skin-switch', 'easy-setup', 'plugin-shield',
+      'plugin-manager', 'plugin-wizard',
+    ],
+    webPort: 0,
+  }, null, 2) + '\n');
+
+  const runExe = path.join(runDir, path.basename(EXE));
+  fs.copyFileSync(EXE, runExe);
+
+  const env = {
+    ...process.env,
+    DSH_HOME: home,
+    DSH_DESKTOP_SKIP_AUTO_UPDATE: '1',
+    DSH_DESKTOP_SKIP_CLIENT_UPDATE: '1',
+    DSH_DESKTOP_TEST_NO_SHORTCUTS: '1',
+    DEEPSEEK_API_BASE: 'http://localhost:20128/v1',
+    DEEPSEEK_API_KEY: routerKey,
+    DSH_RESCUE_MODEL: MODEL,
+    TEMP: TMP_DIR, TMP: TMP_DIR,
+    NPM_CONFIG_REGISTRY: 'https://registry.npmmirror.com',
+  };
+  const readLog = () => { try { return fs.readFileSync(logFile, 'utf8'); } catch { return ''; } };
+
+  // ── 阶段 1：首次正常启动 ──
+  console.log('[demo] 阶段 1：首次正常启动（等待 Web UI 就绪）…');
+  let child = spawn(runExe, ['--remote-debugging-port=' + DEBUG_PORT], { env, stdio: 'ignore', windowsHide: true });
+  let t0 = Date.now();
+  while (Date.now() - t0 < 10 * 60 * 1000) {
+    if (/Web UI 就绪/.test(readLog())) break;
+    if (child.exitCode !== null) { console.error('[demo] 首次启动失败（exitCode=' + child.exitCode + '）：\n' + readLog().slice(-1500)); process.exit(1); }
+    await sleep(2000);
+  }
+  if (!/Web UI 就绪/.test(readLog())) { console.error('[demo] 首次启动超时'); process.exit(1); }
+  console.log('[demo] 首次启动成功，Web UI 就绪。退出并制造冲突…');
+  spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+  await sleep(3000);
+  while (procAlive(child.pid)) await sleep(500);
+
+  // ── 阶段 2：复制一个非 bundle 插件行（duplicate loader entry）──
+  const patchFile = path.join(profDir, 'cordis.patch.yml');
+  let patch = fs.readFileSync(patchFile, 'utf8');
+  let bundles = [];
+  try { bundles = JSON.parse(fs.readFileSync(path.join(profDir, 'package.json'), 'utf8')).dsh.profile.bundles || []; } catch {}
+  const rows = [];
+  const re = /^[\t ]*- id:\s*([\w.-]+)\s*$/gm;
+  let m, last = 0;
+  while ((m = re.exec(patch)) !== null) rows.push({ id: m[1], start: m.index, end: re.lastIndex });
+  for (let i = 0; i < rows.length; i++) rows[i].end = i + 1 < rows.length ? rows[i + 1].start : patch.length;
+  const victim = rows.find((r) => !bundles.includes(r.id)) || rows[0];
+  if (!victim) { console.error('[demo] patch 里没有可复制的行'); process.exit(1); }
+  const block = patch.slice(victim.start, victim.end);
+  fs.writeFileSync(patchFile + '.demo-bak', patch);
+  patch = patch.slice(0, victim.end) + block + patch.slice(victim.end);
+  fs.writeFileSync(patchFile, patch);
+  console.log(`[demo] 已复制插件行块「${victim.id}」→ 制造 duplicate loader entry 崩溃（原文件备份: cordis.patch.yml.demo-bak）`);
+
+  // ── 阶段 3：崩溃 → 救援页（用户手动操作）──
+  console.log('[demo] 阶段 3：重新启动 → 应弹出「启动失败」窗口…');
+  child = spawn(runExe, ['--remote-debugging-port=' + DEBUG_PORT], { env, stdio: 'ignore', windowsHide: true });
+  t0 = Date.now();
+  let onRescue = false;
+  let lastLen = 0;
+  while (Date.now() - t0 < 10 * 60 * 1000) {
+    const log = readLog();
+    if (log.length > lastLen) {
+      const fresh = log.slice(lastLen).split(/\r?\n/).filter((l) => l.length);
+      lastLen = log.length;
+      for (const l of fresh) {
+        if (/\[rescue\]|\[recovery\]|\[guard\]|\[boot\] 启动失败|Web UI 就绪/.test(l)) console.log('  ' + l);
+      }
+    }
+    if (/recovery\.html/.test(log) || /界面加载成功/.test(log)) onRescue = true;
+    if (onRescue && /一键 AI 自动修复结束|Web UI 就绪/.test(log)) break;
+    if (child.exitCode !== null) { console.error('[demo] app 异常退出（exitCode=' + child.exitCode + '）'); break; }
+    await sleep(1000);
+  }
+  if (!onRescue) {
+    console.error('[demo] 未检测到救援页。日志尾部：\n' + readLog().slice(-2000));
+    process.exit(1);
+  }
+  console.log('');
+  console.log('════════════════════════════════════════════════════════');
+  console.log('  救援窗口已出现 —— 现在由你亲自操作：');
+  console.log('    1) 若弹出「启动失败」对话框 → 点「进入救援模式」');
+  console.log('    2) 在救援页点「AI 自动修复」按钮');
+  console.log('    3) 观察自动修复过程（诊断 → 建议 → 执行 → 重启）');
+  console.log('════════════════════════════════════════════════════════');
+  console.log('');
+
+  // ── 阶段 4：实时观察直到修复结束 ──
+  t0 = Date.now();
+  let done = false;
+  while (Date.now() - t0 < 15 * 60 * 1000) {
+    const log = readLog();
+    if (log.length > lastLen) {
+      const fresh = log.slice(lastLen).split(/\r?\n/).filter((l) => l.length);
+      lastLen = log.length;
+      for (const l of fresh) {
+        if (/\[rescue\]|\[recovery\]|\[guard\]|Web UI 就绪|启动失败/.test(l)) console.log('  ' + l);
+      }
+    }
+    if (/一键 AI 自动修复结束/.test(log) && /Web UI 就绪/.test(log)) { done = true; break; }
+    if (/一键 AI 自动修复结束/.test(log) && /安全模式已开启/.test(log)) { done = true; break; }
+    await sleep(1000);
+  }
+  const log = readLog();
+  const doneLine = (log.match(/一键 AI 自动修复结束: (.*)/) || [])[1] || '(未记录)';
+  const webUp = /Web UI 就绪/.test(log);
+  console.log('');
+  if (webUp) console.log(`[demo] ✅ 修复完成：Web UI 已恢复（自动修复结果: ${doneLine}）`);
+  else console.log(`[demo] ⚠️ 修复流程结束但未确认 Web UI（自动修复结果: ${doneLine}；兜底路径也属正常恢复）`);
+  console.log(`[demo] app 保持运行中，可亲自确认。演示数据: ${root}`);
+  console.log(`[demo] 清理命令: node scripts/demo-rescue-ai.cjs --clean=${root}`);
+  if (!KEEP) console.log(`[demo] 提示：下次运行加 --keep 可保留演示目录用于检查（.ai-bak / 快照 / 日志）。`);
+}
+
+main().catch((err) => { console.error('[demo] 异常: ' + ((err && err.stack) || err)); process.exit(1); });

--- a/dsh-desktop/scripts/e2e-full.js
+++ b/dsh-desktop/scripts/e2e-full.js
@@ -176,6 +176,21 @@ async function main() {
   }
   const hasKey = fs.existsSync(path.join(home, '.credentials.yaml'));
   console.log(`[full] root=${root} 真实API Key=${hasKey ? '有' : '无（对话测试将跳过）'}`);
+  // 对话测试需要可用的 DSH 默认模型：测试 home 里强制指向 deepseek 官方
+  // provider（用真实 DEEPSEEK_API_KEY）。本机 settings.yaml 的 agent-default-
+  // model 常指向无 key 的第三方端点（如 opencode zen），桥接会 502；测试
+  // 隔离 home 内的覆盖不影响真实数据。
+  if (hasKey) {
+    try {
+      const sf = path.join(home, 'settings.yaml');
+      let doc = {};
+      try { doc = require('js-yaml').load(fs.readFileSync(sf, 'utf8')) || {}; } catch {}
+      doc['agent-default-model'] = { provider: 'deepseek-official', model: 'deepseek-v4-flash' };
+      doc['llm-deepseek'] = doc['llm-deepseek'] || {};
+      fs.writeFileSync(sf, require('js-yaml').dump(doc));
+      console.log('[full] 测试 home 默认模型已覆盖为 deepseek-official/deepseek-v4-flash');
+    } catch (err) { console.log('[full] 覆盖默认模型失败（对话测试可能跳过）: ' + err.message); }
+  }
 
   const runExe = path.join(root, 'run', path.basename(EXE));
   fs.mkdirSync(path.dirname(runExe), { recursive: true });
@@ -407,7 +422,8 @@ async function main() {
   let nodeLeak = true;
   while (Date.now() - tR < 60000) {
     const nowNode = tasklistPids('node.exe');
-    if (![...nowNode].some((p) => p !== process.pid)) { nodeLeak = false; break; }
+    const runnerPid = Number(process.env.E2E_RUNNER_PID || 0);
+    if (![...nowNode].some((p) => p !== process.pid && p !== runnerPid)) { nodeLeak = false; break; }
     await sleep(3000);
   }
   check('更新+重启全链路后无 node.exe 残留', !nodeLeak);

--- a/dsh-desktop/test/rescue-agent.test.mjs
+++ b/dsh-desktop/test/rescue-agent.test.mjs
@@ -4,9 +4,10 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import yaml from 'js-yaml';
 import {
   DEFAULT_OPTS,
   readTail,
@@ -20,6 +21,8 @@ import {
   recordBootFailure,
   shouldEnterRescue,
   chatCompletions,
+  validateEditTarget,
+  applyProfileEdit,
 } from '../rescue-agent.js';
 
 function tempDir() {
@@ -72,7 +75,7 @@ function diagCtx(dir, over = {}) {
     profileDir,
     logsDir,
     profile: 'web-desktop',
-    versions: { app: '4.4.0', dsh: '0.1.0-rc.7', source: '内置' },
+    versions: { app: '4.6.0', dsh: '0.1.0-rc.7', source: '内置' },
     plugins: () => [{ id: 'bad-plugin', name: 'bad-plugin', enabled: true, core: false, toggleable: true }],
     snapshots: () => [{ id: 'snap-1', reason: 'boot', at: '2026-08-19T00:00:00.000Z' }],
     lastGood: () => ({ id: 'snap-1', reason: 'boot' }),
@@ -314,4 +317,171 @@ test('chatCompletions：注入 httpFn 失败 / 畸形响应 / 超时不炸', asy
   const r4 = await chatCompletions({ apiKey: 'k', httpFn: () => Promise.reject(new Error('network down')) });
   assert.equal(r4.ok, false);
   assert.match(r4.error, /network down/);
+});
+
+// ── AI 主动修复：edit-file 动作（validateSuggestion / validateEditTarget / applyProfileEdit） ──
+
+test('validateSuggestion：edit-file 结构化编辑合法参数', () => {
+  const ok1 = validateSuggestion({
+    action: 'edit-file',
+    params: { file: 'settings.yaml', ops: [{ op: 'replace-line', anchor: 'bad:', with: 'good: 1' }] },
+  });
+  assert.equal(ok1.ok, true);
+  assert.equal(ok1.suggestion.params.ops.length, 1);
+  const ok2 = validateSuggestion({
+    action: 'edit-file',
+    params: { file: 'cordis.patch.yml', newContent: '- id: core\n' },
+  });
+  assert.equal(ok2.ok, true);
+  const ok3 = validateSuggestion({
+    action: 'edit-file',
+    params: { file: 'package.json', ops: [{ op: 'insert-after', anchor: '{', with: '  "a": 1' }] },
+  });
+  assert.equal(ok3.ok, true);
+});
+
+test('validateSuggestion：edit-file 非法参数拒绝（越权文件/空操作/未知 op/缺锚点）', () => {
+  assert.equal(validateSuggestion({ action: 'edit-file', params: { file: 'C:\\windows\\evil.exe', ops: [{ op: 'replace-line', anchor: 'x', with: 'y' }] } }).ok, false, '绝对路径拒绝');
+  assert.equal(validateSuggestion({ action: 'edit-file', params: { file: '../evil.yml', ops: [{ op: 'replace-line', anchor: 'x', with: 'y' }] } }).ok, false, '路径穿越拒绝');
+  assert.equal(validateSuggestion({ action: 'edit-file', params: { file: 'settings.yaml', ops: [] } }).ok, false, '空 ops 拒绝');
+  assert.equal(validateSuggestion({ action: 'edit-file', params: { file: 'settings.yaml', ops: [{ op: 'rm -rf', anchor: 'x' }] } }).ok, false, '未知 op 拒绝');
+  assert.equal(validateSuggestion({ action: 'edit-file', params: { file: 'settings.yaml', ops: [{ op: 'replace-line', with: 'y' }] } }).ok, false, '缺 anchor 拒绝');
+  assert.equal(validateSuggestion({ action: 'edit-file', params: { file: 'not-in-whitelist.txt', ops: [{ op: 'replace-line', anchor: 'x', with: 'y' }] } }).ok, false, '白名单外文件名拒绝');
+  assert.equal(validateSuggestion({ action: 'edit-file', params: {} }).ok, false);
+});
+
+test('validateSuggestion：resync 动作合法', () => {
+  const r = validateSuggestion({ action: 'resync', params: {}, reason: '模块树损坏', risk: 'medium' });
+  assert.equal(r.ok, true);
+  assert.equal(r.suggestion.action, 'resync');
+});
+
+test('validateEditTarget：白名单文件解析且拒绝越权', () => {
+  const ctx = { home: 'H:\\dsh-home', profileDir: 'H:\\dsh-home\\profiles\\web-desktop' };
+  const p1 = validateEditTarget('settings.yaml', ctx);
+  assert.equal(p1.ok, true);
+  assert.equal(p1.abs, 'H:\\dsh-home\\settings.yaml');
+  const p2 = validateEditTarget('cordis.patch.yml', ctx);
+  assert.equal(p2.ok, true);
+  assert.equal(p2.abs, 'H:\\dsh-home\\profiles\\web-desktop\\cordis.patch.yml');
+  const p3 = validateEditTarget('pnpm-workspace.yaml', ctx);
+  assert.equal(p3.ok, true);
+  assert.equal(validateEditTarget('package.json', ctx).ok, true);
+  assert.equal(validateEditTarget('.dsh-builtin-plugins.json', ctx).ok, true);
+  assert.equal(validateEditTarget('pnpm-lock.yaml', ctx).ok, true);
+  assert.equal(validateEditTarget('evil.exe', ctx).ok, false);
+  assert.equal(validateEditTarget('..\\settings.yaml', ctx).ok, false);
+  assert.equal(validateEditTarget('profiles/web-desktop/settings.yaml', ctx).ok, false, '子路径也拒绝（只能白名单根内文件）');
+});
+
+test('applyProfileEdit：replace-line 改 YAML，备份先行、写后可解析', () => {
+  const t = tempDir();
+  try {
+    const file = join(t.dir, 'settings.yaml');
+    const home = t.dir;
+    writeFileSync(file, 'agent-default-model:\n  provider: open\n  model: x\n');
+    const writes = [];
+    const backups = [];
+    const r = applyProfileEdit({
+      file: 'settings.yaml',
+      ops: [{ op: 'replace-line', anchor: 'provider: open', with: '  provider: deepseek-official' }],
+    }, {
+      home,
+      profileDir: join(home, 'profiles', 'web-desktop'),
+      readFile: (f) => { try { return readFileSync(f, 'utf8'); } catch { return null; } },
+      writeFile: (f, text) => { writes.push([f, text]); writeFileSync(f, text); },
+      backup: (f) => { backups.push(f); },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.opsApplied, 1);
+    assert.equal(backups.length, 1, '写前必须备份');
+    assert.equal(backups[0], file);
+    assert.equal(writes.length, 1);
+    const out = readFileSync(file, 'utf8');
+    assert.ok(out.includes('deepseek-official'));
+    assert.ok(!out.includes('provider: open'));
+    yaml.load(out); // 不抛 = 可解析
+  } finally { t.cleanup(); }
+});
+
+test('applyProfileEdit：newContent 整体替换 JSON 并校验可解析', () => {
+  const t = tempDir();
+  try {
+    const home = t.dir;
+    const profDir = join(home, 'profiles', 'web-desktop');
+    mkdirSync(profDir, { recursive: true });
+    const file = join(profDir, '.dsh-builtin-plugins.json');
+    writeFileSync(file, '{"a":1}');
+    const r = applyProfileEdit({
+      file: '.dsh-builtin-plugins.json',
+      newContent: '{"a":2,"b":["x"]}',
+    }, {
+      home, profileDir: profDir,
+      readFile: (f) => readFileSync(f, 'utf8'),
+      writeFile: (f, text) => writeFileSync(f, text),
+      backup: () => {},
+    });
+    assert.equal(r.ok, true);
+    assert.equal(JSON.parse(readFileSync(file, 'utf8')).b[0], 'x');
+  } finally { t.cleanup(); }
+});
+
+test('applyProfileEdit：改后不可解析的内容拒绝写入', () => {
+  const t = tempDir();
+  try {
+    const home = t.dir;
+    const file = join(home, 'settings.yaml');
+    writeFileSync(file, 'a: 1\n');
+    let wrote = false;
+    const r = applyProfileEdit({
+      file: 'settings.yaml',
+      ops: [{ op: 'replace-line', anchor: 'a: 1', with: 'a: [unclosed' }],
+    }, {
+      home, profileDir: join(home, 'profiles', 'web-desktop'),
+      readFile: (f) => readFileSync(f, 'utf8'),
+      writeFile: () => { wrote = true; },
+      backup: () => {},
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /解析|可解析/);
+    assert.equal(wrote, false, '非法内容绝不落盘');
+    assert.equal(readFileSync(file, 'utf8'), 'a: 1\n', '原文件不变');
+  } finally { t.cleanup(); }
+});
+
+test('applyProfileEdit：锚点未找到 / 白名单外文件 / 文件不存在都拒绝且不写', () => {
+  const t = tempDir();
+  try {
+    const home = t.dir;
+    const file = join(home, 'settings.yaml');
+    writeFileSync(file, 'a: 1\n');
+    let wrote = 0;
+    const ctx = {
+      home, profileDir: join(home, 'profiles', 'web-desktop'),
+      readFile: (f) => { try { return readFileSync(f, 'utf8'); } catch { return null; } },
+      writeFile: (f, text) => { wrote += 1; writeFileSync(f, text); },
+      backup: () => {},
+    };
+    const r1 = applyProfileEdit({ file: 'settings.yaml', ops: [{ op: 'delete-line', anchor: 'no-such-anchor' }] }, ctx);
+    assert.equal(r1.ok, false);
+    assert.match(r1.error, /锚点|未找到/);
+    const r2 = applyProfileEdit({ file: 'evil.exe', ops: [{ op: 'replace-line', anchor: 'a', with: 'b' }] }, ctx);
+    assert.equal(r2.ok, false);
+    assert.match(r2.error, /白名单|越权/);
+    const r3 = applyProfileEdit({ file: 'settings.yaml', newContent: 'b: 2\n' }, ctx);
+    assert.equal(r3.ok, true, '文件存在时允许用 newContent 整体替换');
+    assert.equal(wrote, 1, 'r1/r2 不得写入，仅 r3 写入一次');
+    assert.equal(readFileSync(file, 'utf8'), 'b: 2\n');
+  } finally { t.cleanup(); }
+});
+
+test('collectDiagnosis：settings.yaml 进入诊断 payload 与发送清单', () => {
+  const t = tempDir();
+  try {
+    writeFileSync(join(t.dir, 'settings.yaml'), 'agent-default-model:\n  provider: open\n');
+    const d = collectDiagnosis(diagCtx(t.dir));
+    assert.equal(d.ok, true);
+    assert.ok(d.payload.settingsYaml.includes('provider: open'), 'settings.yaml 内容必须进入 payload');
+    assert.ok(d.sendManifest.some((m) => m.kind === '配置面' && m.name === 'settings.yaml'), '发送清单含 settings.yaml');
+  } finally { t.cleanup(); }
 });

--- a/dsh-desktop/test/rescue-auto-repair.test.mjs
+++ b/dsh-desktop/test/rescue-auto-repair.test.mjs
@@ -1,0 +1,143 @@
+// Tests for the AI auto-repair loop (runAutoRepair) — 一键「AI 自动修复」引擎。
+// 覆盖：自动执行低/中风险建议并跳过 high-risk、迭代重试、无进展兜底回滚、
+// 诊断/AI 失败降级。全部副作用注入，纯逻辑可测。
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { runAutoRepair } from '../rescue-agent.js';
+
+function okDiag() {
+  return { ok: true, payload: { env: { appVersion: '4.6.0' } } };
+}
+
+test('runAutoRepair：自动执行低/中风险建议，high-risk 自动跳过，重试成功', async () => {
+  const executed = [];
+  const r = await runAutoRepair({
+    maxRounds: 2,
+    diagnose: async () => okDiag(),
+    analyze: async () => ({
+      ok: true,
+      analysis: 'settings.yaml 损坏',
+      suggestions: [
+        { action: 'edit-file', params: { file: 'settings.yaml', ops: [{ op: 'replace-line', anchor: 'bad:', with: 'good: 1' }] }, reason: '修配置', risk: 'medium' },
+        { action: 'remove', params: { pluginId: 'dsh-x' }, reason: '高危', risk: 'high' },
+      ],
+    }),
+    execute: async (s) => { executed.push(s.action); return { ok: true, result: 'done', restartRequired: true }; },
+    retry: async () => ({ ok: true }),
+    fallback: async () => ({ ok: true }),
+  });
+  assert.equal(r.ok, true, '重试成功即整体成功');
+  assert.equal(r.rounds.length, 1);
+  assert.deepEqual(executed, ['edit-file'], 'high-risk remove 不应被执行');
+  assert.ok(r.rounds[0].applied.some((a) => a.action === 'remove' && a.skipped === 'high-risk'));
+  assert.equal(r.rounds[0].retryOk, true);
+});
+
+test('runAutoRepair：首轮有进展但重试失败，第二轮修复后成功', async () => {
+  const executed = [];
+  let round = 0;
+  const r = await runAutoRepair({
+    maxRounds: 2,
+    diagnose: async () => okDiag(),
+    analyze: async () => {
+      round += 1;
+      return {
+        ok: true,
+        analysis: 'round ' + round,
+        suggestions: round === 1
+          ? [{ action: 'edit-file', params: { file: 'settings.yaml', ops: [{ op: 'delete-line', anchor: 'bad:' }] }, reason: 'r', risk: 'medium' }]
+          : [{ action: 'disable', params: { pluginId: 'dsh-x' }, reason: 'r', risk: 'low' }],
+      };
+    },
+    execute: async (s) => { executed.push(s.action); return { ok: true, result: 'done', restartRequired: true }; },
+    retry: async () => ({ ok: round > 1 }),
+    fallback: async () => ({ ok: true, rolledBack: true }),
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.rounds.length, 2);
+  assert.deepEqual(executed, ['edit-file', 'disable']);
+  assert.equal(r.rounds[0].retryOk, false);
+  assert.equal(r.rounds[1].retryOk, true);
+});
+
+test('runAutoRepair：无任何进展时不做无谓重试，直接兜底回滚+安全模式', async () => {
+  let fallbackCalls = 0;
+  let retryCalls = 0;
+  const r = await runAutoRepair({
+    maxRounds: 2,
+    diagnose: async () => okDiag(),
+    analyze: async () => ({ ok: true, analysis: '无法确定', suggestions: [] }),
+    execute: async () => ({ ok: false, error: 'no-op' }),
+    retry: async () => { retryCalls += 1; return { ok: false }; },
+    fallback: async () => { fallbackCalls += 1; return { ok: true, rolledBack: true }; },
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.fallback.rolledBack, true);
+  assert.equal(fallbackCalls, 1);
+  assert.equal(retryCalls, 0, '无进展不得触发重试');
+});
+
+test('runAutoRepair：有进展但重试失败且无更多轮次 → 兜底', async () => {
+  const r = await runAutoRepair({
+    maxRounds: 1,
+    diagnose: async () => okDiag(),
+    analyze: async () => ({
+      ok: true,
+      analysis: 'a',
+      suggestions: [{ action: 'repair', params: {}, reason: 'r', risk: 'medium' }],
+    }),
+    execute: async () => ({ ok: true, result: 'applied', restartRequired: true }),
+    retry: async () => ({ ok: false }),
+    fallback: async () => ({ ok: true, rolledBack: true }),
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.fallback.rolledBack, true);
+});
+
+test('runAutoRepair：诊断收集失败 → 直接失败，不执行任何动作', async () => {
+  let executed = 0;
+  const r = await runAutoRepair({
+    diagnose: async () => ({ ok: false, error: 'collect fail' }),
+    analyze: async () => ({ ok: true, suggestions: [] }),
+    execute: async () => { executed += 1; return { ok: true }; },
+    retry: async () => ({ ok: true }),
+    fallback: async () => ({ ok: true }),
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /collect fail/);
+  assert.equal(executed, 0);
+});
+
+test('runAutoRepair：AI 诊断失败 → 失败并说明，不执行', async () => {
+  const r = await runAutoRepair({
+    diagnose: async () => okDiag(),
+    analyze: async () => ({ ok: false, error: 'no-key' }),
+    execute: async () => ({ ok: true }),
+    retry: async () => ({ ok: true }),
+    fallback: async () => ({ ok: true }),
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /no-key/);
+});
+
+test('runAutoRepair：执行器抛错按单条失败记录，不中断整轮', async () => {
+  const r = await runAutoRepair({
+    diagnose: async () => okDiag(),
+    analyze: async () => ({
+      ok: true,
+      analysis: 'a',
+      suggestions: [
+        { action: 'repair', params: {}, reason: 'r', risk: 'low' },
+        { action: 'retry', params: {}, reason: 'r', risk: 'low' },
+      ],
+    }),
+    execute: async (s) => { if (s.action === 'repair') throw new Error('boom'); return { ok: true, result: 'ok' }; },
+    retry: async () => ({ ok: true }),
+    fallback: async () => ({ ok: true }),
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.rounds[0].applied[0].ok, false);
+  assert.match(String(r.rounds[0].applied[0].error), /boom/);
+  assert.equal(r.rounds[0].applied[1].ok, true);
+});

--- a/dsh-desktop/test/rescue-integration.test.mjs
+++ b/dsh-desktop/test/rescue-integration.test.mjs
@@ -31,6 +31,18 @@ test('main.js registers every rescue IPC endpoint', () => {
   }
 });
 
+test('main.js wires the one-click AI auto-repair IPC', () => {
+  assert.ok(mainSrc.includes("'rescue:auto-repair'"), "IPC handler rescue:auto-repair missing");
+  assert.ok(/rescueAgent\.runAutoRepair\(/.test(mainSrc), 'main.js must call rescueAgent.runAutoRepair()');
+});
+
+test('main.js executes edit-file and resync in the whitelist dispatcher', () => {
+  assert.ok(/case 'edit-file'/.test(mainSrc), "rescueExecuteSuggestion edit-file case missing");
+  assert.ok(/case 'resync'/.test(mainSrc), "rescueExecuteSuggestion resync case missing");
+  assert.ok(/applyProfileEdit\(/.test(mainSrc), 'edit-file must go through applyProfileEdit()');
+  assert.ok(/snapshot\('ai-edit-before'\)/.test(mainSrc), 'edit-file must snapshot before writing');
+});
+
 test('main.js offers 进入救援模式 from the boot-failure dialog', () => {
   assert.ok(mainSrc.includes("'进入救援模式'"), 'rescue-mode button missing from handleBootFailure');
   assert.ok(/function showRescuePage\(/.test(mainSrc), 'showRescuePage() missing');
@@ -52,6 +64,19 @@ test('preload exposes the rescue bridge', () => {
   for (const ch of ['rescue:state', 'rescue:confirm', 'rescue:diagnose', 'rescue:apply', 'rescue:retry', 'safe-mode:set']) {
     assert.ok(preloadSrc.includes(`'${ch}'`), `preload bridge for ${ch} missing`);
   }
+});
+
+test('preload exposes the auto-repair bridge', () => {
+  assert.ok(preloadSrc.includes("'rescue:auto-repair'"), 'preload auto-repair bridge missing');
+  assert.ok(/autoRepair:/.test(preloadSrc), 'preload rescue.autoRepair() missing');
+});
+
+test('rescue page offers the one-click AI auto repair', () => {
+  const page = join(ROOT, 'assets', 'recovery.html');
+  const html = readFileSync(page, 'utf8');
+  assert.ok(html.includes('AI 自动修复'), 'recovery.html must offer the AI auto-repair button');
+  assert.ok(/btn-autorepair/.test(html), 'recovery.html btn-autorepair missing');
+  assert.ok(/auto-progress/.test(html), 'recovery.html auto-repair progress area missing');
 });
 
 test('rescue page exists and references the rescue bridge', () => {


### PR DESCRIPTION
## 背景
上一 PR（崩溃救援模式）的 AI 自动修复实测中发现三个阻断问题，本 PR 全部修复，并补齐隔离环境演示脚本与 e2e 泄漏误报。

## 修复
- `chatCompletions` 显式 `stream: false`：本地路由网关（9router 等）未指定 stream 时默认返回 SSE 流，`JSON.parse` 直接失败，AI 修复 100% 失败
- `max_tokens` 2000 → 8192（对齐客户端默认）：`oc/deepseek-v4-flash-free(max)` 等推理模型会把 2000 全部耗在 `reasoning_content`，返回空 `content`（`finish_reason=length`）
- 模型/超参可覆盖：`DSH_RESCUE_MODEL`、`DSH_RESCUE_MAX_TOKENS` 环境变量
- 启动失败对话框：无覆盖层场景（BSP 阶段）也能点「进入救援模式」，不再直接 fatal 退出
- 演示脚本 `scripts/demo-rescue-ai.cjs`：隔离 DSH_HOME 复制真实 profile（含 node_modules），制造 patch 重复行冲突 → 崩溃窗口 → 人工进救援 → 观察 AI 修复全程；模型自动取自客户端 settings.yaml 路由列表并优先非推理档
- e2e-full 泄漏检查：排除 `E2E_RUNNER_PID`（修复 wrapper 多出的 node 进程被误判为泄漏）

## 验证
- rescue-agent / rescue-auto-repair / rescue-integration 三个测试文件：50/50 通过
- 实测 chatCompletions 走真实路由网关返回合法 JSON（parseAiResponse ok）
- dist 已重建（4.6.0），演示链路在真实 exe 上跑通（守护自愈先行恢复属正常设计）

## 变更文件
11 files changed, +1080/-101