### PR TITLE
docs: README 底部新增协作者头像（自动更新）与 Star 曲线图

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,35 @@
+name: Contributors
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update contributors (README.md)
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        with:
+          readme_path: README.md
+          columns_per_row: 8
+          image_size: 100
+          use_username: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update contributors (README.en.md)
+        uses: akhilmhdh/contributors-readme-action@v2.3.11
+        with:
+          readme_path: README.en.md
+          columns_per_row: 8
+          image_size: 100
+          use_username: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.en.md
+++ b/README.en.md
@@ -197,6 +197,21 @@ openclaw-dsh-bridge/          # WeChat bridge plugin (optional, research-grade)
 research/                     # Third-party WeChat / bridge protocol research
 ```
 
+## Contributors
+
+Thanks to every contributor:
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
+## Star History
+
+<p align="center">
+  <a href="https://star-history.com/#zouyuxuan122/Deepseek-Harness-EAC&Date">
+    <img src="https://api.star-history.com/svg?repos=zouyuxuan122/Deepseek-Harness-EAC&type=Date" alt="Star History Chart">
+  </a>
+</p>
+
 ## License
 
 MIT. Based on [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (MIT). Built-in skins are owned by their original authors (see the skin license table above).

--- a/README.md
+++ b/README.md
@@ -247,8 +247,18 @@ research/                     # 第三方微信/桥接协议调研资料
 
 ## Contributors
 
-- [@zouyuxuan122](https://github.com/zouyuxuan122) — 项目发起者与维护者
-- [@Luoye-hb](https://github.com/Luoye-hb) — Linux 多发行版打包支持（[PR #12](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/pull/12)）
+感谢每一位贡献者：
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
+## Star History
+
+<p align="center">
+  <a href="https://star-history.com/#zouyuxuan122/Deepseek-Harness-EAC&Date">
+    <img src="https://api.star-history.com/svg?repos=zouyuxuan122/Deepseek-Harness-EAC&type=Date" alt="Star History Chart">
+  </a>
+</p>
 
 ## License
 


### PR DESCRIPTION
## 内容
- 新增 `.github/workflows/contributors.yml`：push 到 main 后自动从 GitHub API 拉取协作者头像网格（`akhilmhdh/contributors-readme-action@v2.3.11`），中英两份 README 各自更新；main 有 review 保护时 action 自动以 PR 形式提交更新
- `README.md` / `README.en.md`：Contributors 区替换为 action 锚点（`<!-- readme: contributors -->`），新增 Star History 曲线图（star-history.com 实时 SVG，零维护）

## 效果
- 合并后 action 自动运行，8 位协作者头像网格写入两份 README；未来新协作者免维护
- Star 图实时反映仓库 star 增长（当前 990 stars）

## 验证
- 合并后到 Actions 页确认 Contributors 运行成功，并检查其自动开的 README 更新 PR