### PR TITLE
fix: 退役内置插件清理识别 dsh 官方「空块项+独立id」patch 格式

### DIFF
--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "dsh-desktop",
   "productName": "Deepseek Harness EAC",
   "version": "4.6.0",

--- a/dsh-desktop/scripts/plugin-manager-patch.js
+++ b/dsh-desktop/scripts/plugin-manager-patch.js
@@ -39,14 +39,51 @@ function entryIndentOf(line, id, indentLo, indentHi) {
 }
 
 /**
- * 在行数组中定位第一个满足层级的 `- id: <id>` 条目块。
+ * 行是否是指定 id 的「空块项 + 独立 id」条目起始行（dsh 官方 patch 常用写法）：
+ *     -
+ *         id: <id>
+ *         name: '…'
+ * 即一行只有 `-`（无内联内容），其后的非空行若以 `id: <id>` 开头即命中。
+ * 返回空块项 `-` 行的缩进（作为条目块语义缩进；id/name 行都更深），
+ * 否则 null；indentLo/Hi 限定该空块项层级。
+ */
+function dashEntryIndentOf(lines, i, id, indentLo, indentHi) {
+  const line = lines[i];
+  const [, dashWs, dashRest] = LEADING.exec(line);
+  if (!/^-\s*$/.test(dashRest)) return null; // 不是纯 `-` 空块项
+  const next = lines[i + 1];
+  if (next === undefined) return null;
+  const [, nextWs, nextRest] = LEADING.exec(next);
+  const trimmed = nextRest.replace(/^[ \t]+/, '');
+  const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp('^id:\\s*' + escapedId + '(?![A-Za-z0-9_.-])').exec(trimmed);
+  if (!m) return null;
+  const dashIndent = dashWs.length;
+  const idIndent = nextWs.length;
+  // 空块项必须浅于 id 行（id/name 都是它的内容）
+  if (idIndent <= dashIndent) return null;
+  if (dashIndent < indentLo || dashIndent > indentHi) return null;
+  return dashIndent;
+}
+
+/**
+ * 在行数组中定位第一个满足层级的 `<id>` 条目块。支持两种书写等价格式：
+ *   ① `- id: <id>`        —— EAC sync 单行写形；
+ *   ② `-` 空块项 + 独立 `id:` 行 —— dsh 官方 profile 的多行写形。
  * 返回 { start, end, indent }（end 为独占下界）：块 = 起始行 + 其后所有
- * 缩进比起始行更深的非空行（空行视为块结束，保守不吞）。
+ * 缩进足够深的属性行（空行视为块结束，保守不吞）。
  */
 function findEntryBlock(lines, id, indentLo, indentHi) {
   for (let i = 0; i < lines.length; i++) {
-    const ind = entryIndentOf(lines[i], id, indentLo, indentHi);
-    if (ind === null) continue;
+    let ind = entryIndentOf(lines[i], id, indentLo, indentHi);
+    let blockStart = i;
+    if (ind === null) {
+      const d = dashEntryIndentOf(lines, i, id, indentLo, indentHi);
+      if (d === null) continue;
+      ind = d;
+      blockStart = i; // `-` 空块项行
+      i += 1; // 下一行（id 行）纳入块
+    }
     let j = i + 1;
     while (j < lines.length) {
       const [, ws, rest] = LEADING.exec(lines[j]);
@@ -54,7 +91,7 @@ function findEntryBlock(lines, id, indentLo, indentHi) {
       if (ws.length <= ind) break; // 兄弟条目或外层结构：块结束
       j += 1;
     }
-    return { start: i, end: j, indent: ind };
+    return { start: blockStart, end: j, indent: ind };
   }
   return null;
 }

--- a/dsh-desktop/test/plugin-manager-toggle.test.mjs
+++ b/dsh-desktop/test/plugin-manager-toggle.test.mjs
@@ -100,3 +100,50 @@ test('移除：id 白名单校验（防注入）', () => {
   assert.throws(() => removePluginFromPatch('- insert:\n', 'a b'), /非法字符/);
   assert.throws(() => removePluginFromPatch('', '../evil'), /非法字符/);
 });
+
+// —— dsh 官方「空块项 + 独立 id」多行格式（web-desktop profile 实际写法）——
+
+test('移除：dsh 官方 `-` 空块项 + 独立 id 格式（退役 tdai-memory 场景）', () => {
+  const t =
+    '-\n' +
+    '    insert:\n' +
+    '        -\n' +
+    '            id: tdai-memory\n' +
+    '            name: \'dsh-tdai-memory\'\n' +
+    '-\n' +
+    '    insert:\n' +
+    '        -\n' +
+    '            id: mobile-fix\n' +
+    '            name: \'dsh-web-mobile-fix\'\n';
+  assert.equal(hasEntryId(t, 'tdai-memory'), true, '应识别空块项格式的 tdai-memory');
+  const r = removePluginFromPatch(t, 'tdai-memory');
+  assert.equal(hasEntryId(r, 'tdai-memory'), false, 'tdai-memory 应被移除');
+  assert.ok(r.includes('mobile-fix'), '兄弟条目 mobile-fix 必须保留');
+  assert.ok(!/name:\s*dsh-tdai-memory/.test(r), '不得残留孤立 name 行');
+  assert.ok(!r.includes('tdai-memory'), '整块（含 name）都应清除');
+});
+
+test('移除：dsh 官方格式删 picturereader（web profile 重复挂载清理场景）', () => {
+  const t =
+    '- insert:\n' +
+    '    - id: worktree\n' +
+    "      name: 'dsh-worktree'\n" +
+    '- insert:\n' +
+    '    - id: picturereader\n' +
+    "      name: 'picturereader'\n";
+  assert.equal(hasEntryId(t, 'picturereader'), true);
+  const r = removePluginFromPatch(t, 'picturereader');
+  assert.equal(hasEntryId(r, 'picturereader'), false);
+  assert.ok(r.includes('worktree'), 'worktree 必须保留');
+});
+
+test('hasEntryId：dsh 官方空块项格式命中与短 id 前缀不误配', () => {
+  const t =
+    '-\n' +
+    '    insert:\n' +
+    '        -\n' +
+    '            id: dsh-pet-settings\n' +
+    '            name: \'dsh-pet-settings\'\n';
+  assert.equal(hasEntryId(t, 'dsh-pet'), false, '短 id 不得命中长 id 兄弟（空块项格式）');
+  assert.equal(hasEntryId(t, 'dsh-pet-settings'), true, '完整 id 应命中空块项格式');
+});


### PR DESCRIPTION
## 问题

应用升级到 4.4.1 后，内置插件 **tdai-memory** 退役时**只删包不删挂载行**，导致：

- 插件树加载时按残留的 patch 行 import 已被删除的包 → **启动即崩**（`Cannot find package 'dsh-tdai-memory'`）；
- web-desktop 与 web (CLI) profile 的 `cordis.patch.yml` 里 picturereader 等行同样无法被精确删除，重复挂载（overlay+bundles）残留 → **duplicate loader entry 崩**。

## 根因

dsh 官方 profile 的 `cordis.patch.yml` 使用 **「`-` 空块项 + 独立缩进 `id:`」多行 YAML 写法**（等价于 EAC 的 `- id:` 单行）：

```yaml
-
    insert:
        -
            id: tdai-memory
            name: 'dsh-tdai-memory'
```

而 `plugin-manager-patch.js` 的 `findEntryBlock` 只认 `- id:` 单行格式，**识别不了 dsh 官方多行格式**，导致退役清理（`retireRemovedBuiltinPlugins`）删不掉行。

（补充：`hasEntryId` 用宽松正则能命中，但 `removePluginFromPatch` 用严格 `- id:` 同行匹配删不掉，判断与删除不一致。）

## 修复

`findEntryBlock` / 新增 `dashEntryIndentOf` 支持「`-` 空块项 + 独立 `id:` 行」块格式识别（块语义缩进取空块项行，id/name 为更深内容），保持原有 `- id:` 单行格式不回归。

## 顺带

`dsh-desktop/package.json` 移除历史残留的 UTF-8 BOM（此前 picturereader 提交以 PowerShell 写入引入），`JSON.parse` 恢复正常，`better-sidebar-bundle` 测试通过。

## 测试

- `plugin-manager-toggle`：15/15（新增 3 例 dsh 官方格式：删 tdai-memory、删 picturereader、hasEntryId 短 id 前缀）
- 全套：**533/533 通过**