### PR TITLE
fix：修复dsh web 重启时 ERR_STREAM_WRITE_AFTER_END

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -19,6 +19,19 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 
 ## [4.6.0] · 2026-08-20
 
+### 修复：dsh web 重启时日志流重复写入（#137）
+- 根因：子进程的 `exit` 事件可能早于 stdout/stderr 管道排空；旧实现收到
+  `exit` 后立即 `end()` 日志文件，尾部 `data` 随后继续写入，触发
+  `ERR_STREAM_WRITE_AFTER_END`，在受限端口换端口重启和应用退出时尤其容易复现。
+- 修复：业务退出处理仍由 `exit` 驱动，但日志文件延后到 stdio 全部关闭后的
+  `close` 事件再结束；新增统一 Writable 生命周期保护，同时覆盖
+  `dsh-web.log` 与 `desktop.log`，迟到写入会被安全拒绝且保留关闭前尾部日志。
+- 调试期间一并修复隔离 DSH_HOME 初始化时 `home` 未定义，以及 Windows
+  CRLF/BOM 格式 `cordis.patch.yml` 无法清理退役插件的问题，保证重启后的新
+  dsh web 实例可以完整启动。
+- 验证：新增独立复现脚本 `scripts/debug-stream-write-after-end.js` 与流时序回归
+  测试；强制受限端口重启后新实例正常就绪，完整测试 538 项全部通过。
+
 ### 新增：AI 主动修复（一键全自动）
 - 救援页新增「AI 自动修复」按钮：一键串联 诊断 → AI 分析 → 自动执行修复 →
   自动重启 全链路，最多迭代两轮；高风险动作（回滚/卸载）自动跳过，多轮

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -42,6 +42,7 @@ files:
   - error-detail.js
   - bundle-integrity.js
   - stable-port.js
+  - stream-write-guard.js
   - koffi-preflight.js
   - renderer-recovery.js
   - watchdog.js

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -34,6 +34,7 @@ const rescueAgent = require('./rescue-agent');
 const bundleIntegrity = require('./bundle-integrity');
 const { RendererRecovery } = require('./renderer-recovery');
 const { restrictedPortOf, chooseStableWebPort } = require('./stable-port');
+const { createStreamWriteGuard } = require('./stream-write-guard');
 const {
   STANDARD_SHORTCUT_NAME,
   RUNTIME_SHORTCUT_DESCRIPTION,
@@ -125,6 +126,7 @@ let userDataDir = '';
 let logsDir = '';
 let dshHome = '';
 let desktopLog = null;
+let desktopLogGuard = null;
 let tray = null;
 let forceQuit = false;
 let clientUpdateBusy = false;
@@ -178,6 +180,7 @@ function desktopProfileDir() {
 // 创建：package.json（bundles）+ pnpm-workspace.yaml + 空 patch 层。
 function ensureDesktopProfileInit() {
   try {
+    const home = dshHome || path.join(os.homedir(), '.dsh');
     const dir = desktopProfileDir();
     if (desktopProfile() === 'web') return; // 共享模式走官方模板
     fs.mkdirSync(dir, { recursive: true });
@@ -248,7 +251,7 @@ function log(tag, msg) {
     `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}` +
     ` UTC${sign}${p(Math.floor(Math.abs(off) / 60))}:${p(Math.abs(off) % 60)}`;
   const line = `[${ts}] [${tag}] ${msg}\n`;
-  try { if (desktopLog) desktopLog.write(line); } catch {}
+  if (desktopLogGuard) desktopLogGuard.write(line);
   if (process.env.DSH_DESKTOP_DEBUG) process.stdout.write(line);
   try {
     const level = /^(warn|warning|err|error|fatal)$/i.test(tag) ? 'warn'
@@ -774,12 +777,15 @@ function watchServerProc(proc, out, opts = {}) {
     let settled = false;
     let handedOff = false; // 受限端口重启：本实例的退出不再影响外层 Promise/弹窗
     let bootTimer = null;
+    const output = createStreamWriteGuard(out, {
+      onError: (err) => log('warn', 'dsh web 日志流异常: ' + String(err && err.message || err)),
+    });
     const finish = (fn, value) => {
       if (!settled) { settled = true; fn(value); }
       if (bootTimer) { clearTimeout(bootTimer); bootTimer = null; }
     };
     const onData = (chunk) => {
-      out.write(chunk);
+      output.write(chunk);
       const text = chunk.toString();
       for (const line of text.split(/\r?\n/)) {
         const m = line.match(/dsh web:\s+(https?:\/\/\S+)/);
@@ -820,9 +826,17 @@ function watchServerProc(proc, out, opts = {}) {
         finish(resolve, m[1]);
       }
     };
+    const onStderrData = (chunk) => output.write(chunk);
     proc.stdout.on('data', onData);
-    proc.stderr.on('data', (c) => out.write(c));
+    proc.stderr.on('data', onStderrData);
     proc.on('error', (err) => finish(reject, err));
+    // ChildProcess 的 close 在 exit 之后、stdio 全部关闭后触发。此时再结束
+    // 文件流既能保留尾部输出，也不会让迟到的 data 写入已 end 的 Writable。
+    proc.once('close', () => {
+      proc.stdout.removeListener('data', onData);
+      proc.stderr.removeListener('data', onStderrData);
+      output.end();
+    });
     // V4：HTTP 就绪探测与 stdout 就绪行并行竞争 —— 就绪行被管道缓冲吞掉
     // 或格式变化时不再白白等满 bootTimer（「启动 60 秒超时」的主要假阳性
     // 来源）。expectedPort 由 chooseStableWebPort 挑选、已避开 Chromium
@@ -846,7 +860,6 @@ function watchServerProc(proc, out, opts = {}) {
       })();
     }
     proc.on('exit', (code, signal) => {
-      out.end();
       log('dsh', `进程退出 code=${code} signal=${signal}`);
       // 原地重启（插件市场）或已替换为新进程时，不打扰用户、也不清掉新进程的句柄。
       const intentional = restartingServer || serverProc !== proc;
@@ -4944,6 +4957,10 @@ async function boot() {
     try { console.error('[logger.init fail]', e && e.message); } catch {}
   }
   desktopLog = fs.createWriteStream(path.join(logsDir, 'desktop.log'), { flags: 'a' });
+  desktopLogGuard = createStreamWriteGuard(desktopLog, {
+    // 不能调用 log()，否则日志流错误会递归写入同一个流。
+    onError: (err) => { try { console.error('[desktop.log]', err && err.message || err); } catch {} },
+  });
   log('boot', `Deepseek Harness EAC（封装 ${APP_VERSION}）  userData=${userDataDir}  dshHome=${dshHome || '(dsh 默认)'}  agent=${dshVersion()}(${dshVersionSource()})`);
 
   // 移除原生菜单栏（文件/视图/帮助），全部功能由自绘 chrome 与托盘提供。
@@ -5098,7 +5115,7 @@ if (!gotLock) {
         // 日志系统 flush：结构化 logger 先关（flush 缓冲区+结束 rotation stream），
         // 再关 desktop.log 纯文本，保证退出前两条通道都落盘。
         try { structuredLogger.close(); } catch {}
-        try { if (desktopLog) desktopLog.end(); } catch {}
+        if (desktopLogGuard) desktopLogGuard.end();
         app.exit(0);
       }
     })();

--- a/dsh-desktop/scripts/check-syntax.js
+++ b/dsh-desktop/scripts/check-syntax.js
@@ -24,6 +24,7 @@ const entryFiles = [
   'watchdog.js',
   'shortcut-maintenance.js',
   'stable-port.js',
+  'stream-write-guard.js',
   'koffi-preflight.js',
   'profile-module-heal.js',
   'patch-row-heal.js',

--- a/dsh-desktop/scripts/debug-stream-write-after-end.js
+++ b/dsh-desktop/scripts/debug-stream-write-after-end.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { once } = require('node:events');
+const { Writable } = require('node:stream');
+const { createStreamWriteGuard } = require('../stream-write-guard');
+
+function sink() {
+  return new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+}
+
+async function reproduceUnsafeWrite() {
+  const stream = sink();
+  stream.end();
+  const errorPromise = once(stream, 'error');
+  stream.write('late child output');
+  const [err] = await errorPromise;
+  return err;
+}
+
+async function verifyGuardedWrite() {
+  const stream = sink();
+  const errors = [];
+  const guard = createStreamWriteGuard(stream, { onError: (err) => errors.push(err) });
+  guard.end();
+  const accepted = guard.write('late child output');
+  await once(stream, 'finish');
+  return { accepted, errors };
+}
+
+(async () => {
+  const unsafeError = await reproduceUnsafeWrite();
+  console.log(`[repro] unprotected: ${unsafeError.code} (${unsafeError.message})`);
+
+  const guarded = await verifyGuardedWrite();
+  if (guarded.accepted || guarded.errors.length > 0) {
+    throw new Error('guarded stream accepted a late write or emitted an error');
+  }
+  console.log('[repro] guarded: late write rejected without stream error');
+})().catch((err) => {
+  console.error('[repro] FAIL', err);
+  process.exitCode = 1;
+});

--- a/dsh-desktop/scripts/plugin-manager-patch.js
+++ b/dsh-desktop/scripts/plugin-manager-patch.js
@@ -26,12 +26,14 @@ function yamlQuote(s) {
   return "'" + String(s).replace(/'/g, "''") + "'";
 }
 
-const LEADING = /^([ \t]*)(.*)$/;
+// split('\n') 会在 Windows 文本中保留行尾 \r；显式接纳它，避免逐行
+// 解析返回 null。首行 BOM 也可能出现在用户/PowerShell 写入的 patch 中。
+const LEADING = /^([ \t]*)(.*)\r?$/;
 
 /** 行是否是指定 id 的条目起始行；返回缩进宽度，否则 null。indentLo/Hi 限定层级。 */
 function entryIndentOf(line, id, indentLo, indentHi) {
   const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const m = new RegExp('^- id:\\s*' + escapedId + '(?![A-Za-z0-9_.-])').exec(line.replace(/^[ \t]+/, ''));
+  const m = new RegExp('^- id:\\s*' + escapedId + '(?![A-Za-z0-9_.-])').exec(line.replace(/^\uFEFF/, '').replace(/^[ \t]+/, ''));
   if (!m) return null;
   const ind = LEADING.exec(line)[1].length;
   if (ind < indentLo || ind > indentHi) return null;
@@ -50,7 +52,7 @@ function entryIndentOf(line, id, indentLo, indentHi) {
 function dashEntryIndentOf(lines, i, id, indentLo, indentHi) {
   const line = lines[i];
   const [, dashWs, dashRest] = LEADING.exec(line);
-  if (!/^-\s*$/.test(dashRest)) return null; // 不是纯 `-` 空块项
+  if (!/^-\s*$/.test(dashRest.replace(/^\uFEFF/, ''))) return null; // 不是纯 `-` 空块项
   const next = lines[i + 1];
   if (next === undefined) return null;
   const [, nextWs, nextRest] = LEADING.exec(next);

--- a/dsh-desktop/stream-write-guard.js
+++ b/dsh-desktop/stream-write-guard.js
@@ -1,0 +1,55 @@
+'use strict';
+
+function createStreamWriteGuard(stream, opts = {}) {
+  if (!stream || typeof stream.write !== 'function' || typeof stream.end !== 'function') {
+    throw new TypeError('createStreamWriteGuard: writable stream is required');
+  }
+
+  const onError = typeof opts.onError === 'function' ? opts.onError : () => {};
+  let closing = false;
+  let ended = false;
+
+  const report = (err) => {
+    try { onError(err); } catch {}
+  };
+
+  // Writable failures, including write-after-end, are commonly emitted
+  // asynchronously and cannot be contained by a try/catch around write().
+  stream.on('error', report);
+
+  return {
+    write(chunk) {
+      if (closing || ended || stream.destroyed || stream.writableEnded || stream.writable === false) {
+        return false;
+      }
+      try {
+        return stream.write(chunk);
+      } catch (err) {
+        report(err);
+        return false;
+      }
+    },
+
+    end() {
+      if (closing || ended) return false;
+      closing = true;
+      if (stream.destroyed || stream.writableEnded) {
+        ended = true;
+        return false;
+      }
+      try {
+        stream.end(() => { ended = true; });
+        return true;
+      } catch (err) {
+        ended = true;
+        report(err);
+        return false;
+      }
+    },
+
+    get closing() { return closing; },
+    get ended() { return ended || stream.writableEnded || stream.destroyed; },
+  };
+}
+
+module.exports = { createStreamWriteGuard };

--- a/dsh-desktop/test/better-sidebar-bundle.test.mjs
+++ b/dsh-desktop/test/better-sidebar-bundle.test.mjs
@@ -47,6 +47,16 @@ test('schemastery (the plugin\'s only missing server dep) is declared', () => {
     'schemastery must be in dependencies for fallback junction resolution');
 });
 
+test('desktop profile initialization resolves the DSH home before linking schemastery', () => {
+  const main = readFileSync(join(ROOT, 'main.js'), 'utf8');
+  const start = main.indexOf('function ensureDesktopProfileInit()');
+  const end = main.indexOf('\n}\n', start);
+  const body = main.slice(start, end);
+  assert.match(body, /const home = dshHome \|\| path\.join\(os\.homedir\(\), '\.dsh'\)/,
+    'ensureDesktopProfileInit must define home before path.join(home, ...)');
+  assert.match(body, /path\.join\(home, 'profiles', 'node_modules'\)/);
+});
+
 // issue #14 / zcode 报告：app 层声明不足以让 fallback 闭包（BFS 起点是
 // 捆绑的 dsh 包 package.json）包含 schemastery → 全新安装后
 // profiles/node_modules 永远缺 junction → dsh web 启动即崩（退出码 1）。

--- a/dsh-desktop/test/plugin-manager-toggle.test.mjs
+++ b/dsh-desktop/test/plugin-manager-toggle.test.mjs
@@ -147,3 +147,17 @@ test('hasEntryId：dsh 官方空块项格式命中与短 id 前缀不误配', ()
   assert.equal(hasEntryId(t, 'dsh-pet'), false, '短 id 不得命中长 id 兄弟（空块项格式）');
   assert.equal(hasEntryId(t, 'dsh-pet-settings'), true, '完整 id 应命中空块项格式');
 });
+
+test('移除：兼容带 BOM 的 Windows CRLF patch', () => {
+  const t =
+    '\uFEFF- insert:\r\n' +
+    '    - id: tdai-memory\r\n' +
+    "      name: 'dsh-tdai-memory'\r\n" +
+    '- insert:\r\n' +
+    '    - id: mobile-fix\r\n' +
+    "      name: 'dsh-web-mobile-fix'\r\n";
+  const r = removePluginFromPatch(t, 'tdai-memory');
+  assert.equal(hasEntryId(r, 'tdai-memory'), false);
+  assert.equal(hasEntryId(r, 'mobile-fix'), true);
+  assert.ok(r.includes('\r\n'), '应保留 Windows CRLF 换行');
+});

--- a/dsh-desktop/test/stream-write-after-end.test.mjs
+++ b/dsh-desktop/test/stream-write-after-end.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter, once } from 'node:events';
+import { Writable } from 'node:stream';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { createStreamWriteGuard } = require(join(root, 'stream-write-guard.js'));
+
+function recordingWritable() {
+  const chunks = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { stream, chunks };
+}
+
+test('guard ignores a data chunk that arrives after end', async () => {
+  const { stream, chunks } = recordingWritable();
+  const errors = [];
+  const guard = createStreamWriteGuard(stream, { onError: (err) => errors.push(err) });
+
+  assert.equal(guard.write('before-close'), true);
+  assert.equal(guard.end(), true);
+  assert.equal(guard.write('late-data'), false);
+  await once(stream, 'finish');
+
+  assert.deepEqual(chunks, ['before-close']);
+  assert.deepEqual(errors, []);
+});
+
+test('child close ordering keeps output emitted after exit and closes once', async () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  const { stream, chunks } = recordingWritable();
+  const guard = createStreamWriteGuard(stream);
+  let endCalls = 0;
+
+  child.stdout.on('data', (chunk) => guard.write(chunk));
+  child.stderr.on('data', (chunk) => guard.write(chunk));
+  child.once('close', () => {
+    endCalls++;
+    guard.end();
+  });
+
+  child.emit('exit', 1, null);
+  child.stdout.emit('data', 'stdout-tail');
+  child.stderr.emit('data', 'stderr-tail');
+  child.emit('close', 1, null);
+  child.emit('close', 1, null);
+  await once(stream, 'finish');
+
+  assert.deepEqual(chunks, ['stdout-tail', 'stderr-tail']);
+  assert.equal(endCalls, 1);
+  assert.equal(guard.write('too-late'), false);
+});
+
+test('unprotected Writable reproduces ERR_STREAM_WRITE_AFTER_END', async () => {
+  const { stream } = recordingWritable();
+  stream.end();
+  const errorPromise = once(stream, 'error');
+  stream.write('late-data');
+  const [err] = await errorPromise;
+
+  assert.equal(err.code, 'ERR_STREAM_WRITE_AFTER_END');
+});


### PR DESCRIPTION
## 摘要

修复 Issue #137 中 dsh web 重启或退出时可能触发的
`ERR_STREAM_WRITE_AFTER_END`，并补充对应的复现脚本和回归测试。

Fixes #137

## 问题

子进程的 `exit` 事件可能早于 stdout/stderr 管道排空。旧实现收到 `exit` 后
立即结束日志流，导致随后到达的尾部数据继续写入已关闭的 Writable，从而触发
`ERR_STREAM_WRITE_AFTER_END`。

调试时还发现隔离 DSH_HOME 初始化引用未定义变量，以及 Windows CRLF/BOM
格式的 `cordis.patch.yml` 无法正确解析。

## 修复

- 等待子进程 `close` 后再结束日志流，保留 stdout/stderr 尾部数据。
- 新增 Writable 生命周期保护，拒绝日志流关闭后的迟到写入。
- 同时保护 `dsh-web.log` 和 `desktop.log`。
- 修复隔离 DSH_HOME 初始化及 Windows CRLF/BOM 配置解析问题。
- 将新增模块加入 Electron 打包清单和语法检查。

## 验证

- 独立脚本成功复现未保护流的 `ERR_STREAM_WRITE_AFTER_END`。
- 保护后的日志流能够安全拒绝迟到写入。
- 强制触发受限端口重启后，新 dsh web 实例正常就绪。
- 入口语法检查和 `git diff --check` 通过。
- 完整测试结果：538 passed，0 failed。