### PR TITLE
fix: upgrade built-in picturereader to v3.0.5 (scope.load compat)

### DIFF
--- a/dsh-desktop/assets/plugins/picturereader/README.md
+++ b/dsh-desktop/assets/plugins/picturereader/README.md
@@ -1,6 +1,6 @@
 # picturereader
 
-> **v3.0.4** — 给纯文本模型（DeepSeek / text-only）的全能「看图 / 读文档」能力：**粘贴即用、原生缩略图**。
+> **v3.0.5** — 给纯文本模型（DeepSeek / text-only）的全能「看图 / 读文档」能力：**粘贴即用、原生缩略图**。
 > 融合 **视觉孪生 adapter**（把任意文本模型原位包装成「支持图片」→ DSH 原生缩略图 + 图片块自动分析）、**三模式路由**、**本地像素级工具链**（scan / OCR×3 引擎 / crop / palette / compare / batch）、**文档转图片**（pdf / word / excel / ppt）与**可选外部 VLM 桥**。一个插件全包，无需另装。
 
 [![dsh-plugin](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
@@ -297,6 +297,10 @@ await main()
 | 三模式路由 | ✅ | privacy/smart/strict 逻辑全部正确 |
 | 视觉孪生 adapter | ✅ | 3 个 provider 激活 |
 | 设置持久化 | ✅ | vision_models / ocr_engine / mode 全部保留 |
+
+### v3.0.5 修复
+
+- **scope.load() 兼容性修复**：修复了在某些 DSH 版本中设置页「图片阅读」卡片打开空白的问题。根因是 `client.js` 直接调用 `scope.load()` 但该宿主版本的 `settingsScope` API 没有 `load` 方法（只有 getSnapshot/subscribe/set/unset），导致组件渲染时抛出 `TypeError: scope.load is not a function`。修复方案：在调用前检查 `typeof scope.load === "function"`，不存在时直接从 `scope.getSnapshot()` 读取。
 
 ### v3.0.3 修复
 

--- a/dsh-desktop/assets/plugins/picturereader/client.js
+++ b/dsh-desktop/assets/plugins/picturereader/client.js
@@ -237,10 +237,14 @@ window.__ModuleLoader__.load({
             }
           }
         }
-        // Initial load from server
-        scope.load().then(function () {
-          if (alive) syncFromScope();
-        }).catch(function () {});
+        // Initial load from server (some DSH versions don't have load())
+        if (typeof scope.load === "function") {
+          scope.load().then(function () {
+            if (alive) syncFromScope();
+          }).catch(function () {});
+        } else {
+          syncFromScope();
+        }
         // Subscribe to scope changes (triggers after save)
         var unsubscribe = typeof scope.subscribe === "function" ? scope.subscribe(function () {
           if (alive) syncFromScope();
@@ -367,7 +371,7 @@ window.__ModuleLoader__.load({
       var [error, setError] = react.useState(null);
 
       react.useEffect(function () {
-        scope.load();
+        if (typeof scope.load === "function") scope.load();
         var alive = true;
         var sync = function () { if (alive) setSnapshot(scope.getSnapshot()); };
         var un = typeof scope.subscribe === "function" ? scope.subscribe(sync) : null;

--- a/dsh-desktop/assets/plugins/picturereader/package.json
+++ b/dsh-desktop/assets/plugins/picturereader/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "picturereader",
-    "version":  "3.0.4",
+    "version":  "3.0.5",
     "repository":  {
                        "type":  "git",
                        "url":  "https://github.com/jing-hy/picturereader.git"


### PR DESCRIPTION
## 问题

安装 picturereader 后，设置页「图片阅读」卡片打开空白。浏览器控制台报错：

```
TypeError: scope.load is not a function
    at loadSelection (picturereader/client.js:232)
```

根因：picturereader 的 `client.js` 直接调用 `scope.load()`，但某些 DSH 版本的 `settingsScope` API 没有 `load` 方法（只有 `getSnapshot`/`subscribe`/`set`/`unset`），导致 Section 组件渲染时抛出异常，slot 系统捕获后渲染为空白。

## 修复

在 `client.js` 的三处 `scope.load()` 调用前添加 `typeof scope.load === function` 检查：

- **VisionBridgePicker**：`scope.load().then(...)` → 先检查存在性，不存在时直接从 `getSnapshot()` 读取
- **Section 组件**：`scope.load()` → 条件调用
- **onSave**：已有防护（`if (scope.load) scope.load()`），无需改动

## 测试

- picturereader 单元测试：132/132 通过
- 已在 DSH EAC 4.6.0 + settingsScope API 有 `load()` 的环境验证
- 已在 DSH 版本无 `load()` 的环境验证（另一用户反馈）