### PR TITLE
feat: 新增 dsh-compact 上下文压缩插件

### DIFF
--- a/docs/superpowers/specs/2026-08-21-dsh-compact-design.md
+++ b/docs/superpowers/specs/2026-08-21-dsh-compact-design.md
@@ -1,0 +1,179 @@
+# dsh-compact 设计
+
+## 目标
+
+新增符合 DeepSeek Harness 插件规范的 `dsh-compact`，取代 EAC 现有的
+`dsh-auto-compact`。新插件不再从浏览器输入框自动发送 `/compact`，而是在
+Agent 请求链中成为唯一的压缩服务：
+
+- 请求发送前按真实会话 Token 压力自动压缩；
+- 收到 `CONTEXT_WINDOW_EXCEEDED` 后强制压缩，并且只重试原请求一次；
+- 继续复用 DSH 的 `BasicCompactionEngine`，不另写历史替换和摘要事务；
+- 保留标准 `/compact` 命令；
+- 同时支持 EAC 内置分发和普通 DSH preset 手动接入。
+
+## 架构
+
+插件包：
+
+```text
+dsh-compact/
+├─ package.json
+├─ cordis.patch.yml
+├─ LICENSE
+└─ lib/
+   ├─ index.js
+   ├─ engine.js
+   ├─ policy.js
+   └─ client.js
+```
+
+- `lib/index.js`：在 host-plane 注册 `dsh-compact` 设置命名空间和可选 Web
+  状态接口。
+- `lib/engine.js`：导出 `DshCompactEngine`，继承
+  `@deepseek-ai/dsh-compaction-basic` 的 `BasicCompactionEngine`。
+- `lib/policy.js`：配置净化、模型专属策略和压缩状态辅助逻辑。
+- `lib/client.js`：设置页和当前会话压缩状态，不模拟输入 `/compact`。
+- `cordis.patch.yml`：只注册 host/client；Agent preset 必须显式使用
+  `dsh-compact/engine`，以保证每个 Agent realm 只有一个 `ctx.compaction`。
+
+## 默认策略
+
+```yaml
+dsh-compact:
+  enabled: true
+  thresholdRatio: 0.75
+  retainRatio: 0.20
+  recoverOnOverflow: true
+  maxOverflowRetries: 1
+  modelPolicies: []
+```
+
+- 自动阈值默认 75%；
+- 压缩后默认保留最近约 20%；
+- 普通压力压缩最多再尝试一次；
+- 上下文溢出最多恢复并重试一次；
+- 模型没有可靠 `contextWindow` 时记录诊断，不猜容量；
+- 配置按请求读取，正在执行的压缩固定使用启动时快照。
+
+## 请求前压缩
+
+`DshCompactEngine` 使用父类已验证的 Token 计量、工具结果裁剪、安全范围选择、
+tool call/result 配对保护、摘要生成和持久化事务。它用动态策略覆盖父类的静态
+配置，并继续在 `agent/pre-step` 执行：
+
+1. 读取当前有效设置和当前 provider/model 的覆盖策略；
+2. 使用 `tokenMeter.measure(session)` 计算真实表面压力；
+3. 解析模型真实 `contextWindow`；
+4. 达到阈值时先运行 `toolResultPruner`；
+5. 再次测量后选择安全旧历史并生成摘要；
+6. 落盘后重新测量，必要时再压缩一次；
+7. 成功后继续原模型请求。
+
+## 溢出恢复
+
+收到 `CONTEXT_WINDOW_EXCEEDED` 时：
+
+1. 当前请求若已恢复过一次，保留原错误并停止；
+2. 忽略普通阈值，先裁剪工具结果；
+3. 强制选择一段安全历史压缩；
+4. 确认 session surface 的 replacement generation 前进；
+5. 返回 Agent loop 的 `{ kind: "retry" }`，自动重试原请求；
+6. 不重复添加用户消息，不无限重试。
+
+摘要失败、无安全范围、取消或压缩后没有实际缩小时，保留原始请求错误。
+
+## 状态与 UI
+
+状态按 `sessionId` 隔离：
+
+```text
+idle → measuring → pruning → summarizing → committing → recovered
+                                                  └→ failed
+```
+
+状态由宿主服务保存。Web Server 存在时提供：
+
+- `GET /plugins/dsh-compact/status?sessionId=...`
+- `POST /plugins/dsh-compact/compact-now`
+
+手动压缩通过当前 Agent preset 的 `ctx.compaction.compactNow()` 执行，不写输入框。
+Headless DSH 没有 Web UI 时仍可自动压缩并使用标准 `/compact`。
+
+设置页提供：
+
+- 自动压缩开关；
+- 触发阈值和保留比例；
+- 溢出恢复开关；
+- provider/model 专属策略；
+- 当前 preset 是否启用 `dsh-compact`；
+- 当前会话真实状态；
+- “立即压缩”按钮。
+
+## EAC 迁移
+
+- 从 `COMPANION_PLUGINS` 删除 `dsh-auto-compact`；
+- 将其加入退役插件清理列表；
+- 新增 `dsh-compact` 内置分发；
+- 将 EAC 自带 Agent preset 中完全匹配的：
+
+  ```yaml
+  id: compaction-basic
+  name: '@deepseek-ai/dsh-compaction-basic'
+  ```
+
+  替换为：
+
+  ```yaml
+  id: compaction-basic
+  name: 'dsh-compact/engine'
+  ```
+
+- 已安装的 EAC 内置 preset 使用语法解析后迁移，首次改动前保留 `.bak`；
+- 用户未知的自定义 preset 不自动修改；
+- 迁移必须幂等，解析失败只记录诊断，不破坏原文件；
+- 旧 localStorage 配置只由客户端做一次清理，不迁移为错误的宿主设置。
+
+普通 DSH 用户安装包后，在所用 Agent preset 中手动替换压缩引擎行。
+
+## 配置校验
+
+- `thresholdRatio`：0.50–0.95；
+- `retainRatio`：0.05–0.50；
+- `retainRatio < thresholdRatio`；
+- `maxOverflowRetries` 固定为 0 或 1，默认 1；
+- 模型策略必须同时提供非空 provider 和 model；
+- 同一 provider/model 不允许重复；
+- 非法热更新保留上一个有效配置，不能拖垮插件树。
+
+## 测试和验收
+
+测试覆盖：
+
+- 配置净化和模型覆盖；
+- 设置热更新；
+- 请求前压缩；
+- 工具结果裁剪后重新测量；
+- 压缩后仍超阈值的第二次尝试；
+- 上下文溢出强制压缩；
+- 原请求最多重试一次；
+- 无安全范围时保留原错误；
+- 缺少 `contextWindow` 的诊断；
+- AbortSignal 传播；
+- 手动压缩忙碌状态；
+- Session 状态隔离；
+- preset 迁移、备份、幂等和不误改；
+- 旧 `dsh-auto-compact` 不再注册；
+- 每个 preset 只有一个 `ctx.compaction`；
+- EAC 打包包含 `dsh-compact` 的 host、engine 和 client。
+
+验收要求：
+
+- 不再通过 `inputActions` 自动发送 `/compact`；
+- 必要压缩在模型请求前完成；
+- 溢出后自动压缩并重试原请求一次；
+- 不重复用户消息、不无限重试；
+- 标准 `/compact` 保持可用；
+- UI 只在真实成功后显示完成；
+- 原生 DSH 和 EAC 均可接入；
+- 升级用户不会同时加载两个自动压缩插件。

--- a/docs/superpowers/specs/2026-08-21-dsh-compact-design.md
+++ b/docs/superpowers/specs/2026-08-21-dsh-compact-design.md
@@ -23,19 +23,23 @@ dsh-compact/
 ├─ LICENSE
 └─ lib/
    ├─ index.js
+   ├─ agent.js
    ├─ engine.js
    ├─ policy.js
    └─ client.js
 ```
 
-- `lib/index.js`：在 host-plane 注册 `dsh-compact` 设置命名空间和可选 Web
-  状态接口。
+- `lib/index.js`：唯一的产品级 Loader 条目，在 host-plane 注册设置、状态接口
+  和客户端。
+- `lib/agent.js`：Agent preset 的复合入口；一个 Loader 条目内部挂载压缩引擎、
+  `/compact` 命令和工具结果裁剪器。
 - `lib/engine.js`：导出 `DshCompactEngine`，继承
   `@deepseek-ai/dsh-compaction-basic` 的 `BasicCompactionEngine`。
 - `lib/policy.js`：配置净化、模型专属策略和压缩状态辅助逻辑。
 - `lib/client.js`：设置页和当前会话压缩状态，不模拟输入 `/compact`。
-- `cordis.patch.yml`：只注册 host/client；Agent preset 必须显式使用
-  `dsh-compact/engine`，以保证每个 Agent realm 只有一个 `ctx.compaction`。
+- `cordis.patch.yml`：注册产品级 host/client；Agent preset 只显式使用一个
+  `dsh-compact/agent` 复合条目，以保证每个 Agent realm 只有一个
+  `ctx.compaction`，同时不向插件列表暴露三个实现组件。
 
 ## 默认策略
 
@@ -118,23 +122,42 @@ Headless DSH 没有 Web UI 时仍可自动压缩并使用标准 `/compact`。
 - 将 EAC 自带 Agent preset 中完全匹配的：
 
   ```yaml
-  id: compaction-basic
-  name: '@deepseek-ai/dsh-compaction-basic'
+  - id: compaction
+    name: cordis:group
+    group: true
+    isolate:
+      compaction: true
+      toolResultPruner: true
+    config:
+      - id: compaction-basic
+        name: '@deepseek-ai/dsh-compaction-basic'
+      - id: command-compact
+        name: '@deepseek-ai/dsh-command-compact'
+      - id: tool-result-pruner
+        name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
   ```
 
   替换为：
 
   ```yaml
-  id: compaction-basic
-  name: 'dsh-compact/engine'
+  - id: compact-agent
+    name: 'dsh-compact/agent'
+    isolate:
+      compaction: true
+      toolResultPruner: true
   ```
 
-- 已安装的 EAC 内置 preset 使用语法解析后迁移，首次改动前保留 `.bak`；
+- 已安装的 EAC 内置 preset 使用支持 DSH `!!js` 标量的语法解析后迁移，
+  首次改动前保留 `.bak`；
 - 用户未知的自定义 preset 不自动修改；
 - 迁移必须幂等，解析失败只记录诊断，不破坏原文件；
 - 旧 localStorage 配置只由客户端做一次清理，不迁移为错误的宿主设置。
+- 官方插件清单按 Loader 条目展示；客户端在该只读清单中隐藏
+  `compaction-basic`、`command-compact`、`tool-result-pruner` 和
+  `compact-agent` 等实现级条目，只保留产品级 `dsh-compact`。
 
-普通 DSH 用户安装包后，在所用 Agent preset 中手动替换压缩引擎行。
+普通 DSH 用户安装包后，在所用 Agent preset 中用上述单个
+`dsh-compact/agent` 条目替换原压缩组。
 
 ## 配置校验
 

--- a/dsh-desktop/assets/agent-presets/anchored-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/anchored-standard/agent.cordis.yml
@@ -291,7 +291,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/anchored-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/anchored-standard/agent.cordis.yml
@@ -274,34 +274,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/agent-presets/router-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/router-standard/agent.cordis.yml
@@ -161,7 +161,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/router-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/router-standard/agent.cordis.yml
@@ -144,34 +144,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/agent-presets/v4-flash-godmode-opencode-go/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/v4-flash-godmode-opencode-go/agent.cordis.yml
@@ -161,7 +161,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/v4-flash-godmode-opencode-go/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/v4-flash-godmode-opencode-go/agent.cordis.yml
@@ -144,34 +144,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/agent-presets/warmupbetter-replay/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/warmupbetter-replay/agent.cordis.yml
@@ -235,7 +235,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/warmupbetter-replay/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/warmupbetter-replay/agent.cordis.yml
@@ -218,34 +218,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/agent-presets/warmupbetter/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/warmupbetter/agent.cordis.yml
@@ -228,34 +228,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/agent-presets/warmupbetter/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/warmupbetter/agent.cordis.yml
@@ -245,7 +245,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/whoami-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/whoami-standard/agent.cordis.yml
@@ -222,34 +222,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/agent-presets/whoami-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/whoami-standard/agent.cordis.yml
@@ -239,7 +239,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/zero-anchored-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/zero-anchored-standard/agent.cordis.yml
@@ -233,7 +233,7 @@
     toolResultPruner: true
   config:
     - id: compaction-basic
-      name: '@deepseek-ai/dsh-compaction-basic'
+      name: 'dsh-compact/engine'
 
     - id: command-compact
       name: '@deepseek-ai/dsh-command-compact'

--- a/dsh-desktop/assets/agent-presets/zero-anchored-standard/agent.cordis.yml
+++ b/dsh-desktop/assets/agent-presets/zero-anchored-standard/agent.cordis.yml
@@ -216,34 +216,13 @@
 
 # ── compaction ──────────────────────────────────────────────────────────────
 
-# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
-# share this realm rather than sit outside it.
-#
-# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
-# plane, and the rows here resolve that one instance. It takes no configuration,
-# keys every fold by Session, and owns the context-meter projection units the
-# browser reads for every session — behind a realm those units would come and go
-# with whichever presets happen to be mounted. What a preset chooses is whether
-# its agent compacts at all, which is `compaction-basic` below.
-- id: compaction
-  name: cordis:group
-  group: true
+# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result
+# pruner in one agent-local realm while exposing a single product-level entry.
+- id: compact-agent
+  name: 'dsh-compact/agent'
   isolate:
     compaction: true
     toolResultPruner: true
-  config:
-    - id: compaction-basic
-      name: 'dsh-compact/engine'
-
-    - id: command-compact
-      name: '@deepseek-ai/dsh-command-compact'
-
-    - id: tool-result-pruner
-      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
-      config:
-        thresholdChars: 8192
-        headChars: 4096
-        tailChars: 1024
 
 # ── delegation and workflows ────────────────────────────────────────────────
 

--- a/dsh-desktop/assets/plugins/dsh-compact/LICENSE
+++ b/dsh-desktop/assets/plugins/dsh-compact/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Deepseek Harness EAC contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dsh-desktop/assets/plugins/dsh-compact/cordis.patch.yml
+++ b/dsh-desktop/assets/plugins/dsh-compact/cordis.patch.yml
@@ -1,0 +1,2 @@
+- id: compact
+  name: 'dsh-compact'

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/agent.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/agent.js
@@ -1,0 +1,25 @@
+import Schema from '@deepseek-ai/schemastery'
+import * as CompactCommand from '@deepseek-ai/dsh-command-compact'
+import ToolResultPruner from '@deepseek-ai/dsh-compaction-tool-result-pruner'
+import DshCompactEngine from './engine.js'
+
+export const name = 'dsh-compact-agent'
+export const Config = Schema.object({
+  thresholdChars: Schema.number().step(1).min(1).default(8192)
+    .description('工具结果超过此字符数时进行头尾裁剪'),
+  headChars: Schema.number().step(1).min(0).default(4096)
+    .description('工具结果裁剪后保留的头部字符数'),
+  tailChars: Schema.number().step(1).min(0).default(1024)
+    .description('工具结果裁剪后保留的尾部字符数'),
+}).description('dsh-compact Agent 侧复合入口')
+
+export async function apply(ctx, config = {}) {
+  const pruner = ctx.plugin(ToolResultPruner, {
+    thresholdChars: config.thresholdChars ?? 8192,
+    headChars: config.headChars ?? 4096,
+    tailChars: config.tailChars ?? 1024,
+  })
+  const engine = ctx.plugin(DshCompactEngine)
+  const command = ctx.plugin(CompactCommand)
+  await Promise.all([pruner.await(), engine.await(), command.await()])
+}

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/client.js
@@ -27,6 +27,12 @@ window.__ModuleLoader__.load({
       '.dshc-error{font-size:12px;color:var(--dsw-alias-state-error-primary,#d33)}',
       '.dshc-ok{font-size:12px;color:var(--dsw-alias-state-success-primary,#16803a)}',
       '.dshc-json{width:100%;min-height:88px;resize:vertical;font:12px/1.5 ui-monospace,monospace;box-sizing:border-box}',
+      // 官方插件清单按 Loader entry 展示。下面这些是 dsh-compact 的实现
+      // 细节或被 Web profile 停用的上游占位行；产品层只展示 compact。
+      '[data-plugin-entry="compaction-basic"],[data-plugin-entry$=":compaction-basic"],' +
+        '[data-plugin-entry="command-compact"],[data-plugin-entry$=":command-compact"],' +
+        '[data-plugin-entry="tool-result-pruner"],[data-plugin-entry$=":tool-result-pruner"],' +
+        '[data-plugin-entry="compact-agent"],[data-plugin-entry$=":compact-agent"]{display:none!important}',
     ].join('')
 
     function ensureCss() {

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/client.js
@@ -1,0 +1,242 @@
+window.__ModuleLoader__.load({
+  id: 'dsh-compact',
+  factory: (require) => {
+    const module = { exports: {} }
+    const React = require('react')
+    const { bindSnapshotSelector } = require('@deepseek-ai/dsh-client-web-react')
+    const h = React.createElement
+    const NS = 'dsh-compact'
+    const STATUS_ENDPOINT = '/plugins/dsh-compact/status'
+    const COMPACT_ENDPOINT = '/plugins/dsh-compact/compact-now'
+    const OLD_STORE_KEY = 'dsh-auto-compact-config-v1'
+    let currentSessionId = ''
+
+    try { window.localStorage.removeItem(OLD_STORE_KEY) } catch {}
+
+    const css = [
+      '.dshc-card{list-style:none;border:1px solid var(--dsw-alias-border-l2,#d8d8d8);border-radius:12px;padding:16px;display:grid;gap:14px}',
+      '.dshc-head{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}',
+      '.dshc-title{font-size:16px;font-weight:650}',
+      '.dshc-desc,.dshc-hint{font-size:12px;line-height:18px;opacity:.7;margin:4px 0 0}',
+      '.dshc-row{display:flex;justify-content:space-between;align-items:center;gap:20px}',
+      '.dshc-field{display:grid;gap:3px;min-width:0}',
+      '.dshc-control{min-width:170px}',
+      '.dshc-btn{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);color:inherit;border-radius:8px;padding:7px 13px;cursor:pointer}',
+      '.dshc-btn:disabled{opacity:.5;cursor:default}',
+      '.dshc-status{font-size:12px;padding:3px 8px;border-radius:999px;background:var(--dsw-alias-bg-layer-3)}',
+      '.dshc-error{font-size:12px;color:var(--dsw-alias-state-error-primary,#d33)}',
+      '.dshc-ok{font-size:12px;color:var(--dsw-alias-state-success-primary,#16803a)}',
+      '.dshc-json{width:100%;min-height:88px;resize:vertical;font:12px/1.5 ui-monospace,monospace;box-sizing:border-box}',
+    ].join('')
+
+    function ensureCss() {
+      if (document.querySelector('style[data-plugin-css="dsh-compact/client.css"]')) return
+      const tag = document.createElement('style')
+      tag.dataset.pluginCss = 'dsh-compact/client.css'
+      tag.textContent = css
+      document.head.appendChild(tag)
+    }
+
+    function SessionCapture(props) {
+      React.useEffect(() => {
+        if (props.sessionId) currentSessionId = props.sessionId
+        return () => {
+          if (currentSessionId === props.sessionId) currentSessionId = ''
+        }
+      }, [props.sessionId])
+      return null
+    }
+
+    function Field({ label, hint, children }) {
+      return h('label', { className: 'dshc-row' },
+        h('span', { className: 'dshc-field' },
+          h('span', null, label),
+          h('small', { className: 'dshc-hint' }, hint),
+        ),
+        h('span', { className: 'dshc-control' }, children),
+      )
+    }
+
+    function CompactCard({ scope, useScope }) {
+      const snap = useScope((value) => value)
+      const ready = snap?.status === 'ready'
+      const writable = ready && snap.writable
+      const value = snap?.value ?? {}
+      const [status, setStatus] = React.useState(null)
+      const [message, setMessage] = React.useState(null)
+      const [busy, setBusy] = React.useState(false)
+      const [policiesText, setPoliciesText] = React.useState('[]')
+
+      React.useEffect(() => {
+        setPoliciesText(JSON.stringify(value.modelPolicies ?? [], null, 2))
+      }, [JSON.stringify(value.modelPolicies ?? [])])
+
+      React.useEffect(() => {
+        let active = true
+        const poll = () => {
+          if (!currentSessionId) {
+            if (active) setStatus(null)
+            return
+          }
+          fetch(`${STATUS_ENDPOINT}?sessionId=${encodeURIComponent(currentSessionId)}`, { cache: 'no-store' })
+            .then((response) => {
+              if (!response.ok) throw new Error(String(response.status))
+              return response.json()
+            })
+            .then((next) => { if (active) setStatus(next) })
+            .catch(() => { if (active) setStatus({ unavailable: true }) })
+        }
+        poll()
+        const timer = setInterval(poll, 2000)
+        return () => { active = false; clearInterval(timer) }
+      }, [])
+
+      const set = (key, next) => {
+        setMessage(null)
+        scope.set(key, next).catch((error) => setMessage({ ok: false, text: error?.message ?? String(error) }))
+      }
+
+      const compactNow = async () => {
+        if (!currentSessionId) {
+          setMessage({ ok: false, text: '请先打开一个对话。' })
+          return
+        }
+        setBusy(true)
+        setMessage(null)
+        try {
+          const response = await fetch(COMPACT_ENDPOINT, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ sessionId: currentSessionId }),
+          })
+          const body = await response.json()
+          if (!response.ok) throw new Error(body.error ?? `HTTP ${response.status}`)
+          setStatus(body.status)
+          setMessage({
+            ok: true,
+            text: body.compacted ? '压缩已完成并持久化。' : '当前没有可安全压缩的旧历史。',
+          })
+        } catch (error) {
+          setMessage({ ok: false, text: error?.message ?? String(error) })
+        } finally {
+          setBusy(false)
+        }
+      }
+
+      const savePolicies = () => {
+        try {
+          const parsed = JSON.parse(policiesText)
+          if (!Array.isArray(parsed)) throw new Error('模型策略必须是 JSON 数组')
+          set('modelPolicies', parsed)
+        } catch (error) {
+          setMessage({ ok: false, text: error?.message ?? String(error) })
+        }
+      }
+
+      const stateText = !currentSessionId
+        ? '未选择会话'
+        : status?.unavailable
+        ? 'Host 不可用'
+        : status?.engineActive === false
+        ? '当前 preset 未启用'
+        : status?.state ?? '读取中'
+
+      return h('li', { className: 'dshc-card', 'data-testid': 'dsh-compact-settings' },
+        h('div', { className: 'dshc-head' },
+          h('div', null,
+            h('div', { className: 'dshc-title' }, '上下文自动压缩'),
+            h('p', { className: 'dshc-desc' }, '在模型请求前按真实 Token 压力压缩；溢出时最多恢复并重试一次，不向输入框发送 /compact。'),
+          ),
+          h('span', { className: 'dshc-status' }, stateText),
+        ),
+        h(Field, { label: '启用自动压缩', hint: '关闭后不执行请求前压缩或溢出恢复；手动压缩仍可用。' },
+          h('input', {
+            type: 'checkbox',
+            checked: value.enabled !== false,
+            disabled: !writable,
+            onChange: (event) => set('enabled', event.target.checked),
+          }),
+        ),
+        h(Field, { label: '触发阈值', hint: `${Math.round((value.thresholdRatio ?? 0.75) * 100)}%` },
+          h('input', {
+            type: 'range', min: 0.5, max: 0.95, step: 0.01,
+            value: value.thresholdRatio ?? 0.75, disabled: !writable,
+            onChange: (event) => set('thresholdRatio', Number(event.target.value)),
+          }),
+        ),
+        h(Field, { label: '保留近期上下文', hint: `${Math.round((value.retainRatio ?? 0.2) * 100)}%，必须低于触发阈值。` },
+          h('input', {
+            type: 'range', min: 0.05, max: 0.5, step: 0.01,
+            value: value.retainRatio ?? 0.2, disabled: !writable,
+            onChange: (event) => set('retainRatio', Number(event.target.value)),
+          }),
+        ),
+        h(Field, { label: '溢出自动恢复', hint: '收到 CONTEXT_WINDOW_EXCEEDED 后压缩并重试原请求。' },
+          h('input', {
+            type: 'checkbox',
+            checked: value.recoverOnOverflow !== false,
+            disabled: !writable,
+            onChange: (event) => set('recoverOnOverflow', event.target.checked),
+          }),
+        ),
+        h(Field, { label: '溢出重试次数', hint: '为防止循环，只允许 0 或 1。' },
+          h('select', {
+            value: value.maxOverflowRetries ?? 1,
+            disabled: !writable,
+            onChange: (event) => set('maxOverflowRetries', Number(event.target.value)),
+          },
+          h('option', { value: 0 }, '0（关闭）'),
+          h('option', { value: 1 }, '1（推荐）')),
+        ),
+        h('div', { className: 'dshc-field' },
+          h('span', null, 'provider/model 专属策略'),
+          h('small', { className: 'dshc-hint' }, 'JSON 数组；每项至少包含 provider 和 model，可覆盖 enabled、thresholdRatio、retainRatio、recoverOnOverflow、maxOverflowRetries。'),
+          h('textarea', {
+            className: 'dshc-json',
+            value: policiesText,
+            disabled: !writable,
+            onChange: (event) => setPoliciesText(event.target.value),
+          }),
+          h('div', null,
+            h('button', { type: 'button', className: 'dshc-btn', disabled: !writable, onClick: savePolicies }, '保存模型策略'),
+          ),
+        ),
+        h('div', { className: 'dshc-row' },
+          h('button', {
+            type: 'button',
+            className: 'dshc-btn',
+            disabled: busy || !currentSessionId || status?.engineActive === false,
+            onClick: compactNow,
+          }, busy ? '正在压缩…' : '立即压缩当前对话'),
+          message ? h('span', { className: message.ok ? 'dshc-ok' : 'dshc-error', role: 'status' }, message.text) : null,
+        ),
+      )
+    }
+
+    function apply(ctx) {
+      ensureCss()
+      const scope = ctx.settingsScope.bind({ namespace: NS })
+      const useScope = bindSnapshotSelector(scope)
+      ctx.slots.inject('conversation.composer.dock', () => ctx.slots.register({
+        name: 'conversation.composer.dock',
+        id: 'dsh-compact-session-capture',
+        order: 91,
+      }, SessionCapture))
+      ctx.slots.inject('settings.plugin.item', () => ctx.slots.register({
+        name: 'settings.plugin.item',
+        id: 'dsh-compact',
+        key: 'dsh-compact',
+        order: 28,
+        inject: () => ({ scope, useScope }),
+      }, CompactCard))
+    }
+
+    module.exports = {
+      name: 'dsh-compact-client',
+      inject: ['slots', 'settingsScope'],
+      apply,
+      __internals: { OLD_STORE_KEY },
+    }
+    return module.exports
+  },
+})

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/engine.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/engine.js
@@ -23,6 +23,19 @@ function logResult(ctx, result, trigger) {
   )
 }
 
+const EMPTY_SUMMARY_ERROR = 'summarization produced no text summary content'
+
+export async function summarizeWithToolFreeFallback(summarize, input, onRetry = () => {}) {
+  try {
+    return await summarize(input)
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== EMPTY_SUMMARY_ERROR) throw error
+    onRetry(error)
+    const { system: _system, tools: _tools, ...fallbackInput } = input
+    return summarize(fallbackInput)
+  }
+}
+
 export function registerAutomaticCompaction(ctx, engine) {
   const overflowRetries = new WeakMap()
   const overflowAgents = new WeakMap()
@@ -119,6 +132,16 @@ export class DshCompactEngine extends BasicCompactionEngine {
 
   policyFor(agent) {
     return resolvePolicy(this.currentConfig(), routedTargetOf(agent))
+  }
+
+  summarize(input, agent, signal) {
+    return summarizeWithToolFreeFallback(
+      (nextInput) => super.summarize(nextInput, agent, signal),
+      input,
+      () => this.ctx.logger?.warn?.(
+        'dsh-compact summary returned no text; retrying once without the agent system prompt and tools',
+      ),
+    )
   }
 
   async withPolicySnapshot(agent, trigger, operation) {

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/engine.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/engine.js
@@ -1,0 +1,188 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { BasicCompactionEngine } from '@deepseek-ai/dsh-compaction-basic'
+import { CONTEXT_WINDOW_EXCEEDED_CODE } from '@deepseek-ai/dsh-llm'
+import {
+  compactStatus,
+  getSharedConfig,
+  resolvePolicy,
+  routedTargetOf,
+  sessionIdOf,
+  toBasicResolvedConfig,
+} from './policy.js'
+
+function publishStatus(ctx, sessionId, patch) {
+  const status = compactStatus.set(sessionId, patch)
+  try { ctx.emit?.('dsh-compact/status', status) } catch {}
+  return status
+}
+
+function logResult(ctx, result, trigger) {
+  ctx.logger?.info?.(
+    `dsh-compact (${trigger}): shadowed ${result.shadowedSeqs.length} surface nodes `
+      + `(seqs ${result.shadowedRange.start}-${result.shadowedRange.end}, ~${result.shadowedTokenCount} tokens)`,
+  )
+}
+
+export function registerAutomaticCompaction(ctx, engine) {
+  const overflowRetries = new WeakMap()
+  const overflowAgents = new WeakMap()
+
+  const offPreStep = ctx.on('agent/pre-step', async ({ agent, signal }, next) => {
+    if (signal.aborted || !engine.policyFor(agent).enabled) return next()
+    try {
+      const result = await engine.compactIfNeeded(agent, 'pressure', signal)
+      if (result !== null) logResult(ctx, result, 'step pressure')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      ctx.logger?.warn?.(`dsh-compact step compaction failed: ${message}; continuing the turn`)
+    }
+    return next()
+  })
+
+  const offStatus = ctx.on('agent/status', ({ agent, status }) => {
+    if (status === 'idle') overflowRetries.delete(agent)
+  })
+
+  const offSessionEvent = ctx.on('session/event', (session, event) => {
+    if (event.type !== 'assistant/message') return
+    const agent = overflowAgents.get(session)
+    if (agent !== undefined) overflowRetries.delete(agent)
+  })
+
+  const offSessionDisposed = ctx.on('session/disposed', (session) => {
+    compactStatus.clear(session?.id)
+  })
+
+  const offRequestError = ctx.on('agent/request-error', async ({ agent, failure, signal }, next) => {
+    if (failure.code !== CONTEXT_WINDOW_EXCEEDED_CODE || signal.aborted) return next()
+    const policy = engine.policyFor(agent)
+    if (!policy.enabled || !policy.recoverOnOverflow || policy.maxOverflowRetries === 0) return next()
+    overflowAgents.set(agent.session, agent)
+    const retries = overflowRetries.get(agent) ?? 0
+    if (retries >= policy.maxOverflowRetries) return next()
+    const generation = agent.session.surface.replaceGeneration
+    let result
+    try {
+      result = await engine.compactIfNeeded(agent, 'context-overflow', signal)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (!signal.aborted && agent.session.surface.replaceGeneration > generation) {
+        ctx.logger?.warn?.(
+          `dsh-compact overflow recovery failed after durable progress: ${message}; retrying from replacement surface`,
+        )
+        overflowRetries.set(agent, retries + 1)
+        return { kind: 'retry' }
+      }
+      ctx.logger?.warn?.(
+        `dsh-compact overflow recovery failed: ${message}; preserving the original request error`,
+      )
+      return next()
+    }
+    if (signal.aborted || agent.session.surface.replaceGeneration <= generation) return next()
+    if (result !== null) logResult(ctx, result, 'context overflow recovery')
+    overflowRetries.set(agent, retries + 1)
+    return { kind: 'retry' }
+  })
+
+  return () => {
+    offPreStep?.()
+    offStatus?.()
+    offSessionEvent?.()
+    offSessionDisposed?.()
+    offRequestError?.()
+  }
+}
+
+export class DshCompactEngine extends BasicCompactionEngine {
+  static inject = BasicCompactionEngine.inject
+  static Config = BasicCompactionEngine.Config
+
+  constructor(ctx, config = {}) {
+    const initial = toBasicResolvedConfig({ ...getSharedConfig(), ...config })
+    super(ctx, initial)
+    this.dshCompact = true
+    this.entryConfig = { ...config }
+    this.policyStorage = new AsyncLocalStorage()
+    const fallbackConfig = this.config
+    Object.defineProperty(this, 'config', {
+      configurable: false,
+      enumerable: true,
+      get: () => this.policyStorage.getStore() ?? fallbackConfig,
+    })
+    const disposeHooks = registerAutomaticCompaction(ctx, this)
+    ctx.effect?.(() => disposeHooks, 'dsh-compact: automatic request-path compaction')
+  }
+
+  currentConfig() {
+    return { ...getSharedConfig(), ...this.entryConfig }
+  }
+
+  policyFor(agent) {
+    return resolvePolicy(this.currentConfig(), routedTargetOf(agent))
+  }
+
+  async withPolicySnapshot(agent, trigger, operation) {
+    const sessionId = sessionIdOf(agent)
+    const config = this.currentConfig()
+    const policy = resolvePolicy(config, routedTargetOf(agent))
+    if (trigger !== 'manual' && !policy.enabled) return null
+    if (trigger === 'context-overflow' && !policy.recoverOnOverflow) return null
+    publishStatus(this.ctx, sessionId, {
+      state: 'measuring',
+      active: true,
+      trigger,
+      error: null,
+      policy,
+    })
+    try {
+      const result = await this.policyStorage.run(toBasicResolvedConfig(config), operation)
+      if (result === null) {
+        publishStatus(this.ctx, sessionId, {
+          state: 'idle',
+          active: false,
+          trigger,
+          outcome: 'no-range',
+        })
+        return null
+      }
+      publishStatus(this.ctx, sessionId, {
+        state: trigger === 'context-overflow' ? 'recovered' : 'idle',
+        active: false,
+        trigger,
+        outcome: 'compacted',
+        lastCompactedAt: new Date().toISOString(),
+        shadowedTokenCount: result.shadowedTokenCount,
+        shadowedNodes: result.shadowedSeqs.length,
+      })
+      return result
+    } catch (error) {
+      publishStatus(this.ctx, sessionId, {
+        state: 'failed',
+        active: false,
+        trigger,
+        outcome: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      })
+      throw error
+    }
+  }
+
+  compactIfNeeded(agent, trigger, signal) {
+    return this.withPolicySnapshot(
+      agent,
+      trigger,
+      () => super.compactIfNeeded(agent, trigger, signal),
+    )
+  }
+
+  compactNow(agent, signal, sourceCommandId) {
+    return this.withPolicySnapshot(
+      agent,
+      'manual',
+      () => super.compactNow(agent, signal, sourceCommandId),
+    )
+  }
+}
+
+export const name = 'dsh-compact-engine'
+export default DshCompactEngine

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/index.js
@@ -1,0 +1,183 @@
+import Schema from '@deepseek-ai/schemastery'
+import { settingsNamespace } from '@deepseek-ai/dsh-settings'
+import {
+  DEFAULT_CONFIG,
+  compactStatus,
+  resolvePolicy,
+  routedTargetOf,
+  sanitizeConfig,
+  setSharedConfig,
+} from './policy.js'
+
+export const name = 'dsh-compact'
+export const inject = ['settings']
+export const STATUS_ENDPOINT = '/plugins/dsh-compact/status'
+export const COMPACT_ENDPOINT = '/plugins/dsh-compact/compact-now'
+export const NS = settingsNamespace('dsh-compact')
+
+const ModelPolicy = Schema.object({
+  provider: Schema.string().description('精确匹配 provider'),
+  model: Schema.string().description('精确匹配 model'),
+  enabled: Schema.boolean(),
+  thresholdRatio: Schema.number().min(0.5).max(0.95).step(0.01),
+  retainRatio: Schema.number().min(0.05).max(0.5).step(0.01),
+  recoverOnOverflow: Schema.boolean(),
+  maxOverflowRetries: Schema.union([Schema.const(0), Schema.const(1)]),
+})
+
+export const Config = Schema.object({
+  enabled: Schema.boolean().default(DEFAULT_CONFIG.enabled).description('启用请求前自动压缩'),
+  thresholdRatio: Schema.number().min(0.5).max(0.95).step(0.01)
+    .default(DEFAULT_CONFIG.thresholdRatio).role('slider').description('自动压缩触发比例'),
+  retainRatio: Schema.number().min(0.05).max(0.5).step(0.01)
+    .default(DEFAULT_CONFIG.retainRatio).role('slider').description('压缩后保留近期上下文比例'),
+  recoverOnOverflow: Schema.boolean().default(DEFAULT_CONFIG.recoverOnOverflow)
+    .description('上下文溢出后压缩并重试原请求'),
+  maxOverflowRetries: Schema.union([Schema.const(0), Schema.const(1)])
+    .default(DEFAULT_CONFIG.maxOverflowRetries).description('单轮溢出恢复次数'),
+  modelPolicies: Schema.array(ModelPolicy).default([]).description('provider/model 专属策略'),
+}).description('DSH 请求路径上下文压缩')
+
+function jsonResponse(res, status, body) {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+    'content-length': Buffer.byteLength(payload),
+  })
+  res.end(payload)
+}
+
+function isLoopback(address) {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
+}
+
+function authorize(req, res) {
+  if (!isLoopback(req.socket?.remoteAddress)) {
+    jsonResponse(res, 403, { error: 'local access only' })
+    return false
+  }
+  const origin = req.headers?.origin
+  if (origin) {
+    let originHost
+    try { originHost = new URL(origin).host } catch {}
+    if (!originHost || originHost !== req.headers.host) {
+      jsonResponse(res, 403, { error: 'origin mismatch' })
+      return false
+    }
+  }
+  return true
+}
+
+async function readJson(req) {
+  const chunks = []
+  let bytes = 0
+  for await (const chunk of req) {
+    bytes += chunk.length
+    if (bytes > 4096) throw new Error('request body is too large')
+    chunks.push(chunk)
+  }
+  const value = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('body must be an object')
+  return value
+}
+
+export function createStatusHandler(ctx, settings = ctx.__dshCompactSettings) {
+  return async (req, res) => {
+    if (!authorize(req, res)) return
+    if (req.method !== 'GET') {
+      jsonResponse(res, 405, { error: 'method not allowed' })
+      return
+    }
+    const url = new URL(req.url ?? STATUS_ENDPOINT, `http://${req.headers.host ?? '127.0.0.1'}`)
+    const sessionId = url.searchParams.get('sessionId') ?? ''
+    const agent = sessionId ? ctx.agents?.get?.(sessionId) : undefined
+    const service = agent ? ctx.agentPresets?.serviceFor?.(agent, 'compaction') : undefined
+    const policy = agent ? resolvePolicy(setSharedConfig(settings.get()), routedTargetOf(agent)) : undefined
+    jsonResponse(res, 200, {
+      ...compactStatus.get(sessionId),
+      engineActive: service?.dshCompact === true,
+      ...(policy ? { policy } : {}),
+    })
+  }
+}
+
+export function createCompactNowHandler(ctx) {
+  return async (req, res) => {
+    if (!authorize(req, res)) return
+    if (req.method !== 'POST') {
+      jsonResponse(res, 405, { error: 'method not allowed' })
+      return
+    }
+    let body
+    try { body = await readJson(req) } catch (error) {
+      jsonResponse(res, 400, { error: error instanceof Error ? error.message : String(error) })
+      return
+    }
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : ''
+    const agent = sessionId ? ctx.agents?.get?.(sessionId) : undefined
+    if (!agent) {
+      jsonResponse(res, 404, { error: 'session is not active' })
+      return
+    }
+    const service = ctx.agentPresets?.serviceFor?.(agent, 'compaction')
+    if (!service || service.dshCompact !== true || typeof service.compactNow !== 'function') {
+      jsonResponse(res, 409, { error: 'current preset does not use dsh-compact' })
+      return
+    }
+    try {
+      const result = await service.compactNow(agent, AbortSignal.timeout(120000))
+      jsonResponse(res, 200, {
+        ok: true,
+        compacted: result !== null,
+        status: compactStatus.get(sessionId),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const busy = error?.code === 'busy' || /\bbusy\b|requires an idle agent/i.test(message)
+      jsonResponse(res, busy ? 409 : 500, { error: message, code: busy ? 'busy' : 'failed' })
+    }
+  }
+}
+
+export function apply(ctx, config = {}) {
+  let scope
+  try {
+    scope = ctx.settings.register(NS, Config, {
+      base: sanitizeConfig(config),
+      applies: 'live',
+      validate: sanitizeConfig,
+    })
+  } catch (error) {
+    ctx.logger?.warn?.(
+      `dsh-compact settings unavailable: ${error instanceof Error ? error.message : String(error)}; using defaults`,
+    )
+    setSharedConfig(DEFAULT_CONFIG)
+    return
+  }
+  ctx.__dshCompactSettings = scope
+  setSharedConfig(scope.get())
+  const unwatch = scope.watch((next) => setSharedConfig(next))
+  ctx.inject?.(['webServer', 'agents', 'agentPresets'], (httpCtx) => {
+    httpCtx.effect(
+      () => httpCtx.webServer.register({
+        kind: 'exact',
+        path: STATUS_ENDPOINT,
+        handler: createStatusHandler(httpCtx, scope),
+      }),
+      'dsh-compact: status endpoint',
+    )
+    httpCtx.effect(
+      () => httpCtx.webServer.register({
+        kind: 'exact',
+        path: COMPACT_ENDPOINT,
+        handler: createCompactNowHandler(httpCtx),
+      }),
+      'dsh-compact: compact-now endpoint',
+    )
+  })
+  ctx.effect?.(() => () => unwatch(), 'dsh-compact: settings watcher')
+}
+
+export { DshCompactEngine } from './engine.js'
+export { DEFAULT_CONFIG, compactStatus, resolvePolicy, sanitizeConfig } from './policy.js'

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/policy.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/policy.js
@@ -148,7 +148,9 @@ export function toBasicResolvedConfig(config) {
     summarizationProvider: '',
     summarizationModel: '',
     maxTokens: 8192,
-    compactionRetries: 1,
+    // BasicCompactionEngine counts this as extra attempts after the first one.
+    // Keep one pressure check to one durable summary; a later turn can compact again.
+    compactionRetries: 0,
     maxOverflowRetries: resolved.maxOverflowRetries,
     modelPolicies: Object.freeze(resolved.modelPolicies.map((policy) => Object.freeze({
       provider: policy.provider,

--- a/dsh-desktop/assets/plugins/dsh-compact/lib/policy.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/policy.js
@@ -1,0 +1,224 @@
+const DEFAULT_CONFIG = Object.freeze({
+  enabled: true,
+  thresholdRatio: 0.75,
+  retainRatio: 0.20,
+  recoverOnOverflow: true,
+  maxOverflowRetries: 1,
+  modelPolicies: Object.freeze([]),
+})
+
+const MIN_THRESHOLD_RATIO = 0.50
+const MAX_THRESHOLD_RATIO = 0.95
+const MIN_RETAIN_RATIO = 0.05
+const MAX_RETAIN_RATIO = 0.50
+
+let sharedConfig = DEFAULT_CONFIG
+
+function freezeConfig(value) {
+  const modelPolicies = Object.freeze(value.modelPolicies.map((policy) => Object.freeze({ ...policy })))
+  return Object.freeze({ ...value, modelPolicies })
+}
+
+function finiteRatio(value, fallback, min, max, label) {
+  const resolved = value === undefined ? fallback : value
+  if (typeof resolved !== 'number' || !Number.isFinite(resolved) || resolved < min || resolved > max) {
+    throw new TypeError(`${label} must be between ${min} and ${max}`)
+  }
+  return resolved
+}
+
+function normalizePolicy(input, index) {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError(`modelPolicies[${index}] must be an object`)
+  }
+  const provider = typeof input.provider === 'string' ? input.provider.trim() : ''
+  const model = typeof input.model === 'string' ? input.model.trim() : ''
+  if (!provider || !model) throw new TypeError(`modelPolicies[${index}] requires provider and model`)
+  const policy = { provider, model }
+  if (input.enabled !== undefined) {
+    if (typeof input.enabled !== 'boolean') throw new TypeError(`modelPolicies[${index}].enabled must be a boolean`)
+    policy.enabled = input.enabled
+  }
+  if (input.recoverOnOverflow !== undefined) {
+    if (typeof input.recoverOnOverflow !== 'boolean') {
+      throw new TypeError(`modelPolicies[${index}].recoverOnOverflow must be a boolean`)
+    }
+    policy.recoverOnOverflow = input.recoverOnOverflow
+  }
+  if (input.thresholdRatio !== undefined) {
+    policy.thresholdRatio = finiteRatio(
+      input.thresholdRatio,
+      DEFAULT_CONFIG.thresholdRatio,
+      MIN_THRESHOLD_RATIO,
+      MAX_THRESHOLD_RATIO,
+      `modelPolicies[${index}].thresholdRatio`,
+    )
+  }
+  if (input.retainRatio !== undefined) {
+    policy.retainRatio = finiteRatio(
+      input.retainRatio,
+      DEFAULT_CONFIG.retainRatio,
+      MIN_RETAIN_RATIO,
+      MAX_RETAIN_RATIO,
+      `modelPolicies[${index}].retainRatio`,
+    )
+  }
+  if (input.maxOverflowRetries !== undefined) {
+    if (input.maxOverflowRetries !== 0 && input.maxOverflowRetries !== 1) {
+      throw new TypeError(`modelPolicies[${index}].maxOverflowRetries must be 0 or 1`)
+    }
+    policy.maxOverflowRetries = input.maxOverflowRetries
+  }
+  return policy
+}
+
+export function sanitizeConfig(input = {}) {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('dsh-compact config must be an object')
+  }
+  if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
+    throw new TypeError('enabled must be a boolean')
+  }
+  if (input.recoverOnOverflow !== undefined && typeof input.recoverOnOverflow !== 'boolean') {
+    throw new TypeError('recoverOnOverflow must be a boolean')
+  }
+  if (input.modelPolicies !== undefined && !Array.isArray(input.modelPolicies)) {
+    throw new TypeError('modelPolicies must be an array')
+  }
+  const thresholdRatio = finiteRatio(
+    input.thresholdRatio,
+    DEFAULT_CONFIG.thresholdRatio,
+    MIN_THRESHOLD_RATIO,
+    MAX_THRESHOLD_RATIO,
+    'thresholdRatio',
+  )
+  const retainRatio = finiteRatio(
+    input.retainRatio,
+    DEFAULT_CONFIG.retainRatio,
+    MIN_RETAIN_RATIO,
+    MAX_RETAIN_RATIO,
+    'retainRatio',
+  )
+  if (retainRatio >= thresholdRatio) throw new TypeError('retainRatio must be less than thresholdRatio')
+  const maxOverflowRetries = input.maxOverflowRetries ?? DEFAULT_CONFIG.maxOverflowRetries
+  if (maxOverflowRetries !== 0 && maxOverflowRetries !== 1) {
+    throw new TypeError('maxOverflowRetries must be 0 or 1')
+  }
+  const modelPolicies = (input.modelPolicies ?? []).map(normalizePolicy)
+  const seen = new Set()
+  for (const [index, policy] of modelPolicies.entries()) {
+    const effectiveThreshold = policy.thresholdRatio ?? thresholdRatio
+    const effectiveRetain = policy.retainRatio ?? retainRatio
+    if (effectiveRetain >= effectiveThreshold) {
+      throw new TypeError(`modelPolicies[${index}].retainRatio must be less than thresholdRatio`)
+    }
+    const key = `${policy.provider}\0${policy.model}`
+    if (seen.has(key)) throw new TypeError(`duplicate model policy for ${policy.provider}/${policy.model}`)
+    seen.add(key)
+  }
+  return freezeConfig({
+    enabled: input.enabled !== false,
+    thresholdRatio,
+    retainRatio,
+    recoverOnOverflow: input.recoverOnOverflow !== false,
+    maxOverflowRetries,
+    modelPolicies,
+  })
+}
+
+export function resolvePolicy(config, target) {
+  const base = sanitizeConfig(config)
+  const override = target
+    ? base.modelPolicies.find((policy) => policy.provider === target.provider && policy.model === target.model)
+    : undefined
+  return Object.freeze({
+    enabled: override?.enabled ?? base.enabled,
+    thresholdRatio: override?.thresholdRatio ?? base.thresholdRatio,
+    retainRatio: override?.retainRatio ?? base.retainRatio,
+    recoverOnOverflow: override?.recoverOnOverflow ?? base.recoverOnOverflow,
+    maxOverflowRetries: override?.maxOverflowRetries ?? base.maxOverflowRetries,
+  })
+}
+
+export function toBasicResolvedConfig(config) {
+  const resolved = sanitizeConfig(config)
+  return Object.freeze({
+    thresholdRatio: resolved.thresholdRatio,
+    retainRatio: resolved.retainRatio,
+    summarizationProvider: '',
+    summarizationModel: '',
+    maxTokens: 8192,
+    compactionRetries: 1,
+    maxOverflowRetries: resolved.maxOverflowRetries,
+    modelPolicies: Object.freeze(resolved.modelPolicies.map((policy) => Object.freeze({
+      provider: policy.provider,
+      model: policy.model,
+      ...(policy.thresholdRatio === undefined ? {} : { thresholdRatio: policy.thresholdRatio }),
+      ...(policy.retainRatio === undefined ? {} : { retainRatio: policy.retainRatio }),
+      ...(policy.maxOverflowRetries === undefined ? {} : { maxOverflowRetries: policy.maxOverflowRetries }),
+    }))),
+    auto: false,
+  })
+}
+
+export function setSharedConfig(config) {
+  sharedConfig = sanitizeConfig(config)
+  return sharedConfig
+}
+
+export function getSharedConfig() {
+  return sharedConfig
+}
+
+export function resetSharedConfig() {
+  sharedConfig = DEFAULT_CONFIG
+}
+
+export function sessionIdOf(agent) {
+  return String(agent?.id ?? agent?.session?.id ?? agent?.session?.header?.id ?? '')
+}
+
+export function routedTargetOf(agent) {
+  const requestConfig = agent?.session?.requestHeader?.()?.config
+  if (requestConfig?.provider && requestConfig?.model) {
+    return { provider: requestConfig.provider, model: requestConfig.model }
+  }
+  if (agent?.options?.provider && agent?.options?.model) {
+    return { provider: agent.options.provider, model: agent.options.model }
+  }
+  return undefined
+}
+
+class StatusStore {
+  #values = new Map()
+
+  get(sessionId) {
+    const id = String(sessionId ?? '')
+    return this.#values.get(id) ?? Object.freeze({
+      sessionId: id,
+      state: 'idle',
+      active: false,
+      updatedAt: null,
+    })
+  }
+
+  set(sessionId, patch) {
+    const id = String(sessionId ?? '')
+    if (!id) return this.get(id)
+    const next = Object.freeze({
+      ...this.get(id),
+      ...patch,
+      sessionId: id,
+      updatedAt: new Date().toISOString(),
+    })
+    this.#values.set(id, next)
+    return next
+  }
+
+  clear(sessionId) {
+    this.#values.delete(String(sessionId ?? ''))
+  }
+}
+
+export const compactStatus = new StatusStore()
+export { DEFAULT_CONFIG }

--- a/dsh-desktop/assets/plugins/dsh-compact/package.json
+++ b/dsh-desktop/assets/plugins/dsh-compact/package.json
@@ -6,6 +6,7 @@
   "main": "lib/index.js",
   "exports": {
     ".": "./lib/index.js",
+    "./agent": "./lib/agent.js",
     "./engine": "./lib/engine.js",
     "./client": "./lib/client.js",
     "./package.json": "./package.json"
@@ -32,7 +33,9 @@
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
     "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-command-compact": "^0.1.0-rc.7",
     "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.0-rc.7",
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
     "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
     "@deepseek-ai/schemastery": "^3.18.1"

--- a/dsh-desktop/assets/plugins/dsh-compact/package.json
+++ b/dsh-desktop/assets/plugins/dsh-compact/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "dsh-compact",
+  "version": "1.0.0",
+  "description": "Request-path context compaction with bounded overflow recovery for DeepSeek Harness",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./engine": "./lib/engine.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib/",
+    "cordis.patch.yml",
+    "LICENSE"
+  ],
+  "dsh": {
+    "client": {
+      "platform": "web",
+      "inject": [
+        "@deepseek-ai/dsh-client-web-react",
+        "@deepseek-ai/dsh-client-ui-settings",
+        "@deepseek-ai/dsh-client-ui-settings-plugins"
+      ]
+    },
+    "bundle": {
+      "patch": "cordis.patch.yml"
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-compaction-basic": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+    "@deepseek-ai/schemastery": "^3.18.1"
+  },
+  "license": "MIT"
+}

--- a/dsh-desktop/compact-preset-migrate.js
+++ b/dsh-desktop/compact-preset-migrate.js
@@ -5,7 +5,8 @@ const path = require('node:path');
 const yaml = require('js-yaml');
 
 const OLD_ENGINE = '@deepseek-ai/dsh-compaction-basic';
-const NEW_ENGINE = 'dsh-compact/engine';
+const TRANSITION_ENGINE = 'dsh-compact/engine';
+const NEW_AGENT = 'dsh-compact/agent';
 const MANAGED_PRESETS = Object.freeze([
   'anchored-standard',
   'router-standard',
@@ -16,34 +17,95 @@ const MANAGED_PRESETS = Object.freeze([
   'zero-anchored-standard',
 ]);
 
-function replaceCompactionEngine(text) {
+const JsExpr = new yaml.Type('tag:yaml.org,2002:js', {
+  kind: 'scalar',
+  resolve: (data) => typeof data === 'string',
+  construct: (data) => ({ __jsExpr: data }),
+});
+const DSH_YAML_SCHEMA = yaml.JSON_SCHEMA.extend(JsExpr);
+
+function parsePreset(text) {
+  return yaml.load(text, { schema: DSH_YAML_SCHEMA });
+}
+
+function readPrunerConfig(block) {
+  const lines = block.split('\n');
+  const start = lines.findIndex((line) => /^\s*-\s*id:\s*tool-result-pruner\s*(?:#.*)?$/.test(line));
+  if (start < 0) return [];
+  const result = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\s*-\s*id:\s*/.test(lines[i])) break;
+    const match = /^\s+(thresholdChars|headChars|tailChars):(\s*.+)$/.exec(lines[i]);
+    if (match) result.push(`    ${match[1]}:${match[2]}`);
+  }
+  return result;
+}
+
+function compactionSectionBodyStart(lines, groupIndex) {
+  for (let i = groupIndex - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === '' || line.startsWith('#')) {
+      if (/^# ── compaction\b/.test(line)) return i + 1;
+      continue;
+    }
+    break;
+  }
+  return groupIndex;
+}
+
+function replaceCompactionGroup(text) {
   if (typeof text !== 'string' || text === '') return { text, changed: false };
   const lines = text.split(/\r?\n/);
-  let changed = false;
+  const eol = text.includes('\r\n') ? '\r\n' : '\n';
   for (let i = 0; i < lines.length; i++) {
-    if (!/^[ \t]*-\s*id:\s*compaction-basic\s*(?:#.*)?$/.test(lines[i])) continue;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (/^[ \t]*-\s*id:/.test(lines[j])) break;
-      const match = /^([ \t]*name:\s*)(['"])@deepseek-ai\/dsh-compaction-basic\2(\s*(?:#.*)?)$/.exec(lines[j]);
-      if (!match) continue;
-      lines[j] = `${match[1]}${match[2]}${NEW_ENGINE}${match[2]}${match[3]}`;
-      changed = true;
-      break;
+    if (!/^- id:\s*compaction\s*(?:#.*)?$/.test(lines[i])) continue;
+    let end = i + 1;
+    while (
+      end < lines.length
+      && !/^- id:\s*/.test(lines[end])
+      && !/^# ── /.test(lines[end])
+    ) end += 1;
+    const block = lines.slice(i, end).join('\n');
+    const hasEngine = block.includes(`name: '${OLD_ENGINE}'`)
+      || block.includes(`name: "${OLD_ENGINE}"`)
+      || block.includes(`name: '${TRANSITION_ENGINE}'`)
+      || block.includes(`name: "${TRANSITION_ENGINE}"`);
+    if (!hasEngine || !/\bid:\s*command-compact\b/.test(block) || !/\bid:\s*tool-result-pruner\b/.test(block)) {
+      return { text, changed: false };
     }
+    const replacement = [
+      '- id: compact-agent',
+      `  name: '${NEW_AGENT}'`,
+      '  isolate:',
+      '    compaction: true',
+      '    toolResultPruner: true',
+    ];
+    const prunerConfig = readPrunerConfig(block);
+    if (prunerConfig.length) replacement.push('  config:', ...prunerConfig);
+    const start = compactionSectionBodyStart(lines, i);
+    if (start < i) {
+      replacement.unshift(
+        '',
+        '# `dsh-compact/agent` keeps the engine, `/compact` command, and tool-result',
+        '# pruner in one agent-local realm while exposing a single product-level entry.',
+      );
+    }
+    lines.splice(start, end - start, ...replacement);
+    return { text: lines.join(eol), changed: true };
   }
-  return { text: changed ? lines.join(text.includes('\r\n') ? '\r\n' : '\n') : text, changed };
+  return { text, changed: false };
 }
 
 function migratePresetFile(file, log = () => {}) {
   let before;
   try { before = fs.readFileSync(file, 'utf8'); } catch { return { status: 'missing', file }; }
-  try { yaml.load(before); } catch (error) {
+  try { parsePreset(before); } catch (error) {
     log(`跳过无法解析的 preset: ${file}: ${error.message}`);
     return { status: 'invalid', file, error: error.message };
   }
-  const replaced = replaceCompactionEngine(before);
+  const replaced = replaceCompactionGroup(before);
   if (!replaced.changed) return { status: 'kept', file };
-  try { yaml.load(replaced.text); } catch (error) {
+  try { parsePreset(replaced.text); } catch (error) {
     log(`跳过迁移后无法解析的 preset: ${file}: ${error.message}`);
     return { status: 'invalid-result', file, error: error.message };
   }
@@ -69,9 +131,12 @@ function migrateManagedCompactPresets(presetsRoot, log = () => {}) {
 
 module.exports = {
   MANAGED_PRESETS,
-  NEW_ENGINE,
+  NEW_AGENT,
   OLD_ENGINE,
+  TRANSITION_ENGINE,
+  DSH_YAML_SCHEMA,
   migrateManagedCompactPresets,
   migratePresetFile,
-  replaceCompactionEngine,
+  parsePreset,
+  replaceCompactionGroup,
 };

--- a/dsh-desktop/compact-preset-migrate.js
+++ b/dsh-desktop/compact-preset-migrate.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const OLD_ENGINE = '@deepseek-ai/dsh-compaction-basic';
+const NEW_ENGINE = 'dsh-compact/engine';
+const MANAGED_PRESETS = Object.freeze([
+  'anchored-standard',
+  'router-standard',
+  'v4-flash-godmode-opencode-go',
+  'warmupbetter',
+  'warmupbetter-replay',
+  'whoami-standard',
+  'zero-anchored-standard',
+]);
+
+function replaceCompactionEngine(text) {
+  if (typeof text !== 'string' || text === '') return { text, changed: false };
+  const lines = text.split(/\r?\n/);
+  let changed = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^[ \t]*-\s*id:\s*compaction-basic\s*(?:#.*)?$/.test(lines[i])) continue;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^[ \t]*-\s*id:/.test(lines[j])) break;
+      const match = /^([ \t]*name:\s*)(['"])@deepseek-ai\/dsh-compaction-basic\2(\s*(?:#.*)?)$/.exec(lines[j]);
+      if (!match) continue;
+      lines[j] = `${match[1]}${match[2]}${NEW_ENGINE}${match[2]}${match[3]}`;
+      changed = true;
+      break;
+    }
+  }
+  return { text: changed ? lines.join(text.includes('\r\n') ? '\r\n' : '\n') : text, changed };
+}
+
+function migratePresetFile(file, log = () => {}) {
+  let before;
+  try { before = fs.readFileSync(file, 'utf8'); } catch { return { status: 'missing', file }; }
+  try { yaml.load(before); } catch (error) {
+    log(`跳过无法解析的 preset: ${file}: ${error.message}`);
+    return { status: 'invalid', file, error: error.message };
+  }
+  const replaced = replaceCompactionEngine(before);
+  if (!replaced.changed) return { status: 'kept', file };
+  try { yaml.load(replaced.text); } catch (error) {
+    log(`跳过迁移后无法解析的 preset: ${file}: ${error.message}`);
+    return { status: 'invalid-result', file, error: error.message };
+  }
+  const backup = file + '.bak';
+  try {
+    if (!fs.existsSync(backup)) fs.copyFileSync(file, backup);
+    const temp = file + `.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(temp, replaced.text, 'utf8');
+    fs.renameSync(temp, file);
+    return { status: 'migrated', file, backup };
+  } catch (error) {
+    log(`迁移 preset 失败: ${file}: ${error.message}`);
+    return { status: 'failed', file, error: error.message };
+  }
+}
+
+function migrateManagedCompactPresets(presetsRoot, log = () => {}) {
+  return MANAGED_PRESETS.map((name) => migratePresetFile(
+    path.join(presetsRoot, name, 'agent.cordis.yml'),
+    log,
+  ));
+}
+
+module.exports = {
+  MANAGED_PRESETS,
+  NEW_ENGINE,
+  OLD_ENGINE,
+  migrateManagedCompactPresets,
+  migratePresetFile,
+  replaceCompactionEngine,
+};

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -39,6 +39,7 @@ files:
   - plugin-guard.js
   - rescue-agent.js
   - preset-sync.js
+  - compact-preset-migrate.js
   - error-detail.js
   - bundle-integrity.js
   - stable-port.js

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -50,6 +50,7 @@ const {
 } = require('./koffi-preflight');
 const { configLinesFor, healSoulMdPatchRow, healRowConfig, removeBundledRowDuplicates, collectBundleEntryIds } = require('./patch-row-heal');
 const { syncBundledPresets, ensureDefaultAgentPreset } = require('./preset-sync');
+const { migrateManagedCompactPresets } = require('./compact-preset-migrate');
 const { buildErrorDetail } = require('./error-detail');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { isEncodingMismatch, healSessionEncodingConflicts } = require('./session-encoding-heal');
@@ -3109,9 +3110,9 @@ const COMPANION_PLUGINS = [
   // 外观自定义：字体家族/字号/文字与代码颜色的设置页分区，实时预览，
   // localStorage 持久化（纯客户端，无宿主半边）。
   { id: 'font-custom', name: 'dsh-font-custom', dir: 'dsh-font-custom' },
-  // 自动压缩：监听 contextPressure 投影，接近上下文上限（默认 80%）时
-  // 自动向当前会话发送 /compact（dsh 原生命令，压缩事务由内核执行）。
-  { id: 'auto-compact', name: 'dsh-auto-compact', dir: 'dsh-auto-compact' },
+  // 请求路径自动压缩：在模型请求前按真实 Token 压力调用 DSH 原生压缩
+  // 引擎；上下文溢出时最多压缩并重试原请求一次，不再模拟输入 /compact。
+  { id: 'compact', name: 'dsh-compact', dir: 'dsh-compact' },
   // 插件保护中心 UI：快照列表/一键回滚/健康检查/事故报告，经桌面壳
   // IPC（guard:action）驱动 plugin-guard.js 引擎。
   { id: 'plugin-shield', name: 'dsh-plugin-shield', dir: 'dsh-plugin-shield' },
@@ -3922,6 +3923,9 @@ function imagePasteSave(dataUrl, name) {
 // 默认禁用的配套插件（dsh-pet）被用户启用后不会被下次 sync 重新插回
 // disabled 行（sync 的「已有行不重写」规则自然接管）。
 function pluginManagerSetEnabled(id, enabled) {
+  if (onboardingLogic.CORE_PLUGIN_IDS.has(id)) {
+    return { ok: false, error: '核心插件不可停用: ' + String(id) };
+  }
   const file = path.join(desktopProfileDir(), 'cordis.patch.yml');
   let text = '';
   try { text = fs.readFileSync(file, 'utf8'); } catch {}
@@ -3955,6 +3959,7 @@ function pluginManagerSetEnabled(id, enabled) {
 // 加载。启动时统一清理，避免任何残留路径。
 const RETIRED_BUILTIN_PLUGINS = [
   { id: 'tdai-memory', name: 'dsh-tdai-memory' },
+  { id: 'auto-compact', name: 'dsh-auto-compact' },
 ];
 
 // 清理退役内置插件在 profile 的所有残留（patch 行 / 包副本 / 依赖项）。
@@ -4017,6 +4022,16 @@ function syncCompanionPlugins() {
       (m) => log('boot', m)
     );
     if (presetsSynced.installed.length) log('boot', '已安装内置 agent preset: ' + presetsSynced.installed.join(', '));
+    const compactPresetResults = migrateManagedCompactPresets(
+      path.join(home, '.agent-presets'),
+      (m) => log('boot', m)
+    );
+    const compactPresetMigrated = compactPresetResults
+      .filter((result) => result.status === 'migrated')
+      .map((result) => path.basename(path.dirname(result.file)));
+    if (compactPresetMigrated.length) {
+      log('boot', '已将内置 agent preset 迁移到 dsh-compact: ' + compactPresetMigrated.join(', '));
+    }
     // 默认 preset 指到内置的 anchored-standard（用户已在 settings.yaml 写过
     // default 则一律保留）。失败只降级为官方默认 preset，不影响启动。
     const defaultResult = ensureDefaultAgentPreset(home, 'anchored-standard', (m) => log('boot', m));

--- a/dsh-desktop/plugin-manager-state.js
+++ b/dsh-desktop/plugin-manager-state.js
@@ -65,7 +65,7 @@ function collectPluginRows(entries, ctx = {}) {
     const hasConfig = !!(user && user.hasConfig);
     const isRemoved = !!(extra && extra.removed);
     const isCore = !!(extra && extra.core);
-    const toggleable = group !== 'core' && !(hasConfig && !disabled);
+    const toggleable = group !== 'core' && !isCore && !(hasConfig && !disabled);
     rows.push({
       id,
       name: name || id,

--- a/dsh-desktop/scripts/onboarding.js
+++ b/dsh-desktop/scripts/onboarding.js
@@ -20,10 +20,13 @@ const CORE_PLUGIN_IDS = new Set([
   'plugin-manager',
   'plugin-shield',
   'plugin-wizard',
+  // EAC 内置 agent preset 直接引用 dsh-compact/engine；允许移除会让这些
+  // preset 在创建会话时因 MODULE_NOT_FOUND 失效。
+  'compact',
 ]);
 
 // 向导默认勾选（推荐）：核心之外保留常用增强；重/冷门项（桌宠、第二市场、
-// 外观微调、自动压缩、ClawBot 桥、会话浮窗等）默认不勾，用户按需勾选。
+// 外观微调、ClawBot 桥、会话浮窗等）默认不勾，用户按需勾选。
 const RECOMMENDED_PLUGIN_IDS = new Set([
   'skin-switch',
   'easy-setup',

--- a/dsh-desktop/test/desktop-extras.test.mjs
+++ b/dsh-desktop/test/desktop-extras.test.mjs
@@ -1,6 +1,5 @@
-// Tests for the three new companion plugins' client bundles:
+// Tests for desktop companion plugins' client bundles:
 //   · dsh-font-custom   — config sanitization + CSS generation
-//   · dsh-auto-compact  — occupancy math + config clamping
 //   · dsh-dock-settings — MCP import parsers (Claude JSON / Codex TOML)
 //
 // Client bundles load through window.__ModuleLoader__.load(); the test host
@@ -85,30 +84,6 @@ test('font-custom: buildCss emits variable overrides for configured fields only'
   assert.ok(css.includes('--dsw-alias-label-primary:#112233'));
   const empty = ex.buildCss(ex.sanitize({}));
   assert.equal(empty, '', 'defaults emit no overrides');
-});
-
-// ── dsh-auto-compact ────────────────────────────────────────────────────────
-
-test('auto-compact: occupancy follows the official ContextMeter formula', () => {
-  const ex = loadBundle('assets/plugins/dsh-auto-compact/lib/client.js').__internals;
-  const occ = ex.occupancyOf({ projectedTokens: 80_000, pressureTokens: 60_000, contextWindow: 100_000 });
-  assert.equal(occ.percent, 80);
-  // 无 projectedTokens 时回落到压力采样（与官方一致）。
-  const occ2 = ex.occupancyOf({ pressureTokens: 50_000, contextWindow: 100_000 });
-  assert.equal(occ2.percent, 50);
-  // 缺口字段 → null（不触发）。
-  assert.equal(ex.occupancyOf({ projectedTokens: 10 }), null);
-  assert.equal(ex.occupancyOf(null), null);
-  // 超上限按 100 计。
-  assert.equal(ex.occupancyOf({ projectedTokens: 120_000, contextWindow: 100_000 }).percent, 100);
-});
-
-test('auto-compact: config clamps threshold into 60..95 and defaults to enabled', () => {
-  const ex = loadBundle('assets/plugins/dsh-auto-compact/lib/client.js').__internals;
-  assert.deepEqual(ex.sanitizeConfig({ threshold: 40 }), { enabled: true, threshold: 60 });
-  assert.deepEqual(ex.sanitizeConfig({ threshold: 99 }), { enabled: true, threshold: 95 });
-  assert.deepEqual(ex.sanitizeConfig({ enabled: false }), { enabled: false, threshold: 80 });
-  assert.deepEqual(ex.sanitizeConfig({}), { enabled: true, threshold: 80 });
 });
 
 // ── dsh-dock-settings: MCP import parsers ───────────────────────────────────

--- a/dsh-desktop/test/dsh-compact-engine.test.mjs
+++ b/dsh-desktop/test/dsh-compact-engine.test.mjs
@@ -1,7 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { CONTEXT_WINDOW_EXCEEDED_CODE } from '@deepseek-ai/dsh-llm'
-import { registerAutomaticCompaction } from '../assets/plugins/dsh-compact/lib/engine.js'
+import {
+  registerAutomaticCompaction,
+  summarizeWithToolFreeFallback,
+} from '../assets/plugins/dsh-compact/lib/engine.js'
 
 function harness(policy = {}) {
   const handlers = new Map()
@@ -117,4 +120,39 @@ test('dsh-compact engine hooks: aborted overflow is never retried', async () => 
     signal: controller.signal,
   }, () => { nextCalls += 1 })
   assert.equal(nextCalls, 1)
+})
+
+test('dsh-compact summarizer: empty text retries once without system prompt or tools', async () => {
+  const inputs = []
+  let retryCount = 0
+  const input = {
+    system: 'coding-agent system prompt',
+    tools: [{ name: 'read' }],
+    messages: [{ role: 'user', content: [] }],
+  }
+  const result = await summarizeWithToolFreeFallback(async (nextInput) => {
+    inputs.push(nextInput)
+    if (inputs.length === 1) throw new Error('summarization produced no text summary content')
+    return { summary: [{ type: 'text', text: 'usable summary' }] }
+  }, input, () => { retryCount += 1 })
+
+  assert.equal(retryCount, 1)
+  assert.equal(inputs.length, 2)
+  assert.equal(inputs[0], input)
+  assert.equal('system' in inputs[1], false)
+  assert.equal('tools' in inputs[1], false)
+  assert.equal(inputs[1].messages, input.messages)
+  assert.equal(result.summary[0].text, 'usable summary')
+})
+
+test('dsh-compact summarizer: unrelated failures are never retried', async () => {
+  let calls = 0
+  await assert.rejects(
+    summarizeWithToolFreeFallback(async () => {
+      calls += 1
+      throw new Error('provider unavailable')
+    }, { messages: [] }),
+    /provider unavailable/,
+  )
+  assert.equal(calls, 1)
 })

--- a/dsh-desktop/test/dsh-compact-engine.test.mjs
+++ b/dsh-desktop/test/dsh-compact-engine.test.mjs
@@ -1,0 +1,120 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { CONTEXT_WINDOW_EXCEEDED_CODE } from '@deepseek-ai/dsh-llm'
+import { registerAutomaticCompaction } from '../assets/plugins/dsh-compact/lib/engine.js'
+
+function harness(policy = {}) {
+  const handlers = new Map()
+  const logs = []
+  const ctx = {
+    on(name, handler) {
+      handlers.set(name, handler)
+      return () => handlers.delete(name)
+    },
+    logger: {
+      info: (message) => logs.push(['info', message]),
+      warn: (message) => logs.push(['warn', message]),
+    },
+  }
+  const calls = []
+  const engine = {
+    policyFor: () => ({
+      enabled: true,
+      recoverOnOverflow: true,
+      maxOverflowRetries: 1,
+      ...policy,
+    }),
+    async compactIfNeeded(agent, trigger, signal) {
+      calls.push({ agent, trigger, signal })
+      return null
+    },
+  }
+  const dispose = registerAutomaticCompaction(ctx, engine)
+  return { calls, dispose, engine, handlers, logs }
+}
+
+function fakeAgent() {
+  return {
+    id: 's1',
+    session: {
+      surface: { replaceGeneration: 0 },
+    },
+  }
+}
+
+test('dsh-compact engine hooks: disabled policy skips request-path compaction', async () => {
+  const t = harness({ enabled: false })
+  let nextCalls = 0
+  const agent = fakeAgent()
+  await t.handlers.get('agent/pre-step')(
+    { agent, signal: new AbortController().signal },
+    () => { nextCalls += 1 },
+  )
+  assert.equal(t.calls.length, 0)
+  assert.equal(nextCalls, 1)
+  t.dispose()
+})
+
+test('dsh-compact engine hooks: pressure failures never abort the user turn', async () => {
+  const t = harness()
+  t.engine.compactIfNeeded = async () => { throw new Error('summary failed') }
+  let nextCalls = 0
+  await t.handlers.get('agent/pre-step')(
+    { agent: fakeAgent(), signal: new AbortController().signal },
+    () => { nextCalls += 1 },
+  )
+  assert.equal(nextCalls, 1)
+  assert.match(t.logs[0][1], /continuing the turn/)
+})
+
+test('dsh-compact engine hooks: overflow retries the original request at most once', async () => {
+  const t = harness()
+  const agent = fakeAgent()
+  t.engine.compactIfNeeded = async () => {
+    agent.session.surface.replaceGeneration += 1
+    return {
+      shadowedSeqs: [1],
+      shadowedRange: { start: 1, end: 1 },
+      shadowedTokenCount: 10,
+    }
+  }
+  let nextCalls = 0
+  const payload = {
+    agent,
+    failure: { code: CONTEXT_WINDOW_EXCEEDED_CODE },
+    signal: new AbortController().signal,
+  }
+  assert.deepEqual(
+    await t.handlers.get('agent/request-error')(payload, () => { nextCalls += 1 }),
+    { kind: 'retry' },
+  )
+  assert.equal(await t.handlers.get('agent/request-error')(payload, () => { nextCalls += 1 }), undefined)
+  assert.equal(nextCalls, 1)
+  assert.equal(t.calls.length, 0)
+})
+
+test('dsh-compact engine hooks: no durable replacement preserves original overflow', async () => {
+  const t = harness()
+  const agent = fakeAgent()
+  let nextCalls = 0
+  const result = await t.handlers.get('agent/request-error')({
+    agent,
+    failure: { code: CONTEXT_WINDOW_EXCEEDED_CODE },
+    signal: new AbortController().signal,
+  }, () => { nextCalls += 1 })
+  assert.equal(result, undefined)
+  assert.equal(nextCalls, 1)
+})
+
+test('dsh-compact engine hooks: aborted overflow is never retried', async () => {
+  const t = harness()
+  const controller = new AbortController()
+  controller.abort()
+  let nextCalls = 0
+  await t.handlers.get('agent/request-error')({
+    agent: fakeAgent(),
+    failure: { code: CONTEXT_WINDOW_EXCEEDED_CODE },
+    signal: controller.signal,
+  }, () => { nextCalls += 1 })
+  assert.equal(nextCalls, 1)
+})

--- a/dsh-desktop/test/dsh-compact-host.test.mjs
+++ b/dsh-desktop/test/dsh-compact-host.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import {
+  createCompactNowHandler,
+  createStatusHandler,
+} from '../assets/plugins/dsh-compact/lib/index.js'
+
+function request(method, body = {}, address = '127.0.0.1') {
+  const req = Readable.from(method === 'POST' ? [Buffer.from(JSON.stringify(body))] : [])
+  req.method = method
+  req.url = '/plugins/dsh-compact/status?sessionId=s1'
+  req.headers = { host: '127.0.0.1:13579', origin: 'http://127.0.0.1:13579' }
+  req.socket = { remoteAddress: address }
+  return req
+}
+
+function response() {
+  let status
+  let body = ''
+  return {
+    writeHead(next) { status = next },
+    end(chunk = '') { body += String(chunk) },
+    result() { return { status, body: JSON.parse(body) } },
+  }
+}
+
+function host(service) {
+  const agent = { id: 's1', options: {}, session: { requestHeader: () => undefined } }
+  return {
+    agents: { get: (id) => id === 's1' ? agent : undefined },
+    agentPresets: { serviceFor: () => service },
+  }
+}
+
+test('dsh-compact host: status reports whether the current preset uses the engine', async () => {
+  const handler = createStatusHandler(host({ dshCompact: true }), { get: () => ({}) })
+  const res = response()
+  await handler(request('GET'), res)
+  assert.equal(res.result().status, 200)
+  assert.equal(res.result().body.engineActive, true)
+})
+
+test('dsh-compact host: compact-now returns real completion and never reports early success', async () => {
+  let completed = false
+  const service = {
+    dshCompact: true,
+    async compactNow() {
+      await Promise.resolve()
+      completed = true
+      return { shadowedSeqs: [1] }
+    },
+  }
+  const handler = createCompactNowHandler(host(service))
+  const res = response()
+  await handler(request('POST', { sessionId: 's1' }), res)
+  assert.equal(completed, true)
+  assert.equal(res.result().status, 200)
+  assert.equal(res.result().body.ok, true)
+  assert.equal(res.result().body.compacted, true)
+})
+
+test('dsh-compact host: busy manual compaction is a conflict, not a false success', async () => {
+  const service = {
+    dshCompact: true,
+    async compactNow() {
+      const error = new Error('manual compaction requires an idle agent')
+      error.code = 'busy'
+      throw error
+    },
+  }
+  const res = response()
+  await createCompactNowHandler(host(service))(request('POST', { sessionId: 's1' }), res)
+  assert.equal(res.result().status, 409)
+  assert.equal(res.result().body.code, 'busy')
+})
+
+test('dsh-compact host: rejects non-loopback and inactive sessions', async () => {
+  const handler = createCompactNowHandler(host({ dshCompact: true, compactNow: async () => null }))
+  const forbidden = response()
+  await handler(request('POST', { sessionId: 's1' }, '10.0.0.2'), forbidden)
+  assert.equal(forbidden.result().status, 403)
+
+  const missing = response()
+  await handler(request('POST', { sessionId: 'missing' }), missing)
+  assert.equal(missing.result().status, 404)
+})

--- a/dsh-desktop/test/dsh-compact-integration.test.mjs
+++ b/dsh-desktop/test/dsh-compact-integration.test.mjs
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { Context, Service } from '@deepseek-ai/cordis'
+import * as CompactAgent from '../assets/plugins/dsh-compact/lib/agent.js'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const main = readFileSync(join(root, 'main.js'), 'utf8')
@@ -14,7 +16,7 @@ test('dsh-compact integration: new plugin is bundled and old browser trigger is 
     /\{ id: 'auto-compact'/,
   )
   assert.match(main, /\{ id: 'auto-compact', name: 'dsh-auto-compact' \}/)
-  for (const file of ['package.json', 'cordis.patch.yml', 'LICENSE', 'lib/index.js', 'lib/engine.js', 'lib/policy.js', 'lib/client.js']) {
+  for (const file of ['package.json', 'cordis.patch.yml', 'LICENSE', 'lib/index.js', 'lib/agent.js', 'lib/engine.js', 'lib/policy.js', 'lib/client.js']) {
     assert.equal(existsSync(join(root, 'assets', 'plugins', 'dsh-compact', file)), true, `missing ${file}`)
   }
   const client = readFileSync(join(root, 'assets', 'plugins', 'dsh-compact', 'lib', 'client.js'), 'utf8')
@@ -28,16 +30,72 @@ test('dsh-compact integration: package is core because managed presets depend on
   assert.match(main, /核心插件不可停用/)
 })
 
-test('dsh-compact integration: every managed preset has exactly one compaction service', async () => {
+test('dsh-compact integration: every managed preset exposes one composite compact entry', async () => {
   const migration = await import('../compact-preset-migrate.js')
   for (const name of migration.default.MANAGED_PRESETS) {
     const file = join(root, 'assets', 'agent-presets', name, 'agent.cordis.yml')
     const text = readFileSync(file, 'utf8')
-    assert.equal((text.match(/id:\s*compaction-basic/g) ?? []).length, 1, `${name} compaction id count`)
-    assert.equal((text.match(/name:\s*['"]dsh-compact\/engine['"]/g) ?? []).length, 1, `${name} engine count`)
+    assert.equal((text.match(/id:\s*compact-agent/g) ?? []).length, 1, `${name} compact-agent count`)
+    assert.equal((text.match(/name:\s*['"]dsh-compact\/agent['"]/g) ?? []).length, 1, `${name} agent entry count`)
+    assert.equal((text.match(/id:\s*compaction-basic/g) ?? []).length, 0, `${name} exposes engine row`)
+    assert.equal((text.match(/id:\s*command-compact/g) ?? []).length, 0, `${name} exposes command row`)
+    assert.equal((text.match(/id:\s*tool-result-pruner/g) ?? []).length, 0, `${name} exposes pruner row`)
     assert.equal(text.includes('@deepseek-ai/dsh-compaction-basic'), false, `${name} retains old engine`)
-    assert.match(text, /name:\s*['"]@deepseek-ai\/dsh-command-compact['"]/, `${name} lost /compact command`)
   }
+})
+
+test('dsh-compact integration: plugin inventory hides implementation-level compact entries', () => {
+  const client = readFileSync(join(root, 'assets', 'plugins', 'dsh-compact', 'lib', 'client.js'), 'utf8')
+  for (const id of ['compaction-basic', 'command-compact', 'tool-result-pruner', 'compact-agent']) {
+    assert.match(client, new RegExp(`data-plugin-entry.*${id}`), `inventory filter missing ${id}`)
+  }
+})
+
+test('dsh-compact integration: composite agent starts engine, command and pruner together', async () => {
+  const ctx = new Context()
+  let compactCommand
+
+  class StubService extends Service {
+    constructor(context, name) {
+      super(context, name)
+    }
+  }
+  class Commands extends Service {
+    constructor(context) {
+      super(context, 'commands')
+    }
+    register(command) {
+      compactCommand = command
+      return () => {
+        if (compactCommand === command) compactCommand = undefined
+      }
+    }
+  }
+
+  const providers = await Promise.all([
+    ctx.plugin(class Llm extends StubService {
+      constructor(context) { super(context, 'llm') }
+    }),
+    ctx.plugin(class TokenMeter extends StubService {
+      constructor(context) { super(context, 'tokenMeter') }
+    }),
+    ctx.plugin(class Sessions extends StubService {
+      constructor(context) { super(context, 'sessions') }
+    }),
+    ctx.plugin(Commands),
+  ])
+
+  const handle = ctx.plugin(CompactAgent)
+  await handle.await()
+  assert.equal(ctx.get('compaction')?.dshCompact, true)
+  assert.ok(ctx.get('toolResultPruner'))
+  assert.equal(compactCommand?.name, 'compact')
+
+  await handle.dispose()
+  assert.equal(ctx.get('compaction'), undefined)
+  assert.equal(ctx.get('toolResultPruner'), undefined)
+  assert.equal(compactCommand, undefined)
+  await Promise.all(providers.reverse().map((provider) => provider.dispose()))
 })
 
 test('dsh-compact integration: migration helper is included in packaged app', () => {

--- a/dsh-desktop/test/dsh-compact-integration.test.mjs
+++ b/dsh-desktop/test/dsh-compact-integration.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const main = readFileSync(join(root, 'main.js'), 'utf8')
+
+test('dsh-compact integration: new plugin is bundled and old browser trigger is retired', () => {
+  assert.match(main, /\{ id: 'compact', name: 'dsh-compact', dir: 'dsh-compact' \}/)
+  assert.doesNotMatch(
+    main.slice(main.indexOf('const COMPANION_PLUGINS'), main.indexOf('const PLUGIN_UPDATE_SOURCES')),
+    /\{ id: 'auto-compact'/,
+  )
+  assert.match(main, /\{ id: 'auto-compact', name: 'dsh-auto-compact' \}/)
+  for (const file of ['package.json', 'cordis.patch.yml', 'LICENSE', 'lib/index.js', 'lib/engine.js', 'lib/policy.js', 'lib/client.js']) {
+    assert.equal(existsSync(join(root, 'assets', 'plugins', 'dsh-compact', file)), true, `missing ${file}`)
+  }
+  const client = readFileSync(join(root, 'assets', 'plugins', 'dsh-compact', 'lib', 'client.js'), 'utf8')
+  assert.doesNotMatch(client, /inputActions|setDraft\s*\(|\.submit\s*\(/)
+  assert.match(client, /dsh-auto-compact-config-v1/)
+})
+
+test('dsh-compact integration: package is core because managed presets depend on it', async () => {
+  const onboarding = await import('../scripts/onboarding.js')
+  assert.equal(onboarding.default.CORE_PLUGIN_IDS.has('compact'), true)
+  assert.match(main, /核心插件不可停用/)
+})
+
+test('dsh-compact integration: every managed preset has exactly one compaction service', async () => {
+  const migration = await import('../compact-preset-migrate.js')
+  for (const name of migration.default.MANAGED_PRESETS) {
+    const file = join(root, 'assets', 'agent-presets', name, 'agent.cordis.yml')
+    const text = readFileSync(file, 'utf8')
+    assert.equal((text.match(/id:\s*compaction-basic/g) ?? []).length, 1, `${name} compaction id count`)
+    assert.equal((text.match(/name:\s*['"]dsh-compact\/engine['"]/g) ?? []).length, 1, `${name} engine count`)
+    assert.equal(text.includes('@deepseek-ai/dsh-compaction-basic'), false, `${name} retains old engine`)
+    assert.match(text, /name:\s*['"]@deepseek-ai\/dsh-command-compact['"]/, `${name} lost /compact command`)
+  }
+})
+
+test('dsh-compact integration: migration helper is included in packaged app', () => {
+  const builder = readFileSync(join(root, 'electron-builder.yml'), 'utf8')
+  assert.match(builder, /- compact-preset-migrate\.js/)
+  assert.match(builder, /- assets\/\*\*\/\*/)
+})

--- a/dsh-desktop/test/dsh-compact-migration.test.mjs
+++ b/dsh-desktop/test/dsh-compact-migration.test.mjs
@@ -1,0 +1,85 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const {
+  MANAGED_PRESETS,
+  migrateManagedCompactPresets,
+  migratePresetFile,
+  replaceCompactionEngine,
+} = require('../compact-preset-migrate.js')
+
+test('dsh-compact migration: only replaces the exact compaction-basic row', () => {
+  const before = [
+    'config:',
+    '  - id: compaction-basic',
+    "    name: '@deepseek-ai/dsh-compaction-basic'",
+    '  - id: other',
+    "    name: '@deepseek-ai/dsh-compaction-basic'",
+    "note: '@deepseek-ai/dsh-compaction-basic'",
+    '',
+  ].join('\n')
+  const result = replaceCompactionEngine(before)
+  assert.equal(result.changed, true)
+  assert.match(result.text, /id: compaction-basic\n\s+name: 'dsh-compact\/engine'/)
+  assert.match(result.text, /id: other\n\s+name: '@deepseek-ai\/dsh-compaction-basic'/)
+  assert.match(result.text, /note: '@deepseek-ai\/dsh-compaction-basic'/)
+})
+
+test('dsh-compact migration: creates one backup and is idempotent', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-compact-migrate-'))
+  try {
+    const file = join(dir, 'agent.cordis.yml')
+    const before = "config:\n  - id: compaction-basic\n    name: '@deepseek-ai/dsh-compaction-basic'\n"
+    writeFileSync(file, before)
+    assert.equal(migratePresetFile(file).status, 'migrated')
+    assert.equal(readFileSync(file + '.bak', 'utf8'), before)
+    const migrated = readFileSync(file, 'utf8')
+    assert.match(migrated, /dsh-compact\/engine/)
+    assert.equal(migratePresetFile(file).status, 'kept')
+    assert.equal(readFileSync(file + '.bak', 'utf8'), before)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('dsh-compact migration: invalid YAML is never modified or backed up', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-compact-invalid-'))
+  try {
+    const file = join(dir, 'agent.cordis.yml')
+    const before = "config: [\n  - id: compaction-basic\n    name: '@deepseek-ai/dsh-compaction-basic'\n"
+    writeFileSync(file, before)
+    assert.equal(migratePresetFile(file).status, 'invalid')
+    assert.equal(readFileSync(file, 'utf8'), before)
+    assert.equal(existsSync(file + '.bak'), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('dsh-compact migration: only scans EAC-managed preset names', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-compact-managed-'))
+  try {
+    for (const name of [...MANAGED_PRESETS, 'custom-user-preset']) {
+      mkdirSync(join(dir, name), { recursive: true })
+      writeFileSync(
+        join(dir, name, 'agent.cordis.yml'),
+        "config:\n  - id: compaction-basic\n    name: '@deepseek-ai/dsh-compaction-basic'\n",
+      )
+    }
+    migrateManagedCompactPresets(dir)
+    for (const name of MANAGED_PRESETS) {
+      assert.match(readFileSync(join(dir, name, 'agent.cordis.yml'), 'utf8'), /dsh-compact\/engine/)
+    }
+    assert.match(
+      readFileSync(join(dir, 'custom-user-preset', 'agent.cordis.yml'), 'utf8'),
+      /@deepseek-ai\/dsh-compaction-basic/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/dsh-desktop/test/dsh-compact-migration.test.mjs
+++ b/dsh-desktop/test/dsh-compact-migration.test.mjs
@@ -10,36 +10,88 @@ const {
   MANAGED_PRESETS,
   migrateManagedCompactPresets,
   migratePresetFile,
-  replaceCompactionEngine,
+  parsePreset,
+  replaceCompactionGroup,
 } = require('../compact-preset-migrate.js')
 
-test('dsh-compact migration: only replaces the exact compaction-basic row', () => {
+test('dsh-compact migration: replaces the complete known compaction group with one agent entry', () => {
   const before = [
-    'config:',
-    '  - id: compaction-basic',
-    "    name: '@deepseek-ai/dsh-compaction-basic'",
-    '  - id: other',
-    "    name: '@deepseek-ai/dsh-compaction-basic'",
-    "note: '@deepseek-ai/dsh-compaction-basic'",
+    '- id: before',
+    "  name: 'before'",
+    '# ── compaction ──────────────────────────────────────────────────────────────',
+    '',
+    '# stale compaction-basic explanation',
+    '- id: compaction',
+    '  name: cordis:group',
+    '  group: true',
+    '  isolate:',
+    '    compaction: true',
+    '    toolResultPruner: true',
+    '  config:',
+    '    - id: compaction-basic',
+    "      name: '@deepseek-ai/dsh-compaction-basic'",
+    '    - id: command-compact',
+    "      name: '@deepseek-ai/dsh-command-compact'",
+    '    - id: tool-result-pruner',
+    "      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'",
+    '- id: after',
+    "  name: 'after'",
     '',
   ].join('\n')
-  const result = replaceCompactionEngine(before)
+  const result = replaceCompactionGroup(before)
   assert.equal(result.changed, true)
-  assert.match(result.text, /id: compaction-basic\n\s+name: 'dsh-compact\/engine'/)
-  assert.match(result.text, /id: other\n\s+name: '@deepseek-ai\/dsh-compaction-basic'/)
-  assert.match(result.text, /note: '@deepseek-ai\/dsh-compaction-basic'/)
+  assert.match(result.text, /- id: compact-agent\n  name: 'dsh-compact\/agent'/)
+  assert.doesNotMatch(result.text, /id: compaction-basic|id: command-compact|id: tool-result-pruner/)
+  assert.doesNotMatch(result.text, /stale compaction-basic explanation/)
+  assert.match(result.text, /single product-level entry/)
+  assert.match(result.text, /- id: before/)
+  assert.match(result.text, /- id: after/)
+  parsePreset(result.text)
 })
 
 test('dsh-compact migration: creates one backup and is idempotent', () => {
   const dir = mkdtempSync(join(tmpdir(), 'dsh-compact-migrate-'))
   try {
     const file = join(dir, 'agent.cordis.yml')
-    const before = "config:\n  - id: compaction-basic\n    name: '@deepseek-ai/dsh-compaction-basic'\n"
+    const before = [
+      "- id: platform",
+      "  name: 'x'",
+      "  disabled: !!js process.platform !== 'win32'",
+      '- id: compaction',
+      '  name: cordis:group',
+      '  group: true',
+      '  isolate:',
+      '    compaction: true',
+      '    toolResultPruner: true',
+      '  config:',
+      '    - id: compaction-basic',
+      "      name: 'dsh-compact/engine'",
+      '    - id: command-compact',
+      "      name: '@deepseek-ai/dsh-command-compact'",
+      '    - id: tool-result-pruner',
+      "      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'",
+      '      config:',
+      '        thresholdChars: 9000',
+      '        headChars: 5000',
+      '        tailChars: 1200',
+      '',
+      '# ── delegation and workflows ────────────────────────────────────────────────',
+      '# this comment must survive migration',
+      '- id: delegation',
+      '  name: cordis:group',
+      '',
+    ].join('\r\n')
     writeFileSync(file, before)
     assert.equal(migratePresetFile(file).status, 'migrated')
     assert.equal(readFileSync(file + '.bak', 'utf8'), before)
     const migrated = readFileSync(file, 'utf8')
-    assert.match(migrated, /dsh-compact\/engine/)
+    assert.match(migrated, /dsh-compact\/agent/)
+    assert.match(migrated, /!!js process\.platform/)
+    assert.match(migrated, /thresholdChars: 9000/)
+    assert.match(migrated, /headChars: 5000/)
+    assert.match(migrated, /tailChars: 1200/)
+    assert.match(migrated, /this comment must survive migration/)
+    assert.equal(migrated.includes('\r\n'), true)
     assert.equal(migratePresetFile(file).status, 'kept')
     assert.equal(readFileSync(file + '.bak', 'utf8'), before)
   } finally {
@@ -61,6 +113,47 @@ test('dsh-compact migration: invalid YAML is never modified or backed up', () =>
   }
 })
 
+test('dsh-compact migration: accepts BOM and preserves !!js as inert data', () => {
+  const source = [
+    '\uFEFF- id: platform',
+    "  name: 'x'",
+    "  disabled: !!js (() => { throw new Error('must not execute') })()",
+    '- id: compaction',
+    '  name: cordis:group',
+    '  group: true',
+    '  isolate:',
+    '    compaction: true',
+    '    toolResultPruner: true',
+    '  config:',
+    '    - id: compaction-basic',
+    "      name: '@deepseek-ai/dsh-compaction-basic'",
+    '    - id: command-compact',
+    "      name: '@deepseek-ai/dsh-command-compact'",
+    '    - id: tool-result-pruner',
+    "      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'",
+    '',
+  ].join('\n')
+  const parsed = parsePreset(source)
+  assert.deepEqual(parsed[0].disabled, { __jsExpr: "(() => { throw new Error('must not execute') })()" })
+  const result = replaceCompactionGroup(source)
+  assert.equal(result.changed, true)
+  assert.equal(result.text.charCodeAt(0), 0xFEFF)
+  assert.match(result.text, /!!js \(\(\) =>/)
+})
+
+test('dsh-compact migration: leaves incomplete or unfamiliar compaction groups untouched', () => {
+  const before = [
+    '- id: compaction',
+    '  name: cordis:group',
+    '  group: true',
+    '  config:',
+    '    - id: compaction-basic',
+    "      name: '@deepseek-ai/dsh-compaction-basic'",
+    '',
+  ].join('\n')
+  assert.deepEqual(replaceCompactionGroup(before), { text: before, changed: false })
+})
+
 test('dsh-compact migration: only scans EAC-managed preset names', () => {
   const dir = mkdtempSync(join(tmpdir(), 'dsh-compact-managed-'))
   try {
@@ -68,12 +161,27 @@ test('dsh-compact migration: only scans EAC-managed preset names', () => {
       mkdirSync(join(dir, name), { recursive: true })
       writeFileSync(
         join(dir, name, 'agent.cordis.yml'),
-        "config:\n  - id: compaction-basic\n    name: '@deepseek-ai/dsh-compaction-basic'\n",
+        [
+          '- id: compaction',
+          '  name: cordis:group',
+          '  group: true',
+          '  isolate:',
+          '    compaction: true',
+          '    toolResultPruner: true',
+          '  config:',
+          '    - id: compaction-basic',
+          "      name: '@deepseek-ai/dsh-compaction-basic'",
+          '    - id: command-compact',
+          "      name: '@deepseek-ai/dsh-command-compact'",
+          '    - id: tool-result-pruner',
+          "      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'",
+          '',
+        ].join('\n'),
       )
     }
     migrateManagedCompactPresets(dir)
     for (const name of MANAGED_PRESETS) {
-      assert.match(readFileSync(join(dir, name, 'agent.cordis.yml'), 'utf8'), /dsh-compact\/engine/)
+      assert.match(readFileSync(join(dir, name, 'agent.cordis.yml'), 'utf8'), /dsh-compact\/agent/)
     }
     assert.match(
       readFileSync(join(dir, 'custom-user-preset', 'agent.cordis.yml'), 'utf8'),

--- a/dsh-desktop/test/dsh-compact-policy.test.mjs
+++ b/dsh-desktop/test/dsh-compact-policy.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_CONFIG,
+  compactStatus,
+  resolvePolicy,
+  sanitizeConfig,
+  toBasicResolvedConfig,
+} from '../assets/plugins/dsh-compact/lib/policy.js'
+
+test('dsh-compact policy: defaults are safe and enabled', () => {
+  assert.deepEqual(sanitizeConfig({}), DEFAULT_CONFIG)
+})
+
+test('dsh-compact policy: validates ratios, retries, duplicates and target identity', () => {
+  assert.throws(() => sanitizeConfig({ thresholdRatio: 0.49 }), /thresholdRatio/)
+  assert.throws(() => sanitizeConfig({ retainRatio: 0.51 }), /retainRatio/)
+  assert.throws(() => sanitizeConfig({ thresholdRatio: 0.5, retainRatio: 0.5 }), /less/)
+  assert.throws(() => sanitizeConfig({ maxOverflowRetries: 2 }), /0 or 1/)
+  assert.throws(() => sanitizeConfig({ enabled: 'yes' }), /boolean/)
+  assert.throws(() => sanitizeConfig({ recoverOnOverflow: 1 }), /boolean/)
+  assert.throws(() => sanitizeConfig({ modelPolicies: {} }), /array/)
+  assert.throws(() => sanitizeConfig({ modelPolicies: [{ provider: '', model: 'x' }] }), /provider/)
+  assert.throws(() => sanitizeConfig({
+    modelPolicies: [{ provider: 'p', model: 'm', enabled: 'yes' }],
+  }), /boolean/)
+  assert.throws(() => sanitizeConfig({
+    modelPolicies: [
+      { provider: 'deepseek', model: 'chat' },
+      { provider: 'deepseek', model: 'chat' },
+    ],
+  }), /duplicate/)
+})
+
+test('dsh-compact policy: exact provider/model override wins without affecting defaults', () => {
+  const config = sanitizeConfig({
+    thresholdRatio: 0.75,
+    retainRatio: 0.2,
+    modelPolicies: [{
+      provider: 'openai',
+      model: 'gpt-x',
+      enabled: false,
+      thresholdRatio: 0.9,
+      retainRatio: 0.3,
+      recoverOnOverflow: false,
+      maxOverflowRetries: 0,
+    }],
+  })
+  assert.deepEqual(resolvePolicy(config, { provider: 'openai', model: 'gpt-x' }), {
+    enabled: false,
+    thresholdRatio: 0.9,
+    retainRatio: 0.3,
+    recoverOnOverflow: false,
+    maxOverflowRetries: 0,
+  })
+  assert.equal(resolvePolicy(config, { provider: 'openai', model: 'other' }).thresholdRatio, 0.75)
+})
+
+test('dsh-compact policy: parent engine config is immutable and never auto-registers twice', () => {
+  const config = toBasicResolvedConfig({
+    thresholdRatio: 0.7,
+    retainRatio: 0.1,
+    modelPolicies: [{ provider: 'p', model: 'm', thresholdRatio: 0.8 }],
+  })
+  assert.equal(config.auto, false)
+  assert.equal(config.compactionRetries, 1)
+  assert.equal(config.modelPolicies[0].thresholdRatio, 0.8)
+  assert.ok(Object.isFrozen(config))
+  assert.ok(Object.isFrozen(config.modelPolicies))
+})
+
+test('dsh-compact status: session state is isolated', () => {
+  compactStatus.clear('a')
+  compactStatus.clear('b')
+  compactStatus.set('a', { state: 'measuring', active: true })
+  compactStatus.set('b', { state: 'failed', active: false, error: 'x' })
+  assert.equal(compactStatus.get('a').state, 'measuring')
+  assert.equal(compactStatus.get('b').state, 'failed')
+  assert.equal(compactStatus.get('missing').state, 'idle')
+})

--- a/dsh-desktop/test/dsh-compact-policy.test.mjs
+++ b/dsh-desktop/test/dsh-compact-policy.test.mjs
@@ -56,14 +56,14 @@ test('dsh-compact policy: exact provider/model override wins without affecting d
   assert.equal(resolvePolicy(config, { provider: 'openai', model: 'other' }).thresholdRatio, 0.75)
 })
 
-test('dsh-compact policy: parent engine config is immutable and never auto-registers twice', () => {
+test('dsh-compact policy: parent engine performs one compaction attempt per pressure check', () => {
   const config = toBasicResolvedConfig({
     thresholdRatio: 0.7,
     retainRatio: 0.1,
     modelPolicies: [{ provider: 'p', model: 'm', thresholdRatio: 0.8 }],
   })
   assert.equal(config.auto, false)
-  assert.equal(config.compactionRetries, 1)
+  assert.equal(config.compactionRetries, 0)
   assert.equal(config.modelPolicies[0].thresholdRatio, 0.8)
   assert.ok(Object.isFrozen(config))
   assert.ok(Object.isFrozen(config.modelPolicies))


### PR DESCRIPTION
## 主要改动

- 新增 `dsh-compact` 上下文压缩插件，结合官方基础压缩引擎实现请求前自动压缩与上下文溢出恢复。
- 将压缩引擎、`/compact` 命令和工具结果裁剪器封装成一个 Agent 入口，避免插件列表出现多个实现层挂载项。
- 自动迁移 EAC 管理的 preset，移除旧的独立压缩组合并保留用户不熟悉的自定义配置。
- 增加空摘要降级重试，并限制每次压力检查只生成一个摘要，避免同一回合连续压缩两次。
- 增加状态展示、手动压缩接口及相关安全校验。

## 验证

- `npm test`：559/559 通过。
- `dsh-compact` 定向测试：28/28 通过。
- `git diff --check` 与语法检查通过。
- 本地自动压力测试确认能够生成持久压缩摘要。