### PR TITLE
feat: 余额插件支持自定义模型价格设置

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
@@ -142,18 +142,71 @@ window.__ModuleLoader__.load({
 			["offpeak", "空闲价"],
 		];
 
+		// 获取所有可用模型列表
+		function useAvailableModels() {
+			const [models, setModels] = react.useState([]);
+			const [loading, setLoading] = react.useState(true);
+			react.useEffect(() => {
+				let alive = true;
+				const bridge = window.dshDesktop && window.dshDesktop.balanceModels;
+				if (bridge && typeof bridge.list === "function") {
+					bridge.list().then((res) => {
+						if (alive && res && res.ok && Array.isArray(res.models)) {
+							setModels(res.models);
+						}
+						if (alive) setLoading(false);
+					}).catch(() => {
+						if (alive) setLoading(false);
+					});
+				} else {
+					if (alive) setLoading(false);
+				}
+				return () => { alive = false; };
+			}, []);
+			return { models, loading };
+		}
+
 		function priceBridge() {
 			const b = window.dshDesktop && window.dshDesktop.balancePrices;
 			return b || null;
 		}
 
 		function PricingSection() {
+			const { models: availableModels, loading: modelsLoading } = useAvailableModels();
 			const [model, setModel] = react.useState(PRICE_MODELS[0]);
 			const [form, setForm] = react.useState(null);
 			const [dirty, setDirty] = react.useState(false);
 			const [busy, setBusy] = react.useState(false);
 			const [status, setStatus] = react.useState(null);
 			const [loadError, setLoadError] = react.useState(null);
+			const [showModelPicker, setShowModelPicker] = react.useState(false);
+
+			// 合并默认模型和可用模型列表（去重）
+			const allModels = react.useMemo(() => {
+				const seen = new Set();
+				const result = [];
+				// 先添加默认模型
+				for (const m of PRICE_MODELS) {
+					if (!seen.has(m)) {
+						seen.add(m);
+						result.push({ id: m, name: PRICE_LABELS[m] || m, isDefault: true });
+					}
+				}
+				// 再添加可用模型（跳过已存在的）
+				for (const m of availableModels) {
+					if (!seen.has(m.id)) {
+						seen.add(m.id);
+						result.push({ id: m.id, name: m.name || m.id, provider: m.provider, isDefault: false });
+					}
+				}
+				return result;
+			}, [availableModels]);
+
+			// 获取当前模型的显示名称
+			const currentModelInfo = react.useMemo(() => {
+				const found = allModels.find(m => m.id === model);
+				return found || { id: model, name: model };
+			}, [allModels, model]);
 
 			const load = (m) => {
 				const b = priceBridge();
@@ -272,13 +325,45 @@ window.__ModuleLoader__.load({
 				children: [
 					react_jsx_runtime.jsx("div", { className: "dsh-balance-pr-hint", children: "自定义价格覆盖官方默认档（仅影响本机费用估算显示，单位：¥/百万 token）。" }),
 					react_jsx_runtime.jsxs("div", {
-						className: "dsh-balance-pr-models",
-						children: PRICE_MODELS.map((m) => react_jsx_runtime.jsx("button", {
-							type: "button",
-							className: "dsh-balance-pr-model" + (m === model ? " on" : ""),
-							onClick: () => setModel(m),
-							children: PRICE_LABELS[m] || m,
-						})),
+						className: "dsh-balance-pr-model-selector",
+						children: [
+							react_jsx_runtime.jsxs("div", {
+								className: "dsh-balance-pr-current-model",
+								onClick: () => setShowModelPicker(!showModelPicker),
+								children: [
+									react_jsx_runtime.jsxs("div", { className: "dsh-balance-pr-current-model-info", children: [
+										react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-name", children: currentModelInfo.name }),
+										currentModelInfo.provider && react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-provider", children: currentModelInfo.provider }),
+									]}),
+									react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-id", children: currentModelInfo.id }),
+									react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-arrow" + (showModelPicker ? " open" : ""), children: "▾" }),
+								],
+							}),
+							showModelPicker && react_jsx_runtime.jsx("div", {
+								className: "dsh-balance-pr-model-picker",
+								children: react_jsx_runtime.jsx("div", {
+									className: "dsh-balance-pr-model-picker-list",
+									children: allModels.map((m) => react_jsx_runtime.jsxs("div", {
+										className: "dsh-balance-pr-model-option" + (m.id === model ? " selected" : ""),
+										onClick: () => {
+											setModel(m.id);
+											setShowModelPicker(false);
+										},
+										children: [
+											react_jsx_runtime.jsxs("div", { className: "dsh-balance-pr-model-option-info", children: [
+												react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-option-name", children: m.name }),
+												m.provider && react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-option-provider", children: m.provider }),
+											]}),
+											react_jsx_runtime.jsx("span", { className: "dsh-balance-pr-model-option-id", children: m.id }),
+										],
+									}, m.id)),
+								}),
+							}),
+						],
+					}),
+					modelsLoading && react_jsx_runtime.jsx("div", {
+						className: "dsh-balance-pr-hint",
+						children: "正在加载模型列表…",
 					}),
 					react_jsx_runtime.jsxs("div", {
 						className: "dsh-balance-pr-grid",
@@ -321,10 +406,24 @@ window.__ModuleLoader__.load({
 			".dsh-balance-pr{display:flex;flex-direction:column;gap:10px;font-size:13px;line-height:20px;color:var(--eac-widget-fg,var(--dsw-alias-label-secondary))}",
 			".dsh-balance-pr.err{color:var(--dsw-alias-danger,#e5484d)}",
 			".dsh-balance-pr-hint{font-size:12px;color:var(--dsw-alias-label-tertiary)}",
-			".dsh-balance-pr-models{display:flex;flex-wrap:wrap;gap:6px}",
-			".dsh-balance-pr-model{border:1px solid var(--dsw-alias-border-l2);background:transparent;border-radius:999px;padding:2px 10px;font-size:12px;color:inherit;cursor:pointer;transition:color .15s,border-color .15s}",
-			".dsh-balance-pr-model:hover{border-color:var(--dsw-alias-border-l3)}",
-			".dsh-balance-pr-model.on{color:var(--dsw-alias-accent,#5e9cff);border-color:var(--dsw-alias-accent,#5e9cff)}",
+			".dsh-balance-pr-model-selector{position:relative}",
+			".dsh-balance-pr-current-model{display:flex;align-items:center;gap:8px;padding:8px 12px;border:1px solid var(--dsw-alias-border-l2);border-radius:8px;cursor:pointer;transition:border-color .15s}",
+			".dsh-balance-pr-current-model:hover{border-color:var(--dsw-alias-border-l3)}",
+			".dsh-balance-pr-current-model-info{display:flex;flex-direction:column;flex:1;min-width:0}",
+			".dsh-balance-pr-model-name{font-weight:500;color:var(--dsw-alias-label-primary)}",
+			".dsh-balance-pr-model-provider{font-size:11px;color:var(--dsw-alias-label-tertiary)}",
+			".dsh-balance-pr-model-id{font-size:11px;color:var(--dsw-alias-label-tertiary);font-family:monospace}",
+			".dsh-balance-pr-model-arrow{font-size:10px;color:var(--dsw-alias-label-tertiary);transition:transform .15s}",
+			".dsh-balance-pr-model-arrow.open{transform:rotate(180deg)}",
+			".dsh-balance-pr-model-picker{position:absolute;top:100%;left:0;right:0;margin-top:4px;background:var(--dsw-alias-bg-elevated,#fff);border:1px solid var(--dsw-alias-border-l2);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,.15);z-index:1000;max-height:300px;overflow:hidden}",
+			".dsh-balance-pr-model-picker-list{max-height:300px;overflow-y:auto;padding:4px}",
+			".dsh-balance-pr-model-option{display:flex;align-items:center;gap:8px;padding:8px 12px;cursor:pointer;border-radius:6px;transition:background .1s}",
+			".dsh-balance-pr-model-option:hover{background:var(--dsw-alias-bg-hover,rgba(0,0,0,.05))}",
+			".dsh-balance-pr-model-option.selected{background:var(--dsw-alias-accent-subtle,rgba(94,156,255,.1))}",
+			".dsh-balance-pr-model-option-info{display:flex;flex-direction:column;flex:1;min-width:0}",
+			".dsh-balance-pr-model-option-name{font-size:13px;color:var(--dsw-alias-label-primary)}",
+			".dsh-balance-pr-model-option-provider{font-size:11px;color:var(--dsw-alias-label-tertiary)}",
+			".dsh-balance-pr-model-option-id{font-size:11px;color:var(--dsw-alias-label-tertiary);font-family:monospace}",
 			".dsh-balance-pr-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px}",
 			".dsh-balance-pr-tier{border:1px solid var(--dsw-alias-border-l1);border-radius:8px;padding:10px 12px;display:flex;flex-direction:column;gap:8px}",
 			".dsh-balance-pr-tier-title{font-size:12px;color:var(--dsw-alias-label-tertiary)}",

--- a/dsh-desktop/balance.js
+++ b/dsh-desktop/balance.js
@@ -128,10 +128,28 @@ function readApiKey(dshHome) {
 
 // 当前默认模型（~/.dsh/settings.yaml 的 agent-default-model.model），
 // 决定按哪一档价格估算本轮费用。
+// 修复：先定位 agent-default-model 块，再在该块内匹配 model 行，
+// 避免匹配到其他配置块（如 describe-image）的 model 字段。
 function readActiveModel(dshHome) {
   try {
     const text = fs.readFileSync(path.join(dshHome, 'settings.yaml'), 'utf8');
-    const m = text.match(/^\s*model\s*:\s*(\S+)/m);
+    // 找到 agent-default-model: 块的起始位置
+    const blockMatch = text.match(/^agent-default-model\s*:/m);
+    if (!blockMatch) return '';
+    const blockStart = blockMatch.index + blockMatch[0].length;
+    // 找到下一个同级或更高级的 key（缩进 <= 0 的行），作为块的结束
+    const rest = text.slice(blockStart);
+    const lines = rest.split(/\r?\n/);
+    let blockContent = '';
+    for (const line of lines) {
+      // 跳过空行
+      if (!line.trim()) { blockContent += line + '\n'; continue; }
+      // 如果缩进为 0（新的顶级 key），则块结束
+      if (/^\S/.test(line)) break;
+      blockContent += line + '\n';
+    }
+    // 在 agent-default-model 块内匹配 model 行
+    const m = blockContent.match(/^\s*model\s*:\s*(\S+)/m);
     if (m) return m[1];
   } catch {}
   return '';

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -2851,7 +2851,7 @@ function registerChromeIpc() {
   ipcMain.handle('dsh:balance-prices-set', async (event, { model, prices } = {}) => {
     if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
     const m = String(model || '');
-    if (!balance.DEFAULT_PRICES[m]) return { ok: false, error: '未知模型: ' + m };
+    if (!m) return { ok: false, error: '模型名称不能为空' };
     try {
       const cleaned = balance.sanitizePrices(prices);
       const ctx = updCtx();
@@ -2880,6 +2880,122 @@ function registerChromeIpc() {
       return { ok: true };
     } catch (err) {
       return { ok: false, error: String((err && err.message) || err) };
+    }
+  });
+
+  // 获取所有可用模型列表（用于余额插件的价格设置页）
+  // 直接从 settings.yaml 的 llm-pi-ai.providers 中读取所有配置的模型
+  ipcMain.handle('dsh:balance-models', async (event) => {
+    if (!mainWindow || event.sender !== mainWindow.webContents) return { ok: false, error: 'unauthorized' };
+    try {
+      const home = dshHome || path.join(os.homedir(), '.dsh');
+      const settingsPath = path.join(home, 'settings.yaml');
+      if (!fs.existsSync(settingsPath)) {
+        return { ok: true, models: [] };
+      }
+      const text = fs.readFileSync(settingsPath, 'utf8');
+      const models = [];
+
+      // 简单的 YAML 解析：提取 llm-pi-ai.providers 下的所有模型
+      const lines = text.split(/\r?\n/);
+      let inProviders = false;
+      let providerIndent = -1;
+      let currentProvider = '';
+      let inModels = false;
+      let modelsIndent = -1;
+      let currentModel = null;
+
+      for (const line of lines) {
+        // 跳过空行和注释
+        if (!line.trim() || line.trim().startsWith('#')) continue;
+
+        // 计算缩进
+        const indent = line.search(/\S/);
+
+        // 检测 llm-pi-ai.providers 块
+        if (/^llm-pi-ai\s*:/i.test(line)) {
+          inProviders = true;
+          providerIndent = -1;
+          continue;
+        }
+
+        // 在 llm-pi-ai 块内检测 providers
+        if (inProviders && /^\s+providers\s*:/i.test(line)) {
+          providerIndent = indent;
+          continue;
+        }
+
+        // 如果在 providers 块内
+        if (providerIndent >= 0) {
+          // 如果缩进小于等于 providers 的缩进，说明离开了 providers 块
+          if (indent <= providerIndent && line.trim()) {
+            // 检查是否是新的顶级配置块
+            if (/^[a-z]/i.test(line.trim())) {
+              break;
+            }
+            continue;
+          }
+
+          // 检测 provider 名称（缩进比 providers 多 2-4 个空格，排除 models/baseURL/apiKeyEnv 等字段）
+          const providerMatch = line.match(new RegExp(`^\\s{${providerIndent + 2},${providerIndent + 6}}([a-z][\\w-]*)\\s*:`));
+          if (providerMatch && !inModels && !['models', 'baseurl', 'apikeyenv', 'displayname', 'api'].includes(providerMatch[1].toLowerCase())) {
+            currentProvider = providerMatch[1];
+            continue;
+          }
+
+          // 检测 models 块
+          if (/^\s+models\s*:/i.test(line) && indent > providerIndent) {
+            inModels = true;
+            modelsIndent = indent;
+            continue;
+          }
+
+          // 在 models 块内
+          if (inModels) {
+            // 如果缩进小于等于 models 的缩进，说明离开了 models 块
+            if (indent <= modelsIndent && line.trim()) {
+              inModels = false;
+              currentModel = null;
+              // 重新检测 provider
+              const reProvider = line.match(new RegExp(`^\\s{${providerIndent + 2},${providerIndent + 6}}([\\w][\\w-]*)\\s*:`));
+              if (reProvider) {
+                currentProvider = reProvider[1];
+              }
+              continue;
+            }
+
+            // 检测 model 条目（- id: xxx）
+            const modelMatch = line.match(/^\s+-\s+id\s*:\s*(\S+)/);
+            if (modelMatch) {
+              const modelId = modelMatch[1].replace(/^["']|["']$/g, '');
+              currentModel = { id: modelId, name: modelId, provider: currentProvider };
+              models.push(currentModel);
+              continue;
+            }
+
+            // 检测 model 的 name 字段
+            const nameMatch = line.match(/^\s+name\s*:\s*(.+)/);
+            if (nameMatch && currentModel) {
+              currentModel.name = nameMatch[1].trim().replace(/^["']|["']$/g, '');
+              continue;
+            }
+          }
+        }
+      }
+
+      // 按 model id 去重（保留第一个遇到的 provider）
+      const seen = new Set();
+      const uniqueModels = [];
+      for (const m of models) {
+        if (!seen.has(m.id)) {
+          seen.add(m.id);
+          uniqueModels.push(m);
+        }
+      }
+
+      return { ok: true, models: uniqueModels };
+    } catch (err) {
+      return { ok: false, error: String((err && err.message) || err), models: [] };
     }
   });
 

--- a/dsh-desktop/preload.js
+++ b/dsh-desktop/preload.js
@@ -86,6 +86,10 @@ const dshDesktop = {
     set: (model, prices) => ipcRenderer.invoke('dsh:balance-prices-set', { model, prices }),
     reset: (model) => ipcRenderer.invoke('dsh:balance-prices-reset', { model }),
   },
+  // 获取所有可用模型列表（用于余额插件的价格设置页）
+  balanceModels: {
+    list: () => ipcRenderer.invoke('dsh:balance-models'),
+  },
   // 「文件」视图的还原请求：changes = [{path, op, oldText, newText}]（逆序）。
   revertFiles: (changes) => ipcRenderer.invoke('dsh:file-revert', { changes }),
   // 「全部文件」视图：用系统默认程序打开项目文件。


### PR DESCRIPTION
## 概述

本 PR 为余额插件添加了自定义模型价格设置功能，解决了 Issue #133 中报告的价格档错误问题。

## 修改内容

### 1. 修复 readActiveModel() 函数（balance.js）
- **问题**：原来的正则表达式会匹配 settings.yaml 中第一个 model: 行，导致可能匹配到其他配置块的 model 字段
- **修复**：先定位 agent-default-model 块，再在该块内匹配 model 行

### 2. 添加模型列表 API（main.js）
- 新增 dsh:balance-models IPC 处理器
- 直接从 settings.yaml 的 llm-pi-ai.providers 中读取所有配置的模型
- 支持所有 provider 的模型

### 3. 修改价格设置处理器（main.js）
- dsh:balance-prices-set 不再限制于 DEFAULT_PRICES 中的模型
- 支持为任意模型设置自定义价格

### 4. 添加桥接方法（preload.js）
- 新增 balanceModels.list() 方法

### 5. 改进 UI（client.js）
- 将模型选择从标签按钮改为下拉选择器
- 显示所有已配置的模型，按 provider 分组

Fixes #133