### PR TITLE
fix: splash screen dynamically reads version from package.json

### DIFF
--- a/dsh-desktop/assets/loading.html
+++ b/dsh-desktop/assets/loading.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
 <meta charset="utf-8" />
-<title>Deepseek Harness EAC v1.0</title>
+<title>Deepseek Harness EAC</title>
 <style>
   :root { color-scheme: dark; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -35,10 +35,28 @@
 </style>
 </head>
 <body>
-  <img class="icon" src="icon.png" alt="Deepseek Harness EAC v1.0" draggable="false" />
+  <img class="icon" src="icon.png" alt="Deepseek Harness EAC" draggable="false" />
   <div class="spinner"></div>
   <h1>DeepSeek Harness 正在启动…</h1>
   <p>正在本机启动 dsh web 服务，首次启动可能需要几十秒。</p>
-  <p class="hint">Deepseek Harness EAC v1.0 — 数据目录中的日志可帮助排查启动问题。</p>
+  <p class="hint">Deepseek Harness EAC <span id="version">加载中…</span> — 数据目录中的日志可帮助排查启动问题。</p>
+  <script>
+    // 动态读取版本号
+    (async function() {
+      try {
+        if (window.dshDesktop && window.dshDesktop.getInfo) {
+          const info = await window.dshDesktop.getInfo();
+          if (info && info.appVersion) {
+            document.getElementById('version').textContent = 'v' + info.appVersion;
+            document.title = 'Deepseek Harness EAC v' + info.appVersion;
+            document.querySelector('.icon').alt = 'Deepseek Harness EAC v' + info.appVersion;
+          }
+        }
+      } catch (e) {
+        console.error('Failed to get version:', e);
+        document.getElementById('version').textContent = 'v?.?.?';
+      }
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## 问题描述

启动页（loading.html）硬编码了 v1.0 版本号，与实际版本（如 v4.4.1）不一致。

## 修改内容

- 移除 loading.html 中硬编码的 v1.0 版本号
- 通过 window.dshDesktop.getInfo() 动态获取实际版本号
- 更新标题、alt 文本和提示文本
- 如果版本获取失败，显示 v?.?.? 作为 fallback

## 测试情况

- [x] 语法检查通过
- [x] 测试运行（493 pass，15 fail 为预存的依赖缺失问题，与本次修改无关）

## 相关文件

- dsh-desktop/assets/loading.html