### PR TITLE
修复 #135 中桌面端无法识别上一次异常退出的问题，恢复异常退出通知和客户端崩溃自动回退功能。  Fixes #135

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -4958,10 +4958,11 @@ async function boot() {
   // 新老用户判定必须在任何写盘之前：run-state / migrate 标记 / 稳定端口
   // 都会在启动早期创建 settings.json，事后无法区分全新安装与升级。
   const onboardingNeeded = computeOnboardingNeed();
+  // 必须先读取上一次状态，再覆盖写入本次状态；否则当前 PID 会掩盖异常退出。
+  const uncleanPrev = detectUncleanPreviousRun();
   // 看门狗 + 运行状态标记（安装版）：意外崩溃后自动拉起并告知用户。
   writeRunState();
   startWatchdog();
-  const uncleanPrev = detectUncleanPreviousRun();
   // V4.1 更新保障③：便携版客户端更新后若新版崩溃（非干净退出 + 上一版
   // 备份 marker 仍在），先用上一版还原再继续启动，随后再告知用户。
   autoRollbackClientIfCrashed(uncleanPrev);

--- a/dsh-desktop/test/recovery-integration.test.mjs
+++ b/dsh-desktop/test/recovery-integration.test.mjs
@@ -29,6 +29,27 @@ test('main.js runs the watchdog lifecycle: run-state write, spawn, clean-exit ma
   assert.ok(/startWatchdog\(\);/.test(mainSrc), 'startWatchdog() is never called');
 });
 
+test('main.js detects the previous run before replacing run-state.json', () => {
+  const detect = mainSrc.indexOf('const uncleanPrev = detectUncleanPreviousRun();');
+  const write = mainSrc.indexOf('writeRunState();', detect);
+  const watchdog = mainSrc.indexOf('startWatchdog();', write);
+  assert.ok(detect >= 0, 'previous-run detection missing');
+  assert.ok(write > detect, 'current run-state must be written after previous-run detection');
+  assert.ok(watchdog > write, 'watchdog must start after current run-state is written');
+  assert.ok(mainSrc.indexOf('autoRollbackClientIfCrashed(uncleanPrev);', detect) > watchdog);
+  assert.ok(mainSrc.indexOf('if (uncleanPrev) notifyUncleanRestart(uncleanPrev);', detect) > watchdog);
+});
+
+test('unclean previous-run predicate respects clean exit and PID boundaries', () => {
+  const predicate = (prev, currentPid) => Boolean(
+    prev && prev.cleanExit !== true && prev.pid && Number(prev.pid) !== currentPid,
+  );
+  assert.equal(predicate({ pid: 41, cleanExit: false }, 42), true);
+  assert.equal(predicate({ pid: 41, cleanExit: true }, 42), false);
+  assert.equal(predicate({ pid: 42, cleanExit: false }, 42), false);
+  assert.equal(predicate({ pid: 0, cleanExit: false }, 42), false);
+});
+
 test('main.js registers the heartbeat IPC and polls heartbeats', () => {
   assert.ok(mainSrc.includes("'dsh:renderer-heartbeat'"), 'heartbeat IPC channel missing');
   assert.ok(/checkHeartbeats\(\)/.test(mainSrc), 'checkHeartbeats() loop missing');


### PR DESCRIPTION
## 摘要

修复 #135 中桌面端无法识别上一次异常退出的问题，恢复异常退出通知和客户端崩溃自动回退功能。

Fixes #135

## 问题

启动时先调用 `writeRunState()` 写入当前进程状态，再调用 `detectUncleanPreviousRun()`。

检测函数因此读取到当前进程的 PID，始终返回 `null`，导致以下功能失效：

- `notifyUncleanRestart()`
- `autoRollbackClientIfCrashed()`

## 修复

调整运行状态初始化顺序：

1. 读取并检测上一次运行状态
2. 写入当前进程的 `run-state.json`
3. 启动 watchdog
4. 根据检测结果执行自动回退和异常退出通知

## 验证

新增回归测试，覆盖：

- 上次未正常退出且 PID 不同时能够检出
- 上次正常退出时不会误报
- 状态 PID 与当前 PID 相同时不会误报
- 检测完成后正常写入当前状态并启动 watchdog

验证结果：`9` 项相关测试全部通过，`main.js` 语法检查通过。