### PR TITLE
fix(web): 工作区名超长时换行显示，避免截断/挤出行内操作按钮 (#34)

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-web-mobile-fix/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-web-mobile-fix/lib/client.js
@@ -141,6 +141,14 @@ window.__ModuleLoader__.load({
       "    width: 100% !important;",
       "  }",
       "}",
+      "/* 8. Sidebar workspace names longer than the sidebar: wrap on multiple lines",
+      "      instead of being clipped / overflowing, so the row actions (kebab menu",
+      "      and new-session \"+\") stay fully visible instead of being pushed out.",
+      "      Applies at any sidebar width (not only mobile). The workspace row is a",
+      "      fixed-height flex row (.projectRow → .projectText > .title). */",
+      ".YDXeBa_projectRow { height: auto !important; min-height: 34px; }",
+      ".YDXeBa_projectRow .YDXeBa_projectText { min-width: 0 !important; flex: 1 1 auto !important; overflow: visible !important; }",
+      ".YDXeBa_projectRow .YDXeBa_projectText .YDXeBa_title { white-space: normal !important; overflow-wrap: anywhere !important; word-break: break-word !important; overflow: visible !important; }",
     ].join("\n");
 
     function apply(ctx) {


### PR DESCRIPTION
## 问题
#34：工作区名字超长时，侧边栏工作区行显示不完整——名字被截断/溢出，行内「…」「+」操作按钮被挤到只剩一半，窄窗口下尤其明显。

## 原因
侧栏工作区树由 `@deepseek-ai/dsh-client-ui-workspace` 渲染，每行结构为
`.projectRow`（固定高 34px 的 flex 行）→ `.projectText` → `.title`（工作区名）+ `.rowActions`。
`.projectText` 缺 `min-width:0` / `overflow` 约束，超长文本把整行撑宽溢出，把 `.rowActions` 顶出可视区。

## 修复
在 `dsh-web-mobile-fix` 客户端插件注入 CSS，让工作区名在侧边栏内多行换行、完整显示（对任意侧边栏宽度生效）：
- `.projectRow` 高度自适应（`min-height:34px` 兜底）
- `.projectText` 允许收缩（`min-width:0` / `flex:1`）
- `.title` 换行（`white-space:normal` + `overflow-wrap:anywhere` + `word-break:break-word`）

选择器只命中 `.projectRow/.projectText`（工作区行专属），不影响会话行的单行样式。

## 验证
- 修改文件 `node --check` 通过
- `node scripts/check-syntax.js`（打包预检，18 个入口）全部通过
- `node --test` 全量 497/512 通过；15 个失败均为本机 `dsh-desktop/node_modules` 未安装导致的依赖缺失（`Cannot find module 'archiver'/'js-yaml'/'@deepseek-ai/*'`），与本改动无关；所有涉及插件管理/打包/移动端的测试（含引用 dsh-web-mobile-fix 的）全部通过

Closes #34