### PR TITLE
fix(test): 修复 watchdog 测试退出码读取竞态，消除 CI 偶发失败

### DIFF
--- a/dsh-desktop/test/watchdog-behavior.test.mjs
+++ b/dsh-desktop/test/watchdog-behavior.test.mjs
@@ -51,6 +51,19 @@ async function runUntilLog(args, needle, timeoutMs = 12000) {
     }
   }
   if (existsSync(logFile)) out = readFileSync(logFile, 'utf8');
+  // 竞态修复：读到目标日志行时子进程可能尚未触发 exit 事件（exitCode 仍为
+  // null），直接返回会把 null 当成真实退出码，导致本用例在 CI 上偶发失败
+  // （`null !== 0`，见 run 32472320868）。这里等待退出事件（进程通常已自退，
+  // 或已被 finally 中的 kill 终止），2s 兜底避免挂死。
+  if (child.exitCode === null) {
+    await Promise.race([
+      new Promise((resolve) => {
+        child.once('exit', resolve);
+        child.once('error', resolve);
+      }),
+      sleep(2000),
+    ]);
+  }
   return { log: out, code: child.exitCode };
 }
 


### PR DESCRIPTION
### 问题

CI run [32472320868](https://github.com/zouyuxuan122/Deepseek-Harness-EAC/actions/runs/32472320868)（及更早的 32446455820）在「运行测试」步骤偶发失败（exit code 1）。完整日志中唯一失败用例：

```
not ok 539 - clean-exit marker → watchdog exits quietly, no relaunch
  location: dsh-desktop/test/watchdog-behavior.test.mjs:57:1
  failureType: testCodeFailure
  error: Expected values to be strictly equal:  null !== 0
  expected: 0   actual: null
  stack: test/watchdog-behavior.test.mjs:68:10
```

### 根因（测试竞态，非产品代码问题）

`runUntilLog()` 在轮询到目标日志行后**立即返回** `child.exitCode`。Node 的 `child.exitCode` 在子进程 `exit` 事件派发前是 `null`；当进程刚写完日志、尚未完成退出时返回，`assert.equal(code, 0)` 就会拿到 `null`（同一 commit 本地 `npm test` 两轮 568/568 全绿、4 轮压测同样全绿，确认是时序敏感的偶发问题，与具体 PR 改动无关——两次失败的 run 对应完全不同的代码变更）。

### 修复

返回前若 `exitCode` 仍为 `null`，先等待子进程的 `exit`/`error` 事件（2s 兜底防挂死），再读取真实退出码。对三个用例均安全：

- clean-exit：读到标记后进程自退 → 拿到真实退出码 0
- pid alive：超时后在 `finally` 中被 kill → `exit` 事件随之触发
- relaunch：同前者

### 验证

- `watchdog-behavior.test.mjs` 单文件连跑 6 轮：全部通过
- 完整测试套件（`node --test "test/*.test.mjs"`）：570/570 通过，0 失败
- PR CI（Node 22）：第 8 步「运行测试」success，job 整体 in_progress