### PR TITLE
fix(plugins): support dsh 0.1.1 client module table

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-compact/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-compact/lib/client.js
@@ -3,7 +3,11 @@ window.__ModuleLoader__.load({
   factory: (require) => {
     const module = { exports: {} }
     const React = require('react')
-    const { bindSnapshotSelector } = require('@deepseek-ai/dsh-client-web-react')
+    const bindSnapshotSelector = (source) => {
+      const subscribe = (listener) => source.subscribe(listener)
+      const getSnapshot = () => source.getSnapshot()
+      return (select) => select(React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot))
+    }
     const h = React.createElement
     const NS = 'dsh-compact'
     const STATUS_ENDPOINT = '/plugins/dsh-compact/status'

--- a/dsh-desktop/assets/plugins/dsh-compact/package.json
+++ b/dsh-desktop/assets/plugins/dsh-compact/package.json
@@ -20,7 +20,6 @@
     "client": {
       "platform": "web",
       "inject": [
-        "@deepseek-ai/dsh-client-web-react",
         "@deepseek-ai/dsh-client-ui-settings",
         "@deepseek-ai/dsh-client-ui-settings-plugins"
       ]

--- a/dsh-desktop/assets/plugins/dsh-conversation-tweaks/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-conversation-tweaks/lib/client.js
@@ -7,7 +7,11 @@ window.__ModuleLoader__.load({
 
 		const react = require("react");
 		const { jsx, jsxs } = require("react/jsx-runtime");
-		const { bindSnapshotSelector } = require("@deepseek-ai/dsh-client-web-react");
+		const bindSnapshotSelector = (source) => {
+			const subscribe = (listener) => source.subscribe(listener);
+			const getSnapshot = () => source.getSnapshot();
+			return (select) => select(react.useSyncExternalStore(subscribe, getSnapshot, getSnapshot));
+		};
 
 		// ------------------------------------------------------------------
 		// Settings

--- a/dsh-desktop/assets/plugins/dsh-openclaw-bridge/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-openclaw-bridge/lib/client.js
@@ -12,8 +12,13 @@ window.__ModuleLoader__.load({
 
 		const react = require("react");
 		const { jsx, jsxs } = require("react/jsx-runtime");
-		const { bindSnapshotSelector } = require("@deepseek-ai/dsh-client-web-react");
-		const { Button, Input } = require("@deepseek-ai/dsh-client-ui-primitives");
+		const bindSnapshotSelector = (source) => {
+			const subscribe = (listener) => source.subscribe(listener);
+			const getSnapshot = () => source.getSnapshot();
+			return (select) => select(react.useSyncExternalStore(subscribe, getSnapshot, getSnapshot));
+		};
+		const Button = ({ variant, size, loading, ...props }) => jsx("button", { type: "button", disabled: loading || props.disabled, ...props });
+		const Input = (props) => jsx("input", props);
 
 		const NS = "openclaw-bridge";
 

--- a/dsh-desktop/assets/plugins/dsh-prompt-custom/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-prompt-custom/lib/client.js
@@ -13,8 +13,12 @@ window.__ModuleLoader__.load({
 
 		const react = require("react");
 		const { jsx, jsxs } = require("react/jsx-runtime");
-		const { bindSnapshotSelector } = require("@deepseek-ai/dsh-client-web-react");
-		const { Button } = require("@deepseek-ai/dsh-client-ui-primitives");
+		const bindSnapshotSelector = (source) => {
+			const subscribe = (listener) => source.subscribe(listener);
+			const getSnapshot = () => source.getSnapshot();
+			return (select) => select(react.useSyncExternalStore(subscribe, getSnapshot, getSnapshot));
+		};
+		const Button = ({ variant, size, loading, ...props }) => jsx("button", { type: "button", disabled: loading || props.disabled, ...props });
 
 		const NS = "dsh-prompt";
 

--- a/dsh-desktop/assets/plugins/dsh-session-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-session-manager/lib/client.js
@@ -16,9 +16,6 @@ window.__ModuleLoader__.load({
 
 		const react = require("react");
 		const { jsx, jsxs } = require("react/jsx-runtime");
-		const { bindSnapshotSelector } = require("@deepseek-ai/dsh-client-web-react");
-		const { Button } = require("@deepseek-ai/dsh-client-ui-primitives");
-
 		const NS = "dsh-session-manager";
 		const L = {
 			nav: "归档对话管理",

--- a/dsh-desktop/assets/plugins/dsh-session-manager/package.json
+++ b/dsh-desktop/assets/plugins/dsh-session-manager/package.json
@@ -24,8 +24,7 @@
     },
     "client": {
       "inject": [
-        "@deepseek-ai/dsh-client-runtime",
-        "@deepseek-ai/dsh-client-ui-primitives"
+        "@deepseek-ai/dsh-client-runtime"
       ],
       "platform": "web"
     }

--- a/dsh-desktop/assets/plugins/dsh-third-party-thinking/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-third-party-thinking/lib/client.js
@@ -12,8 +12,12 @@ window.__ModuleLoader__.load({
 
 		const react = require("react");
 		const { jsx, jsxs } = require("react/jsx-runtime");
-		const { bindSnapshotSelector } = require("@deepseek-ai/dsh-client-web-react");
-		const { Button } = require("@deepseek-ai/dsh-client-ui-primitives");
+		const bindSnapshotSelector = (source) => {
+			const subscribe = (listener) => source.subscribe(listener);
+			const getSnapshot = () => source.getSnapshot();
+			return (select) => select(react.useSyncExternalStore(subscribe, getSnapshot, getSnapshot));
+		};
+		const Button = ({ variant, size, loading, ...props }) => jsx("button", { type: "button", disabled: loading || props.disabled, ...props });
 
 		const NS = "dsh-third-party-thinking";
 

--- a/dsh-desktop/test/client-forward-compat.test.mjs
+++ b/dsh-desktop/test/client-forward-compat.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const plugins = [
+  'dsh-compact',
+  'dsh-conversation-tweaks',
+  'dsh-openclaw-bridge',
+  'dsh-prompt-custom',
+  'dsh-session-manager',
+  'dsh-third-party-thinking',
+];
+
+// dsh 0.1.1 stopped seeding these old shell modules in the browser module
+// table. Companion plugins are fetched dynamically, so a synchronous require
+// of either package fails before the plugin factory can run. Keep these small
+// plugins on React/native controls so an agent overlay can move forward without
+// waiting for a matching desktop release.
+test('companion clients do not require legacy shell-only modules', () => {
+  for (const name of plugins) {
+    const client = readFileSync(join(root, 'assets', 'plugins', name, 'lib', 'client.js'), 'utf8');
+    assert.doesNotMatch(
+      client,
+      /require\(["']@deepseek-ai\/dsh-client-(?:web-react|ui-primitives)["']\)/,
+      `${name} synchronously requires a module absent from the dsh 0.1.1 module table`,
+    );
+
+    const pkg = JSON.parse(readFileSync(join(root, 'assets', 'plugins', name, 'package.json'), 'utf8'));
+    const inject = pkg.dsh?.client?.inject || [];
+    assert.equal(
+      inject.some((id) => id === '@deepseek-ai/dsh-client-web-react' || id === '@deepseek-ai/dsh-client-ui-primitives'),
+      false,
+      `${name} injects a module absent from the dsh 0.1.1 module table`,
+    );
+  }
+});
+
+test('session manager only injects modules available in current and legacy agents', () => {
+  const pkg = JSON.parse(readFileSync(
+    join(root, 'assets', 'plugins', 'dsh-session-manager', 'package.json'),
+    'utf8',
+  ));
+  assert.deepEqual(pkg.dsh.client.inject, ['@deepseek-ai/dsh-client-runtime']);
+});


### PR DESCRIPTION
## Summary

- make bundled companion clients work with the dsh 0.1.1 browser module table
- replace removed `dsh-client-web-react` selector bindings with local `useSyncExternalStore` bindings
- remove unused/obsolete `dsh-client-ui-primitives` imports and inject entries
- add a regression test for legacy shell-only client dependencies

Fixes #157

## Validation

- Verified interactively with EAC 4.4.1 running `@deepseek-ai/dsh@0.1.1-rc.2`
- `node scripts/check-syntax.js`
- `node --test test/client-forward-compat.test.mjs`
- `npm test` - 572 passed, 0 failed