### PR TITLE
修复升级到统一插件市场后，旧市场插件残留导致 `/api/dsh-market` 路由重复注册、dsh web 以返回码 1 退出的问题。

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -4081,14 +4081,16 @@ function pluginManagerSetEnabled(id, enabled) {
   return { ok: true };
 }
 
-// 曾内置、现已从内置清单移除的插件（tdai-memory：唯一携带 node_modules 的
-// 内置插件，v4.5 起退役 —— 体积 ~310MB 占安装包近半，且 vendor 任一小缺失
-// 即 import 失败拖垮插件树）。老用户 profile 可能残留其 patch 行、node_modules
-// 副本与 package.json 依赖：行在包被清会拖垮插件树，包在行在则退役插件继续
-// 加载。启动时统一清理，避免任何残留路径。
+// 曾内置、现已从内置清单移除的插件。老用户 profile 可能残留其 patch 行、
+// node_modules 副本与 package.json 依赖：行在包被清会拖垮插件树，包在行在则
+// 退役插件继续加载。旧市场还会与 dsh-unified-market 重复注册 /api/dsh-market，
+// 使 dsh web 以 code=1 退出。启动时统一清理这些精确的历史内置条目。
 const RETIRED_BUILTIN_PLUGINS = [
   { id: 'tdai-memory', name: 'dsh-tdai-memory' },
   { id: 'auto-compact', name: 'dsh-auto-compact' },
+  { id: 'plugin-marketplace', name: '@deepseek-ai/dsh-plugin-marketplace' },
+  { id: 'dsh-market-plugin', name: '@sanqi-normal/dsh-webui-market-plugin' },
+  { id: 'zat-market', name: 'zat-dsh-engine' },
 ];
 
 // 清理退役内置插件在 profile 的所有残留（patch 行 / 包副本 / 依赖项）。

--- a/dsh-desktop/test/retired-market-migration.test.mjs
+++ b/dsh-desktop/test/retired-market-migration.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { removePluginFromPatch } from '../scripts/plugin-manager-patch.js';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const main = readFileSync(join(root, 'main.js'), 'utf8');
+
+const retiredMarkets = [
+  { id: 'plugin-marketplace', name: '@deepseek-ai/dsh-plugin-marketplace' },
+  { id: 'dsh-market-plugin', name: '@sanqi-normal/dsh-webui-market-plugin' },
+  { id: 'zat-market', name: 'zat-dsh-engine' },
+];
+
+test('all historical built-in markets are retired before unified-market sync', () => {
+  const listStart = main.indexOf('const RETIRED_BUILTIN_PLUGINS = [');
+  const listEnd = main.indexOf('\n];', listStart);
+  const list = main.slice(listStart, listEnd);
+
+  for (const { id, name } of retiredMarkets) {
+    assert.ok(list.includes(`{ id: '${id}', name: '${name}' }`),
+      `${id} must be removed during profile migration`);
+  }
+
+  const cleanupCall = main.indexOf('retireRemovedBuiltinPlugins(desktopProfileDir());');
+  const syncLoop = main.indexOf('for (const p of COMPANION_PLUGINS)', cleanupCall);
+  assert.ok(cleanupCall !== -1 && syncLoop > cleanupCall,
+    'retired markets must be removed before companion plugins are synced');
+});
+
+test('retired market migration removes only the exact historical patch rows', () => {
+  let patch = [
+    '- insert:',
+    "    - id: plugin-marketplace",
+    "      name: '@deepseek-ai/dsh-plugin-marketplace'",
+    '- insert:',
+    '    - id: dsh-market-plugin',
+    "      name: '@sanqi-normal/dsh-webui-market-plugin'",
+    '- insert:',
+    '    - id: zat-market',
+    "      name: 'zat-dsh-engine'",
+    '- insert:',
+    '    - id: custom-market',
+    "      name: 'community-custom-market'",
+    '',
+  ].join('\n');
+
+  for (const { id } of retiredMarkets) patch = removePluginFromPatch(patch, id);
+
+  for (const { id, name } of retiredMarkets) {
+    assert.doesNotMatch(patch, new RegExp(`id: ${id}(?![A-Za-z0-9_.-])`));
+    assert.ok(!patch.includes(name));
+  }
+  assert.match(patch, /id: custom-market/);
+  assert.match(patch, /name: 'community-custom-market'/);
+});


### PR DESCRIPTION
# 修复旧市场插件残留导致 dsh web 启动失败

## 摘要

修复升级到统一插件市场后，旧市场插件残留导致 `/api/dsh-market` 路由重复注册、dsh web 以返回码 1 退出的问题。

## 问题

旧版本 profile 可能仍包含 `plugin-marketplace`、`dsh-market-plugin` 或 `zat-market`。升级后这些插件会与 `dsh-unified-market` 同时加载并重复注册 `/api/dsh-market`，导致插件树启动失败。

## 修复

将三个历史内置市场加入退役插件清单，启动时自动清理对应的 patch 行、包副本和依赖项，同时不影响无关第三方插件。

## 验证

- 新增旧市场迁移回归测试
- 语法检查通过
- 完整测试通过：572 passed，0 failed