### PR TITLE
修复部分桌面配套插件在特定 profile 或加载顺序下，因直接注册其他插件声明的 slot 而加载失败的问题。

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-balance/lib/client.js
@@ -456,17 +456,17 @@ window.__ModuleLoader__.load({
 		 */
 		function apply(ctx) {
 			ensureCss();
-			ctx.effect(() => ctx.slots.register({
+			ctx.slots.inject("conversation.composer.dock", () => ctx.slots.register({
 				name: "conversation.composer.dock",
 				id: "balance",
 				order: 100
-			}, BalanceDock), "dsh-balance: composer dock entry");
-			ctx.effect(() => ctx.slots.register({
+			}, BalanceDock));
+			ctx.slots.inject("settings.section", () => ctx.slots.register({
 				name: "settings.section",
 				id: "pricing",
 				order: 23,
 				label: () => "价格设置"
-			}, PricingSection), "dsh-balance: pricing settings section");
+			}, PricingSection));
 		}
 
 		exports.apply = apply;

--- a/dsh-desktop/assets/plugins/dsh-float-window/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-float-window/lib/client.js
@@ -305,11 +305,11 @@ window.__ModuleLoader__.load({
 			ensureCss();
 			if (!FLOAT) {
 				// 主窗口：注册弹出按钮 + 侧栏拖出代理。
-				ctx.effect(() => ctx.slots.register({
+				ctx.slots.inject("conversation.session.header.actions", () => ctx.slots.register({
 					name: "conversation.session.header.actions",
 					id: "float-window",
 					order: 200
-				}, PopOutButton), "dsh-float-window: pop-out button");
+				}, PopOutButton));
 				ctx.effect(() => setupDragOut(), "dsh-float-window: drag-out proxy");
 				return;
 			}

--- a/dsh-desktop/assets/plugins/dsh-pet-settings/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-pet-settings/lib/client.js
@@ -216,12 +216,12 @@ window.__ModuleLoader__.load({
 
     // ── 注册 ─────────────────────────────────────────────────
     function apply(ctx) {
-      ctx.effect(() => ctx.slots.register({
+      ctx.slots.inject('settings.section', () => ctx.slots.register({
         name: 'settings.section',
         id: 'pet-settings',
         order: 8,
         label: () => '桌宠',
-      }, PetSettingsSection), 'dsh-pet-settings: pet settings section');
+      }, PetSettingsSection));
     }
 
     exports.apply = apply;

--- a/dsh-desktop/test/plugin-slot-registration.test.mjs
+++ b/dsh-desktop/test/plugin-slot-registration.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function pluginSource(name) {
+  return readFileSync(join(root, 'assets', 'plugins', name, 'lib', 'client.js'), 'utf8');
+}
+
+test('root companion plugins inject parent slots before registering entries', () => {
+  const balance = pluginSource('dsh-balance');
+  const floatWindow = pluginSource('dsh-float-window');
+  const petSettings = pluginSource('dsh-pet-settings');
+
+  assert.match(balance,
+    /slots\.inject\("conversation\.composer\.dock",\s*\(\) => ctx\.slots\.register\(\{\s*name: "conversation\.composer\.dock"/);
+  assert.match(balance,
+    /slots\.inject\("settings\.section",\s*\(\) => ctx\.slots\.register\(\{\s*name: "settings\.section"/);
+  assert.match(floatWindow,
+    /slots\.inject\("conversation\.session\.header\.actions",\s*\(\) => ctx\.slots\.register\(\{\s*name: "conversation\.session\.header\.actions"/);
+  assert.match(petSettings,
+    /slots\.inject\('settings\.section',\s*\(\) => ctx\.slots\.register\(\{\s*name: 'settings\.section'/);
+});


### PR DESCRIPTION
# 修复桌面配套插件加载时父级 slot 未声明

## 摘要

修复部分桌面配套插件在特定 profile 或加载顺序下，因直接注册其他插件声明的 slot 而加载失败的问题。

## 问题

`dsh-balance`、`dsh-float-window` 和 `dsh-pet-settings` 直接调用 `slots.register()` 注册 conversation/settings slot。

当对应父级插件尚未建立 children 表时，loader 会报 `slot is not declared`，导致相关插件加载失败并阻断 Web UI。

## 修复

在注册 occupant 前通过 `slots.inject()` 显式注入对应父级 slot，并保持原有组件、顺序和其他副作用不变。

## 验证

- 新增父级 slot 注入回归测试
- 入口语法检查通过
- slot 相关测试通过
- 完整测试中 600 项通过；2 项主线既有设置分组测试失败，与本次修改无关

## 后续开发

这些 slot 支持多个插件继续扩展。新增核心插件时，跨插件注册应继续使用 `slots.inject()`，并确保 occupant `id` 唯一、通过 `order` 控制排列；删除现有插件不会影响同一 slot 下的其他功能。