### PR TITLE
fix(updater): 避免 npm 11 peer 依赖求解导致 dsh 更新卡死

### DIFF
--- a/dsh-desktop/test/update-mirror-chain.test.mjs
+++ b/dsh-desktop/test/update-mirror-chain.test.mjs
@@ -34,7 +34,11 @@ function makeFakeNpmCli(dir, behavior) {
     const key = reg ? reg.slice('--registry='.length).replace(/\\/+$/, '') : '(default)';
     const behavior = ${JSON.stringify(behavior)};
     const out = behavior[key] || behavior['(default)'];
-    if (out === 'ok') {
+    if (out === 'require-legacy-peer-deps' && !args.includes('--legacy-peer-deps')) {
+      process.stderr.write('ERESOLVE peer dependency conflict\\n');
+      process.exit(1);
+    }
+    if (out === 'ok' || out === 'require-legacy-peer-deps') {
       const prefixArg = args[args.indexOf('--prefix') + 1];
       const fs = require('node:fs');
       const path = require('node:path');
@@ -88,6 +92,16 @@ test('applyUpdate: first registry fails -> automatically switches to mirror and 
   assert.ok(events.some((e) => e.stage === 'done'), '成功阶段应上报');
   assert.ok(logs.some((l) => l.includes('自动切换镜像源')), '日志应记录切换');
   assert.ok(fs.existsSync(path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')));
+  rmRetry(userDataDir);
+});
+
+test('applyUpdate: bypasses npm peer-tree backtracking for the isolated dsh overlay', async () => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'upd-peer-deps-'));
+  const cli = makeFakeNpmCli(userDataDir, { '(default)': 'require-legacy-peer-deps' });
+  const { ctx, logs } = makeCtx(cli, userDataDir);
+  const res = await updater.applyUpdate(ctx, '0.1.1-rc.2', { onProgress: () => {} });
+  assert.equal(res.version, '0.1.1-rc.2');
+  assert.ok(logs.some((l) => l.includes('--legacy-peer-deps')), 'npm command must disable peer-tree solving');
   rmRetry(userDataDir);
 });
 

--- a/dsh-desktop/updater.js
+++ b/dsh-desktop/updater.js
@@ -305,6 +305,11 @@ async function applyUpdate(ctx, version, { onProgress = null, stallMs = NPM_STAL
       const args = [
         'install', '--prefix', staging, PKG + '@' + version,
         '--save-exact', '--omit=dev', '--no-audit', '--no-fund', '--no-update-notifier',
+        // dsh is an aggregator whose runtime packages cross-reference each other
+        // through a dense peer graph. npm 11's peer solver can spend minutes
+        // backtracking here without output; the isolated overlay already gets
+        // every runtime package from dsh's explicit dependency list.
+        '--legacy-peer-deps',
         '--loglevel=info',
       ];
       if (registry) args.push('--registry=' + registry);


### PR DESCRIPTION
## 问题

Fixes #150。

桌面端更新官方 dsh 内核时，多名用户反馈进度固定停在“已获取 126 项”。
开启代理或切换 npm registry 后仍然复现，最终被更新器的 150 秒无输出
看门狗判定为“下载停滞”。

结合更新日志和 npm 发布元数据，卡点实际发生在依赖元数据获取之后、
安装解包之前。此时 npm 仍在本地构建 ideal tree，并非继续从 registry
下载内容，因此切换镜像源只会重复执行同一次依赖求解。

## 根因

`@deepseek-ai/dsh@0.1.1-rc.2` 聚合了大量相互依赖的 DSH 包，其依赖树
广泛使用 `peerDependencies` 描述宿主模块关系。

npm 11 在构建这类密集 peer dependency 图时，可能长时间进行依赖回溯，
期间不再产生 stdout/stderr。更新器因此在 150 秒后将其误判为网络下载
停滞，并依次切换 registry 重试，但无法绕过本地依赖树求解阶段。

## 修复

仅在官方 dsh agent 的隔离 staging 安装命令中增加：

`--legacy-peer-deps`

该参数会绕过 npm 11 的 peer dependency 树求解，避免依赖回溯造成的
长时间静默、CPU 空转和内存持续增长。

同时新增集成式回归测试：使用伪 npm CLI 模拟 peer dependency 冲突，
若更新命令没有携带 `--legacy-peer-deps` 则安装失败。

## 影响范围

修改仅作用于官方 dsh 内核的 overlay 更新流程：

- 不影响插件安装和插件更新
- 保留现有 registry 镜像回退
- 保留 30 分钟整体超时
- 保留 150 秒无输出保护
- 保留 staging 完整性校验
- 保留原子切换和版本回滚

dsh overlay 每次从空 staging 目录安装，且顶层 `@deepseek-ai/dsh`
已经显式聚合运行时模块，因此在此处使用兼容模式的影响范围可控。

## 验证

验证环境：

- Node.js v24.12.0
- npm v11.6.2
- `@deepseek-ai/dsh@0.1.1-rc.2`

实际 dry-run：

- 使用 `--legacy-peer-deps`
- 使用 `--ignore-scripts --dry-run`，不执行安装脚本或实际安装
- 430 个包的依赖规划约 11 秒完成

回归测试：

- `node --test test/update-mirror-chain.test.mjs test/updater-version.test.mjs test/updater-backup.test.mjs`
- 13 passed，0 failed
- `node --check updater.js`
- `node --check test/update-mirror-chain.test.mjs`
- `git diff --check upstream/main...HEAD`
