### PR TITLE
feat: 内置 computer-user 插件（读屏+鼠标键盘自动化，配 picturereader）

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ research/                     # 第三方微信/桥接协议调研资料
 | dsh-web-ui（提供者：zhu1090093659） | 9 款内置 Web UI 皮肤来源 |
 | dsh-webui-market（提供者：Sanqi-normal） | 社区插件目录与一键安装/卸载 |
 | picturereader | 统一图片理解插件 |
+| computer-user | 读屏 + 鼠标键盘自动化（Codex-style computer use；配 picturereader，纯文本模型可用） |
 
 感谢所有插件提供者对本项目与开源社区的奉献；由于插件数量众多，我们很抱歉，未能逐一统计到所有插件与其来源；如有插件的拥有者看到了自己所做的插件，欢迎您告知我们并添加到致谢名单中，也欢迎添加我们的交流群，以便一同交流、共同进步。
 

--- a/dsh-desktop/README.md
+++ b/dsh-desktop/README.md
@@ -141,6 +141,7 @@
 | `dsh-pet` | 桌面宠物：28 个透明动画的悬浮宠物，空闲呼吸、随机动作、屏幕游走 | 随包自动启用 |
 | `dsh-dafeiyu`（v4） | 大肥鱼桌宠：真实会话状态驱动的原生置顶窗口（六态动画 + 项目状态卡 + 摸头/戳一戳；角色素材按 ASSET_LICENSE 分发） | 默认禁用，「插件 → 管理」启用 |
 | `picturereader` | 全能读图/读文档：视觉孪生 adapter（原生缩略图 + 粘贴即用自动分析，opencode 等 pi-ai provider 也可用，杜绝 UNSUPPORTED_CONTENT）；隐私/智能/严谨三模式；本地工具链（像素扫描/3 引擎 OCR/裁剪/取色/对比/批量）；pdf/word/excel/ppt 转图片；可选外部 VLM 桥（OpenAI 兼容端点） | 设置 → 图片阅读 |
+| `computer-user` | 读屏 + 鼠标键盘自动化（Codex-style computer use）：截图读出屏幕、点击/输入/按键/滚动/拖拽/移动鼠标/读光标；配 picturereader 让纯文本模型驱动桌面；纯本地（PowerShell + Win32 SendInput，不调外部 API）；四模式（禁用/只读/手动批准/自动） | 设置 → 电脑操作 |
 | `dsh-soul-md` | soul.md 人设卡：可视化编辑人设，热重载即时生效；未配置时注册空 section，**完全不影响官方系统提示词** | 设置 → 人设卡 |
 | `dsh-web-mobile-fix` | Web UI 移动端适配修复 | 随包自动启用 |
 | `dsh-easy-setup` | 一键迁移（一键夺舍）：选择目录 → 新建工作区与对话 → AI 全程可视化迁移 skills / MCP / 记忆 | 设置 → 一键迁移 |

--- a/dsh-desktop/assets/plugins/computer-user/LICENSE
+++ b/dsh-desktop/assets/plugins/computer-user/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 jing-hy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dsh-desktop/assets/plugins/computer-user/README.md
+++ b/dsh-desktop/assets/plugins/computer-user/README.md
@@ -1,0 +1,151 @@
+# computer-user
+
+Codex-style **computer use** for DeepSeek Harness (DSH): read the screen and drive the
+mouse & keyboard — screenshot → analyze with [picturereader] → click/type/keypress/scroll/
+drag → verify. **Windows only.**
+
+- `computer_screenshot` captures the whole virtual screen (multi-monitor, DPI-aware) to a
+  PNG file and returns its path — feed it straight into picturereader's `image_scan` /
+  `image_ocr` to "see" the screen with any text-only model.
+- 8 more `computer_*` tools operate the mouse & keyboard through bundled PowerShell +
+  Win32 `SendInput` (no native modules, no compilation, works in the DSH/EAC host process).
+- A settings card (「电脑操作 / Computer Use」) puts a **mode dropdown** up front —
+  disabled / read-only / manual approval (`/computer`) / automatic — with the rest
+  collapsed under a default-closed **高级设置 / Advanced** section.
+- **Fully local — no external API calls**: screenshot (PowerShell), analysis
+  (picturereader local scan/OCR), input (Win32 SendInput). Nothing leaves the machine.
+  Read the workflow in [skills/computer-use.md](skills/computer-use.md) (locate the
+  target window first, then OCR inside the window, then click once and verify).
+- Verified on **DeepSeek Harness EAC** desktop (same DSH host kernel as the web app).
+
+> 中文说明见 [README.zh.md](README.zh.md)。
+
+## Works with pure text-only models + picturereader
+
+computer-user **does not need a multimodal model or any external vision API**. Any
+**pure text-only LLM** (e.g. DeepSeek V4 Flash) can drive the desktop end-to-end:
+
+- `computer_screenshot` dumps the screen to a local PNG (no vision needed to capture).
+- **picturereader** turns that PNG into structured text the text-only model can read:
+  `image_scan` (layout/colors/regions), `image_ocr` (real text), `image_sample`
+  (texture), all local (Windows OCR / PaddleOCR / RapidOCR — no cloud).
+- The model "sees" via those descriptions, calls `computer_click` / `computer_type` /
+  … at the reported coordinates, then screenshots again to verify.
+
+So the loop is: screenshot (computer-user) → understand (picturereader) → act
+(computer-user) → verify (both) — entirely with text tokens and zero external APIs.
+See [skills/computer-use.md](skills/computer-use.md) for the locate-window → in-window
+OCR → click-once workflow.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `computer_screenshot` | Save full virtual-screen PNG (region/scale optional) → `{path,width,height,virtual_offset,scale}` |
+| `computer_click` | Click at `[x,y]` (click / right_click / double_click) |
+| `computer_type` | Type arbitrary UTF-16 text — CJK included — via `SendInput` Unicode |
+| `computer_keypress` | Key chord, e.g. `["ctrl","c"]`, `["alt","tab"]`; letters/digits use virtual keys so shortcuts work |
+| `computer_scroll` | Wheel scroll at `[x,y]`: up / down / left / right, `clicks` notches |
+| `computer_drag` | Press → interpolate → release, optional `hold_keys` |
+| `computer_move_mouse` | Move cursor without clicking |
+| `computer_wait` | Sleep `ms` (let UI settle) |
+| `computer_get_cursor_position` | Read current cursor `[x,y]` |
+
+Coordinates are **pixels relative to the virtual-screen origin** (all monitors combined;
+`computer_screenshot` returns it as `virtual_offset`). `SetProcessDPIAware` keeps
+coordinates aligned with physical pixels on scaled displays.
+
+## Install
+
+```bash
+npm install computer-user
+```
+
+or in the DSH profile:
+
+```bash
+dsh plugin --profile web add computer-user
+```
+
+Then restart DSH (or use the EAC settings → Plugins → Manage screen). The tools appear for
+any session; the settings card appears under Settings → Computer Use.
+
+### Pair with picturereader (recommended)
+
+```text
+computer_screenshot → path
+picturereader image_scan / image_ocr <path>   # look
+computer_click / type / ...                   # act
+computer_screenshot → image_compare           # verify
+```
+
+## Settings card
+
+- **Mode dropdown** at the top of the card:
+  - `disabled` — every `computer_*` tool refuses.
+  - `readonly` — only screenshot / cursor-read / wait are allowed.
+  - `manual` — side-effecting tools need the session approved first via the `/computer`
+    slash command (one approval unlocks the session for later turns).
+  - `auto` — the LLM freely calls all tools.
+- **AI may change mode itself** checkbox (below the dropdown, not in Advanced):
+  off by default; when on, the AI can switch modes via `computer_set_mode` — changes are
+  written to the same settings namespace, so the dropdown stays in sync both ways.
+- **高级设置 / Advanced** (collapsed by default): screenshot output dir, default scale,
+  typing interval, scroll units, **Reject code-as-text output (output guard, default on)**,
+  debug logging.
+
+**Output guard** is a host-side filter on the LLM stream: if the model writes a fake
+tool-call / XML markup as *conversation text* (e.g. `computer_click({…})` or `<invoke …>`
+typed out instead of a real call), that chunk is stripped and replaced with a one-time
+coaching note; outputting the exact same text a second time passes through unblocked.
+Turn it off in Advanced when you intentionally want code snippets in replies.
+
+## Safety
+
+- **Locate the target window first** (DPI-aware GetWindowRect — see
+  [skills/computer-use.md](skills/computer-use.md)); desktop icons/background confuse
+  both OCR and clicks. Only work inside the target window.
+- Always `computer_screenshot` first and analyze it (picturereader) before acting.
+- Click once, screenshot to verify; never blind click repeatedly (many UIs toggle).
+- Use `manual` mode with the `/computer` command to keep a human in the loop.
+- If injected input is silently dropped, check security software (some AV suites filter
+  simulated input).
+
+## Verification & known limits
+
+- `node --test` unit suite: 16/16 green (tool registration, gates, arg validation).
+- Real-machine safe-window smoke (throwaway window + cmd.exe, never the user's apps):
+  screenshot PNG correct; cursor read/move round-trip exact; typing `hello 中文 123!`
+  read back verbatim; keypress Home/End navigation + insert verified (`HEADzzzTAIL`);
+  double-click word selection, click-to-clear, drag selection all asserted via control state.
+- Headless integration: both `computer_screenshot` and `computer_get_cursor_position`
+  called successfully by the model inside a real `dsh --profile headless` session.
+- Headless real-scenario: model autonomously executed a 5-step task
+  (screenshot → image_scan → type "hello" → screenshot → image_ocr) inside
+  `dsh --profile headless`, coordinating picturereader and computer-user tools.
+  OCR confirmed the typed text appeared on screen.
+- **Wheel verified**: all 9 tools (screenshot / click / type / keypress / scroll / drag /
+  move_mouse / wait / get_cursor_position) fully end-to-end verified. Wheel scroll position
+  changed and MouseWheel events fired correctly. Note: always-on-top IME toolbars (e.g.
+  Sogou Input floating bar) or other overlay windows can absorb wheel events if the cursor
+  lands on them — move the cursor to a clear area first (same as any cursor-based input).
+- EAC compatibility: loads side-by-side with picturereader in the same host; static scan of
+  all built-in plugins shows zero `computer_*` / `computer-user` namespace collisions.
+
+## Development
+
+```text
+src/capture.ps1    DPI-aware multi-monitor screenshot (System.Drawing)
+src/input.ps1      SendInput mouse/keyboard backend
+src/ps.js          PowerShell runner (base64 JSON, timeout, abort)
+src/tools.js       the 9 computer_* tool definitions + enabled/confirm gates
+src/config.js      settings namespace schema
+src/index.js       plugin entry (register tools + settings, hot reload)
+client.js          Web settings card (ModuleLoader bundle, zh/en)
+scripts/           real-machine smoke scripts (safe-window)
+tests/             node:test unit tests
+```
+
+## License
+
+MIT

--- a/dsh-desktop/assets/plugins/computer-user/README.zh.md
+++ b/dsh-desktop/assets/plugins/computer-user/README.zh.md
@@ -1,0 +1,137 @@
+# computer-user
+
+给 DeepSeek Harness（DSH，含 EAC 桌面客户端）的 **Codex 式电脑操作**插件：读屏幕并操作
+鼠标键盘 —— 截图 → 用 [picturereader] 分析 → click/type/keypress/scroll/drag → 验证。
+**仅支持 Windows。**
+
+- `computer_screenshot` 把整个虚拟屏（多显示器、DPI 感知）截成 PNG 文件并返回路径 ——
+  直接喂给 picturereader 的 `image_scan` / `image_ocr`，让任何纯文本模型都能"看"屏幕。
+- 另外 8 个 `computer_*` 工具，通过内置 PowerShell + Win32 `SendInput` 操作鼠标键盘
+  （零原生模块、无需编译，可在 DSH/EAC 宿主进程内运行）。
+- 设置卡（「电脑操作」）顶部是**模式下拉框** —— 禁用 / 只读 / 手动批准（`/computer`）/
+  自动，其余收进默认折叠的 **高级设置**。
+- **全程纯本地、不调用外部 API**：截图（PowerShell）、分析（picturereader 本地
+  scan/OCR）、操作（Win32 SendInput），数据不出本机。操作流程见
+  [skills/computer-use.md](skills/computer-use.md)（先定位目标窗口，再窗口内分块
+  OCR，确认后一击即中并截图验证）。
+- 已验证兼容 **DeepSeek Harness EAC** 桌面端（与 Web 同一 DSH 宿主内核）。
+
+> English: [README.md](README.md)。
+
+## 纯文本模型搭配 picturereader 即可使用
+
+computer-user **不需要多模态模型，也不需要任何外部视觉 API**——任何**纯文本大模型**
+（如 DeepSeek V4 Flash）都能端到端驱动桌面：
+
+- `computer_screenshot` 把屏幕存成本地 PNG（截图本身不需要视觉）。
+- **picturereader** 把 PNG 转成纯文本模型能读的结构化描述：`image_scan`（布局/颜色/
+  regions）、`image_ocr`（真实文字，Windows OCR / PaddleOCR / RapidOCR，全本地）、
+  `image_sample`（纹理）。
+- 模型靠这些描述"看"屏幕 → 用 `computer_click` / `computer_type` / … 在报告坐标上
+  操作 → 再截图验证。
+
+闭环 = 截图（computer-user）→ 理解（picturereader）→ 操作（computer-user）→ 验证
+（两者），全程只有文本 token、零外部 API。详见 [skills/computer-use.md](skills/computer-use.md)
+的「先定位窗口 → 窗口内分块 OCR → 一击即中」流程。
+
+## 工具
+
+| 工具 | 作用 |
+|---|---|
+| `computer_screenshot` | 保存整虚拟屏 PNG（可选 region/scale）→ `{path,width,height,virtual_offset,scale}` |
+| `computer_click` | 在 `[x,y]` 点击（click / right_click / double_click） |
+| `computer_type` | 输入任意 UTF-16 文本（含中文），走 `SendInput` Unicode |
+| `computer_keypress` | 组合键，如 `["ctrl","c"]`、`["alt","tab"]`；字母/数字走虚拟键以触发快捷键 |
+| `computer_scroll` | 在 `[x,y]` 滚轮：up / down / left / right，`clicks` 格 |
+| `computer_drag` | 按下 → 分步移动 → 释放，可选 `hold_keys` |
+| `computer_move_mouse` | 移动光标但不点击 |
+| `computer_wait` | 等待 `ms`（让 UI 稳定） |
+| `computer_get_cursor_position` | 读取当前光标位置 `[x,y]` |
+
+坐标为「相对**虚拟屏原点**（所有显示器合并区域左上角）」的像素；`computer_screenshot`
+返回的 `virtual_offset` 即该原点。`SetProcessDPIAware` 保证高分屏缩放下坐标与物理像素一致。
+
+## 安装
+
+```bash
+npm install computer-user
+```
+
+或在 DSH profile 里：
+
+```bash
+dsh plugin --profile web add computer-user
+```
+
+然后重启 DSH（或到 EAC「设置 → 插件 → 管理」启用）。工具对所有会话生效；设置卡在「设置 →
+电脑操作」。
+
+### 搭配 picturereader（推荐闭环）
+
+```text
+computer_screenshot → path
+picturereader image_scan / image_ocr <path>   # 看
+computer_click / type / ...                   # 做
+computer_screenshot → image_compare           # 验证
+```
+
+## 设置卡
+
+- **模式下拉框**（卡片顶部）：
+  - `disabled` 禁用 —— 所有 `computer_*` 工具一律拒绝。
+  - `readonly` 只读 —— 仅截图 / 读光标 / 等待可用。
+  - `manual` 手动批准 —— 有副作用工具需先在本会话输入 `/computer` 批准（一次批准，
+    后续轮次持续有效）。
+  - `auto` 自动 —— LLM 自由调用所有工具。
+- **「AI 可自行修改运行模式」开关**（下拉框下方，不在高级设置里）：默认关闭；开启后
+  AI 可用 `computer_set_mode` 切换模式，写入同一设置命名空间，**设置卡下拉框双向同步**。
+- **高级设置**（默认折叠）：截图输出目录、默认缩放、逐字输入间隔、滚动刻度、
+  **代码输出打回（output guard，默认开）**、调试日志。
+
+**代码输出打回**：host 侧对 LLM 输出流的过滤器——若模型把伪工具调用/伪 XML 当**对话
+文本**输出（比如把 `computer_click({…})`、`<invoke …>` 直接打成了字而不是真正调用），
+该段会被剔除并替换为一句一次性提示；**同一内容第二次原样输出时放行不拦截**。需要故意
+在回复里展示代码片段时可到高级设置关掉。
+
+## 安全
+
+- **先定位目标窗口**（DPI 感知 GetWindowRect，见 skills/computer-use.md）——
+  桌面图标/壁纸会同时干扰 OCR 与点击；只在目标窗口内工作。
+- 动手前务必 `computer_screenshot` 并用 picturereader 分析，不要盲点盲输。
+- 确认坐标后一击即中，点完截图验证，不要盲目连点（很多 UI 是点击开关）。
+- 手动批准模式配合 `/computer` 命令，让人在环。
+
+## 验证与已知限制
+
+- `node --test` 单测 16/16 通过（工具注册、门禁、参数校验）。
+- 实机安全窗口冒烟（一次性窗口 + cmd.exe，绝不碰用户应用）：截图 PNG 正确；光标读/移
+  往返精确；`hello 中文 123!` 逐字回读一致；keypress Home/End 导航+插入验证
+  （`HEADzzzTAIL`）；双击选词、单击取消、拖拽选区均通过控件状态断言。
+- headless 集成：`dsh --profile headless` 真实会话中，模型成功调用 `computer_screenshot`
+  与 `computer_get_cursor_position`。
+- headless 真实场景：模型在 `dsh --profile headless` 中自主完成 5 步任务
+  （screenshot → image_scan → type "hello" → screenshot → image_ocr），协调 picturereader
+  与 computer-user 工具，OCR 确认输入文字出现在屏幕上。
+- 滚轮**端到端验证通过**：滚动条位置变化 + MouseWheel 事件触发均正常。注意：鼠标若落在
+  搜狗输入法等置顶悬浮窗上，滚轮事件会被悬浮窗吸收——把光标移到空白处再滚（与任何基于
+  光标的输入同理）。
+- EAC 兼容：与 picturereader 在同一宿主内并存加载；对全部内置插件静态扫描，
+  `computer_*` 工具名 / `computer-user` 命名空间零冲突。
+
+## 开发
+
+```text
+src/capture.ps1     DPI 感知多屏截图（System.Drawing）
+src/input.ps1       SendInput 鼠标键盘后端
+src/ps.js           PowerShell 运行器（base64 JSON、超时、取消）
+src/tools.js       9 个 computer_* 工具定义 + enabled/confirm 门禁
+src/config.js       设置命名空间 schema
+src/index.js        插件入口（注册工具 + 设置热载）
+client.js           Web 设置卡（ModuleLoader bundle，中英）
+scripts/           实机冒烟脚本（安全窗口）
+tests/             node:test 单测
+```
+
+## 许可
+
+MIT

--- a/dsh-desktop/assets/plugins/computer-user/client.js
+++ b/dsh-desktop/assets/plugins/computer-user/client.js
@@ -1,0 +1,307 @@
+/**
+ * computer-user — Web settings card (client half).
+ *
+ * Registers a 「电脑操作 / Computer Use」 section in the DSH Web settings page:
+ *   - Top (visible the moment the card opens): mode dropdown (禁用/只读/手动批准/自动).
+ *   - Advanced (wrapped in a <details> so it is collapsed by default):
+ *     screenshot_dir, default_scale, typing_interval_ms, scroll_units, debug.
+ *
+ * Hand-written ModuleLoader bundle — no build step (same shape as picturereader).
+ */
+window.__ModuleLoader__.load({
+  id: "computer-user",
+  factory: (require) => {
+    var module = { exports: {} };
+    var exports = module.exports;
+    Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+    var react = require("react");
+    var h = react.createElement;
+
+    // ── CSS (theme tokens; own prefix to avoid clobbering other plugins) ──
+    var CSS =
+      ".__cu_root{max-width:640px;display:flex;flex-direction:column;gap:10px}" +
+      ".__cu_field{display:flex;flex-direction:column;gap:4px}" +
+      ".__cu_label{font-size:12px;font-weight:600;color:var(--dsw-alias-label-primary);display:flex;align-items:center;gap:6px}" +
+      ".__cu_hint{font-size:11px;color:var(--dsw-alias-label-tertiary)}" +
+      ".__cu_row{display:flex;align-items:center;gap:8px}" +
+      ".__cu_select{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);font:inherit;color:var(--dsw-alias-label-primary);border-radius:8px;padding:6px 8px;font-size:13px}" +
+      ".__cu_input{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);font:inherit;color:var(--dsw-alias-label-primary);border-radius:8px;padding:6px 10px;font-size:13px;box-sizing:border-box;width:100%}" +
+      ".__cu_actions{display:flex;gap:8px;align-items:center;margin-top:4px}" +
+      ".__cu_btn{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);color:var(--dsw-alias-label-primary);border-radius:8px;padding:6px 14px;font:inherit;font-size:13px;cursor:pointer}" +
+      ".__cu_btn:hover:not(:disabled){border-color:var(--dsw-alias-state-business-primary)}" +
+      ".__cu_btn:disabled{opacity:.5;cursor:default}" +
+      ".__cu_btnPrimary{border-color:var(--dsw-alias-state-business-primary);background:var(--dsw-alias-state-business-primary);color:var(--dsw-alias-label-on-accent)}" +
+      ".__cu_status{font-size:12px;color:var(--dsw-alias-label-tertiary)}" +
+      ".__cu_error{font-size:12px;color:var(--dsw-alias-state-error-primary)}" +
+      ".__cu_advanced{margin-top:8px;border-top:1px solid var(--dsw-alias-border-l2);padding-top:6px}" +
+      ".__cu_advancedSummary{cursor:pointer;font-size:13px;font-weight:600;color:var(--dsw-alias-label-secondary);user-select:none;display:flex;align-items:center;gap:5px}" +
+      ".__cu_advancedArrow{display:inline-block;transition:transform .18s ease;font-size:13px;line-height:1;color:var(--dsw-alias-label-secondary);transform:rotate(0)}" +
+      ".__cu_advanced[open] .__cu_advancedArrow{transform:rotate(90deg)}" +
+      ".__cu_unavailable{font-size:13px;color:var(--dsw-alias-label-tertiary)}";
+    var tagId = "computer-user/main.css";
+    if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=\"" + tagId + "\"]") === null) {
+      var tag = document.createElement("style");
+      tag.dataset.plugin = "computer-user";
+      tag.dataset.pluginCss = tagId;
+      tag.textContent = CSS;
+      document.head.appendChild(tag);
+    }
+
+    var NS = "computer-user";
+    var inject = ["slots", "locale", "settingsScope"];
+
+    var MODE_OPTS = [
+      { value: "disabled", labelKey: "modeDisabled" },
+      { value: "readonly", labelKey: "modeReadonly" },
+      { value: "manual", labelKey: "modeManual" },
+      { value: "auto", labelKey: "modeAuto" },
+    ];
+
+    var zh = {
+      nav: "电脑操作",
+      intro: "computer-user：让 DSH 读屏幕并操作鼠标键盘（Codex computer-use 风格）。选择运行模式后，截图结果配合 picturereader 的 image_scan/image_ocr 使用。",
+      mode: "运行模式",
+      modeDisabled: "禁用",
+      modeReadonly: "只读",
+      modeManual: "手动批准",
+      modeAuto: "自动",
+      modeHint: "禁用=全部拒绝 | 只读=仅截图/读光标/等待 | 手动批准=需 /computer 命令批准后可用 | 自动=LLM自由调用所有工具",
+      aiCanChangeMode: "AI 可自行修改运行模式",
+      aiCanChangeModeHint: "开启后 AI 可通过 computer_set_mode 工具自行切换模式（默认关闭）。AI 修改会同步更新本下拉框。",
+      advanced: "高级设置",
+      screenshotDir: "截图输出目录（空 = 系统临时目录）",
+      defaultScale: "截图默认缩放 0.1..1",
+      typingIntervalMs: "逐字输入间隔（毫秒）",
+      scrollUnits: "滚动刻度（每格 120）",
+      outputGuard: "代码输出打回",
+      outputGuardHint: "把工具调用/伪 XML 写成对话文本时打回并提示；同内容第二次放行。关闭则不拦截。",
+      debug: "调试日志",
+      save: "保存",
+      reset: "恢复默认",
+      saved: "已保存",
+      saving: "保存中…",
+      error: "保存失败",
+      unavailable: "设置命名空间不可用（服务端未注册 computer-user 命名空间？）",
+      loading: "加载中…",
+    };
+    var en = {
+      nav: "Computer Use",
+      intro: "computer-user: let DSH read the screen and drive mouse & keyboard (Codex computer-use style). Pick a mode; screenshots pair with picturereader's image_scan/image_ocr.",
+      mode: "Mode",
+      modeDisabled: "Disabled",
+      modeReadonly: "Read-only",
+      modeManual: "Manual approval",
+      modeAuto: "Automatic",
+      modeHint: "Disabled=refuse all | Read-only=screenshot/cursor/wait only | Manual approval=need /computer command to unlock | Automatic=LLM freely calls all tools",
+      aiCanChangeMode: "AI may change mode itself",
+      aiCanChangeModeHint: "When on, the AI can switch modes via the computer_set_mode tool (default off). AI changes are reflected in this dropdown.",
+      advanced: "Advanced",
+      screenshotDir: "Screenshot output dir (empty = OS temp)",
+      defaultScale: "Screenshot default scale 0.1..1",
+      typingIntervalMs: "Typing interval (ms)",
+      scrollUnits: "Scroll units (120 per tick)",
+      outputGuard: "Reject code-as-text output",
+      outputGuardHint: "Rejects tool-call/XML written as conversation text; the same text passes on second output. Off disables.",
+      debug: "Debug logging",
+      save: "Save",
+      reset: "Reset",
+      saved: "Saved",
+      saving: "Saving…",
+      error: "Save failed",
+      unavailable: "Settings namespace unavailable (computer-user not registered server-side?)",
+      loading: "Loading…",
+    };
+
+    // Top (always visible) vs advanced (collapsed by default).
+    var FIELDS = [
+      { key: "mode", type: "mode", labelKey: "mode", hintKey: "modeHint" },
+      { key: "ai_can_change_mode", type: "checkbox", labelKey: "aiCanChangeMode", hintKey: "aiCanChangeModeHint" },
+      { key: "screenshot_dir", type: "text", labelKey: "screenshotDir", advanced: true },
+      { key: "default_scale", type: "number", labelKey: "defaultScale", advanced: true },
+      { key: "typing_interval_ms", type: "number", labelKey: "typingIntervalMs", advanced: true },
+      { key: "scroll_units", type: "number", labelKey: "scrollUnits", advanced: true },
+      { key: "output_guard", type: "checkbox", labelKey: "outputGuard", hintKey: "outputGuardHint", advanced: true },
+      { key: "debug", type: "checkbox", labelKey: "debug", advanced: true },
+    ];
+    var CFG_KEYS = {
+      mode: "mode", ai_can_change_mode: "ai_can_change_mode",
+      screenshot_dir: "screenshot_dir", default_scale: "default_scale",
+      typing_interval_ms: "typing_interval_ms", scroll_units: "scroll_units",
+      output_guard: "output_guard", debug: "debug",
+    };
+
+    function Section(props) {
+      var t = props.t;
+      var scope = props.scope;
+      var [snapshot, setSnapshot] = react.useState(function () { return scope.getSnapshot(); });
+      var ready = snapshot.status === "ready" && snapshot.value !== void 0;
+      var [draft, setDraft] = react.useState({});
+      var [busy, setBusy] = react.useState(false);
+      var [notice, setNotice] = react.useState(null);
+      var [error, setError] = react.useState(null);
+
+      react.useEffect(function () {
+        scope.load();
+        var alive = true;
+        var sync = function () { if (alive) setSnapshot(scope.getSnapshot()); };
+        var un = typeof scope.subscribe === "function" ? scope.subscribe(sync) : null;
+        return function () { alive = false; if (un) un(); if (scope.dispose) scope.dispose(); };
+      }, [scope]);
+      react.useEffect(function () {
+        if (ready) setDraft(function (prev) {
+          var merged = Object.assign({}, valueToDraft(snapshot.value));
+          for (var k in prev) merged[k] = prev[k];
+          return merged;
+        });
+      }, [ready]);
+
+      if (snapshot.status === "unavailable") {
+        return h("p", { className: "__cu_unavailable" }, t("unavailable"));
+      }
+      if (!ready) return h("p", { className: "__cu_status" }, t("loading"));
+
+      var value = snapshot.value;
+
+      function onSave() {
+        setBusy(true); setNotice(null); setError(null);
+        var ops = [];
+        FIELDS.forEach(function (f) {
+          if (f.type === "checkbox") {
+            ops.push({ op: "set", key: CFG_KEYS[f.key], value: draft[f.key] !== void 0 ? !!draft[f.key] : Boolean(value[CFG_KEYS[f.key]]) });
+            return;
+          }
+          if (f.type === "mode") {
+            ops.push({ op: "set", key: CFG_KEYS[f.key], value: draft[f.key] || value[CFG_KEYS[f.key]] || "manual" });
+            return;
+          }
+          var dv = draft[f.key] !== void 0 ? String(draft[f.key]) : String(value[CFG_KEYS[f.key]] ?? "");
+          if (f.type === "number") {
+            var num = Number(dv);
+            if (Number.isFinite(num)) { ops.push({ op: "set", key: CFG_KEYS[f.key], value: num }); }
+            return;
+          }
+          if (String(dv).trim() === "") { ops.push({ op: "unset", key: CFG_KEYS[f.key] }); return; }
+          ops.push({ op: "set", key: CFG_KEYS[f.key], value: String(dv).trim() });
+        });
+        Promise.all(ops.map(function (o) {
+          return o.op === "set" ? scope.set(o.key, o.value) : scope.unset(o.key);
+        })).then(function () {
+          setBusy(false); setNotice(t("saved"));
+          if (scope.load) scope.load();
+        }).catch(function (e) {
+          setBusy(false); setError(t("error") + ": " + String(e && e.message || e));
+        });
+      }
+      function onReset() {
+        setBusy(true);
+        Promise.all(FIELDS.map(function (f) { return scope.unset(CFG_KEYS[f.key]); })).then(function () {
+          setBusy(false); setNotice(t("saved"));
+          setTimeout(function () {
+            var fresh = scope.getSnapshot();
+            if (fresh.status === "ready" && fresh.value !== void 0) setDraft(Object.assign({}, valueToDraft(fresh.value)));
+          }, 120);
+        }).catch(function (e) { setBusy(false); setError(t("error") + ": " + String(e && e.message || e)); });
+      }
+
+      function fieldDraft(f) {
+        if (f.type === "checkbox") return draft[f.key] !== void 0 ? !!draft[f.key] : Boolean(value[CFG_KEYS[f.key]]);
+        return draft[f.key] !== void 0 ? draft[f.key] : String(value[CFG_KEYS[f.key]] ?? "");
+      }
+      function setField(f, v) {
+        setDraft(function (prev) { var n = Object.assign({}, prev); n[f.key] = v; return n; });
+        setNotice(null); setError(null);
+      }
+      function renderField(f) {
+        if (f.type === "mode") {
+          return h("label", { key: f.key, className: "__cu_field" },
+            h("span", { className: "__cu_label" }, t("mode")),
+            h("select", {
+              className: "__cu_select",
+              value: fieldDraft(f) || "manual",
+              onChange: function (e) { setField(f, e.target.value); },
+            }, MODE_OPTS.map(function (o) {
+              return h("option", { key: o.value, value: o.value }, t(o.labelKey));
+            })),
+            h("span", { className: "__cu_hint" }, t("modeHint"))
+          );
+        }
+        if (f.type === "checkbox") {
+          var checked = draft[f.key] !== void 0 ? !!draft[f.key] : Boolean(value[CFG_KEYS[f.key]]);
+          return h("label", { key: f.key, className: "__cu_field" },
+            h("span", { className: "__cu_row" },
+              h("input", { className: "__cu_check", type: "checkbox", checked: checked, onChange: function (e) { setField(f, e.target.checked); } }),
+              h("span", { className: "__cu_label" }, t(f.labelKey))
+            ),
+            f.hintKey ? h("span", { className: "__cu_hint" }, t(f.hintKey)) : null
+          );
+        }
+        return h("label", { key: f.key, className: "__cu_field" },
+          h("span", { className: "__cu_label" }, t(f.labelKey)),
+          h("input", {
+            className: "__cu_input",
+            type: f.type === "number" ? "number" : "text",
+            value: fieldDraft(f),
+            onChange: function (e) { setField(f, e.target.value); },
+          })
+        );
+      }
+
+      // Top fields are always rendered first, then the collapsed Advanced <details>.
+      var top = FIELDS.filter(function (f) { return !f.advanced; });
+      var advanced = FIELDS.filter(function (f) { return f.advanced; });
+      return h("div", { className: "__cu_root" },
+        h("p", { className: "__cu_hint", style: { margin: "0 0 4px" } }, t("intro")),
+        top.map(renderField),
+        advanced.length ? h("details", { className: "__cu_advanced" },
+          h("summary", { className: "__cu_advancedSummary" },
+            h("span", null, t("advanced")),
+            h("span", { className: "__cu_advancedArrow" }, "\u25b8")
+          ),
+          advanced.map(renderField)
+        ) : null,
+        h("div", { className: "__cu_actions" },
+          h("button", { type: "button", className: "__cu_btn __cu_btnPrimary", onClick: onSave, disabled: busy || !snapshot.writable }, t("save")),
+          h("button", { type: "button", className: "__cu_btn", onClick: onReset, disabled: busy || !snapshot.writable }, t("reset")),
+          notice ? h("span", { className: "__cu_status" }, notice) : null,
+          busy ? h("span", { className: "__cu_status" }, t("saving")) : null,
+          error ? h("span", { className: "__cu_error" }, error) : null
+        )
+      );
+    }
+
+    function valueToDraft(value) {
+      var out = {};
+      FIELDS.forEach(function (f) {
+        if (f.type === "checkbox") {
+          out[f.key] = Boolean(value[CFG_KEYS[f.key]]);
+        } else if (f.type === "mode") {
+          out[f.key] = value[CFG_KEYS[f.key]] || "manual";
+        } else {
+          out[f.key] = String(value[CFG_KEYS[f.key]] ?? "");
+        }
+      });
+      return out;
+    }
+
+    function apply(ctx) {
+      var t = ctx.locale.bind(NS);
+      ctx.effect(function () { return ctx.locale.register(NS, { zh: zh, en: en }); }, "computer-user: dictionaries");
+      var scope = ctx.settingsScope.bind({ namespace: NS });
+      ctx.slots.inject("settings.section", function () {
+        return ctx.slots.register({
+          name: "settings.section",
+          id: "computer-user",
+          order: 50,
+          label: function () { return t("nav"); },
+          locale: NS,
+        }, function (props) {
+          return h(Section, Object.assign({}, props, { scope: scope }));
+        });
+      });
+    }
+
+    exports.apply = apply;
+    exports.inject = inject;
+    return module.exports;
+  },
+});

--- a/dsh-desktop/assets/plugins/computer-user/cordis.patch.yml
+++ b/dsh-desktop/assets/plugins/computer-user/cordis.patch.yml
@@ -1,0 +1,4 @@
+# computer-user — bundle patch: inserts the computer-user plugin row.
+- insert:
+    - id: computer-user
+      name: 'computer-user'

--- a/dsh-desktop/assets/plugins/computer-user/package.json
+++ b/dsh-desktop/assets/plugins/computer-user/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "computer-user",
+  "version": "0.3.4",
+  "description": "Codex-style computer use for DeepSeek Harness (DSH): read the screen and drive the mouse & keyboard. Pairs with picturereader (image_scan/image_ocr) to close the look-act-verify loop. Windows.",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./client": "./client.js",
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "scripts",
+    "client.js",
+    "cordis.patch.yml",
+    "skills",
+    "README.md",
+    "README.zh.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "dsh",
+    "dsh-plugin",
+    "deepseek-harness",
+    "computer-use",
+    "computeruse",
+    "automation",
+    "screenshot",
+    "mouse",
+    "keyboard",
+    "SendInput",
+    "screen",
+    "gui",
+    "codex"
+  ],
+  "license": "MIT",
+  "author": "jing-hy",
+  "engines": {
+    "node": "^22.19 || >=24"
+  },
+  "os": [
+    "win32"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "platform": "web"
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.6",
+    "@deepseek-ai/schemastery": "^3.18.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jing-hy/computer-user.git"
+  },
+  "homepage": "https://github.com/jing-hy/computer-user#readme",
+  "bugs": {
+    "url": "https://github.com/jing-hy/computer-user/issues"
+  }
+}

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-cmd-wheel.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-cmd-wheel.ps1
@@ -1,0 +1,78 @@
+# computer-user / scripts/smoke-cmd-wheel.ps1 — verify WHEEL actually scrolls a
+# real console app (cmd.exe). Generates 50 lines, screenshots before, scrolls
+# down/up at the console center, screenshots after, then closes with exit.
+param([string]$PngA = "", [string]$PngB = "", [string]$PngC = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+$art = Join-Path (Join-Path $Root "tests\_artifacts") ""
+if ([string]::IsNullOrWhiteSpace($PngA)) { $PngA = $art + "wheel-a.png" }
+if ([string]::IsNullOrWhiteSpace($PngB)) { $PngB = $art + "wheel-b.png" }
+if ([string]::IsNullOrWhiteSpace($PngC)) { $PngC = $art + "wheel-c.png" }
+
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class CwWin {
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public struct RECT { public int L, T, R, B; }
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+  public static void Steal(IntPtr hwnd) { int f = FgTid(); uint m = GetCurrentThreadId(); AttachThreadInput(m, (uint)f, true); try { SetForegroundWindow(hwnd); } finally { AttachThreadInput(m, (uint)f, false); } }
+}
+'@
+Add-Type -TypeDefinition 'public class CUdpiC { [System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }'
+[CUdpiC]::SetProcessDPIAware() | Out-Null
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+function Shot($png) {
+  $cap = Join-Path $Root "src\capture.ps1"
+  $cb = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes((@{ outPath = $png; scale = 1 } | ConvertTo-Json -Compress)))
+  & $PSExe -NoProfile -ExecutionPolicy Bypass -File $cap -Json $cb | Out-Null
+}
+$result = @{ ok = $false }
+$proc = $null
+try {
+  $proc = Start-Process -FilePath "cmd.exe" -PassThru
+  $hwnd = [IntPtr]::Zero
+  for ($i = 0; $i -lt 20 -and $hwnd -eq [IntPtr]::Zero; $i++) { Start-Sleep -Milliseconds 300; $proc.Refresh(); $hwnd = $proc.MainWindowHandle }
+  if ($hwnd -eq [IntPtr]::Zero) { throw "no cmd handle" }
+  [CwWin]::Steal($hwnd)
+  Start-Sleep -Milliseconds 300
+  $rc = New-Object CwWin+RECT
+  [CwWin]::GetWindowRect($hwnd, [ref]$rc) | Out-Null
+  $cx = [int](($rc.L + $rc.R) / 2); $cy = [int](($rc.T + $rc.B) * 0.5)
+  $wx = [int]$cx; $wy = [int]$cy - 40
+  Invoke-Input (@{ action = 'click'; coordinate = @($wx, $wy) }) | Out-Null
+  Start-Sleep -Milliseconds 250
+  # generate 50 lines
+  Invoke-Input (@{ action = 'type'; text = "for /l %i in (1,1,50) do echo LINE%i"; sendEnter = $true }) | Out-Null
+  Start-Sleep -Milliseconds 1500
+  Shot $PngA
+  # scroll down 6 ticks
+  $r1 = Invoke-Input (@{ action = 'scroll'; coordinate = @($wx, $wy); direction = 'down'; clicks = 6 })
+  Start-Sleep -Milliseconds 700
+  Shot $PngB
+  $r2 = Invoke-Input (@{ action = 'scroll'; coordinate = @($wx, $wy); direction = 'up'; clicks = 6 })
+  Start-Sleep -Milliseconds 700
+  Shot $PngC
+  # close
+  [CwWin]::Steal($hwnd); Start-Sleep -Milliseconds 150
+  Invoke-Input (@{ action = 'type'; text = "exit"; sendEnter = $true }) | Out-Null
+  Start-Sleep -Milliseconds 700
+  $proc.Refresh()
+  $result = @{ ok = $true; a = $PngA; b = $PngB; c = $PngC; r1 = ($r1 -join "`n"); r2 = ($r2 -join "`n"); stillAlive = (-not $proc.HasExited) }
+} catch {
+  $result.error = $_.Exception.Message
+  if ($proc) { try { $proc.Kill() } catch {} }
+}
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-cmd.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-cmd.ps1
@@ -1,0 +1,65 @@
+# computer-user / scripts/smoke-cmd.ps1 — verify real-world typing into a real
+# console app (cmd.exe) and capture it for OCR, then close cleanly (exit).
+param([string]$OutPng = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+if ([string]::IsNullOrWhiteSpace($OutPng)) { $OutPng = Join-Path (Join-Path $Root "tests\_artifacts") "cmd-verify.png" }
+[System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($OutPng)) | Out-Null
+
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class CmdWin {
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public struct RECT { public int L, T, R, B; }
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+  public static void Steal(IntPtr hwnd) { int f = FgTid(); uint m = GetCurrentThreadId(); AttachThreadInput(m, (uint)f, true); try { SetForegroundWindow(hwnd); } finally { AttachThreadInput(m, (uint)f, false); } }
+}
+'@
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+$marker = "CU-VERIFY-" + [string](Get-Random -Minimum 10000 -Maximum 99999)
+$result = @{ ok = $false }
+$proc = $null
+try {
+  $proc = Start-Process -FilePath "cmd.exe" -PassThru
+  $hwnd = [IntPtr]::Zero
+  for ($i = 0; $i -lt 20 -and $hwnd -eq [IntPtr]::Zero; $i++) { Start-Sleep -Milliseconds 300; $proc.Refresh(); $hwnd = $proc.MainWindowHandle }
+  if ($hwnd -eq [IntPtr]::Zero) { throw "no cmd window handle" }
+  [CmdWin]::Steal($hwnd)
+  Start-Sleep -Milliseconds 300
+  $rc = New-Object CmdWin+RECT
+  [CmdWin]::GetWindowRect($hwnd, [ref]$rc) | Out-Null
+  $cx = [int](($rc.L + $rc.R) / 2); $cy = [int](($rc.T + $rc.B) * 0.55)
+  Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy) }) | Out-Null
+  Start-Sleep -Milliseconds 200
+  $t1 = Invoke-Input (@{ action = 'type'; text = "echo $marker"; sendEnter = $true; typingIntervalMs = 10 })
+  Start-Sleep -Milliseconds 700
+  # capture for OCR
+  $cap = Join-Path $Root "src\capture.ps1"
+  $cb = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes((@{ outPath = $OutPng; scale = 1 } | ConvertTo-Json -Compress)))
+  $shot = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $cap -Json $cb 2>&1
+  Start-Sleep -Milliseconds 200
+  # close cmd cleanly
+  [CmdWin]::Steal($hwnd)
+  Start-Sleep -Milliseconds 150
+  Invoke-Input (@{ action = 'type'; text = "exit"; sendEnter = $true }) | Out-Null
+  Start-Sleep -Milliseconds 700
+  $proc.Refresh()
+  $result = @{ ok = $true; marker = $marker; png = $OutPng; typed = ($t1 -join "`n"); stillAlive = (-not $proc.HasExited) }
+} catch {
+  $result.error = $_.Exception.Message
+  if ($proc) { try { $proc.Kill() } catch {} }
+}
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-exec.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-exec.ps1
@@ -1,0 +1,109 @@
+# computer-user / scripts/smoke-exec.ps1 — full safe-window smoke: type (CJK) +
+# keypress chords + double-click + drag-select + mouse-wheel scroll, asserting
+# each effect by reading back the WinForms TextBox state. All inside a throwaway
+# window; nothing else on screen is touched.
+param([string]$TextB64 = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class ExecWin {
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public struct RECT { public int L, T, R, B; }
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+  public static void Steal(IntPtr hwnd) { int f = FgTid(); uint m = GetCurrentThreadId(); AttachThreadInput(m, (uint)f, true); try { SetForegroundWindow(hwnd); } finally { AttachThreadInput(m, (uint)f, false); } }
+}
+'@
+function Pump($ms) { $sw = [System.Diagnostics.Stopwatch]::StartNew(); while ($sw.ElapsedMilliseconds -lt $ms) { [System.Windows.Forms.Application]::DoEvents(); Start-Sleep -Milliseconds 8 } }
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+
+if ([string]::IsNullOrWhiteSpace($TextB64)) {
+  $Text = "hello 中文 123!"
+  for ($i = 2; $i -le 6; $i++) { $Text += "`r`n LINE $i of the smoke payload" }
+} else {
+  $Text = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($TextB64))
+}
+
+$checks = [System.Collections.Generic.List[string]]::new()
+$form = $null
+try {
+  $form = New-Object System.Windows.Forms.Form
+  $form.Text = "CU-EXEC-$PID"
+  $form.Size = New-Object System.Drawing.Size(620, 460)
+  $form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+  $form.Location = New-Object System.Drawing.Point(3060, 90)
+  $form.TopMost = $true
+  $tb = New-Object System.Windows.Forms.TextBox
+  $tb.Multiline = $true; $tb.ScrollBars = [System.Windows.Forms.ScrollBars]::Both; $tb.Dock = 'Fill'
+  $tb.Font = New-Object System.Drawing.Font('Consolas', 14)
+  $wheelLog = 0
+  $tb.Add_MouseWheel({ $script:wheelLog++ })
+  $form.Controls.Add($tb)
+  $form.Show(); $form.Refresh()
+  [ExecWin]::Steal($form.Handle)
+  Start-Sleep -Milliseconds 250
+  $form.Activate() | Out-Null; $tb.Focus() | Out-Null
+  Pump 200
+  $rc = New-Object ExecWin+RECT
+  [ExecWin]::GetWindowRect($form.Handle, [ref]$rc) | Out-Null
+  $w = $rc.R - $rc.L; $h = $rc.B - $rc.T
+  $borderY = 38  # title bar + padding estimate
+  # --- 1) click to focus + type text ---
+  $cx = [int]($rc.L + $w * 0.5); $cy = [int]($rc.T + $borderY + 12)
+  Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy) }) | Out-Null
+  Pump 300
+  Invoke-Input (@{ action = 'type'; text = $Text; typingIntervalMs = 5 }) | Out-Null
+  Pump 800
+  $norm = { param($s) ([string]$s).Replace("`r", "") }
+  $checks.Add(("typeCJK_match=" + ($( & $norm $tb.Text) -eq $( & $norm $Text))))
+  $len = $tb.Text.Length
+  # --- 2) keypress ctrl+a selects all ---
+  Invoke-Input (@{ action = 'keypress'; keys = @('ctrl', 'a') }) | Out-Null
+  Pump 300
+  $checks.Add(("keypress_ctrlA_selectAll=" + ($tb.SelectionLength -eq $len) + " (sel=" + $tb.SelectionLength + "/" + $len + ")"))
+  # --- 3) double click on first line selects a word ---
+  Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy + 16); action2 = 'double_click' }) | Out-Null
+  Pump 300
+  $checks.Add(("doubleClick_selects=" + (($tb.SelectionLength -gt 0) -and ($tb.SelectionLength -lt $len)) + " (sel=" + $tb.SelectionLength + ")"))
+  # --- 4) drag from line1 to mid -> selection grows ---
+  $sx = $rc.L + 6; $sy = $cy + 2; $emx = $cx + 160; $emy = $cy + 14
+  Invoke-Input (@{ action = 'drag'; start_coordinate = @($sx, $sy); end_coordinate = @($emx, $emy) }) | Out-Null
+  Pump 300
+  $checks.Add(("drag_selects=" + ($tb.SelectionLength -gt 0) + " (sel=" + $tb.SelectionLength + ")"))
+  # --- 5) wheel scroll over the text area (needs content overflow) ---
+  $before = $script:wheelLog
+  Invoke-Input (@{ action = 'scroll'; coordinate = @($cx, $cy + 60); direction = 'down'; clicks = 2 }) | Out-Null
+  Invoke-Input (@{ action = 'scroll'; coordinate = @($cx, $cy + 60); direction = 'up'; clicks = 2 }) | Out-Null
+  Pump 500
+  $checks.Add(("wheel_received=" + (($script:wheelLog - $before) -gt 0) + " (events=" + ($script:wheelLog - $before) + ")"))
+  # --- 6) right click does not throw ---
+  $rr = Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy + 16); action2 = 'right_click' })
+  Pump 300
+  $checks.Add(("rightClick_ok=" + ($rr -like '*ok*')))
+  # --- capture for OCR (text must be visible on screen) ---
+  $png = Join-Path (Join-Path $Root "tests\_artifacts") "exec-text.png"
+  $cap = Join-Path $Root "src\capture.ps1"
+  $cb = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes((@{ outPath = $png; scale = 1 } | ConvertTo-Json -Compress)))
+  & $PSExe -NoProfile -ExecutionPolicy Bypass -File $cap -Json $cb | Out-Null
+  $ok = ($tb.Text -eq $Text)
+  $result = @{ ok = $ok; checks = @($checks); png = $png }
+} catch {
+  $result = @{ ok = $false; checks = @($checks); error = $_.Exception.Message }
+}
+if ($form) { try { $form.Close(); $form.Dispose() } catch {} }
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-exec2.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-exec2.ps1
@@ -1,0 +1,142 @@
+# computer-user / scripts/smoke-exec2.ps1 — robust full safe-window smoke with
+# per-step try/catch: type(CJK) → keypress navigation (home/end) + insert →
+# double-click → drag-select → wheel scroll, each asserted by TextBox state.
+param([string]$TextB64 = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class Exec2Win {
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public struct RECT { public int L, T, R, B; }
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+  public static void Steal(IntPtr hwnd) { int f = FgTid(); uint m = GetCurrentThreadId(); AttachThreadInput(m, (uint)f, true); try { SetForegroundWindow(hwnd); } finally { AttachThreadInput(m, (uint)f, false); } }
+}
+'@
+function Pump($ms) { $sw = [System.Diagnostics.Stopwatch]::StartNew(); while ($sw.ElapsedMilliseconds -lt $ms) { [System.Windows.Forms.Application]::DoEvents(); Start-Sleep -Milliseconds 8 } }
+function Norm($s) { return ([string]$s).Replace("`r", "") }
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+
+if ([string]::IsNullOrWhiteSpace($TextB64)) {
+  $Text = "hello 中文 123!"
+  for ($i = 2; $i -le 6; $i++) { $Text += "`r`n LINE $i of the smoke payload" }
+} else {
+  $Text = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($TextB64))
+}
+
+$checks = [System.Collections.Generic.List[string]]::new()
+$steps = [System.Collections.Generic.List[string]]::new()
+$form = $null
+$prog = Join-Path (Join-Path $Root "tests\_artifacts") "exec2.progress.log"
+function Mark($m) { Add-Content -Path $prog -Value ("{0} {1}" -f (Get-Date -Format "HH:mm:ss.fff"), $m) -Encoding UTF8 }
+function Step($name, $body) {
+  Mark "STEP $name start"
+  try { & $body; Mark "STEP $name done" } catch { $script:steps.Add("$name ERROR: $($_.Exception.Message)"); Mark "STEP $name ERROR: $($_.Exception.Message)" }
+}
+try {
+  Mark "building form"
+  $form = New-Object System.Windows.Forms.Form
+  $form.Text = "CU-EXEC2-$PID"
+  $form.Size = New-Object System.Drawing.Size(640, 480)
+  $form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+  $form.Location = New-Object System.Drawing.Point(3040, 80)
+  $form.TopMost = $true
+  $tb = New-Object System.Windows.Forms.TextBox
+  $tb.Multiline = $true; $tb.ScrollBars = [System.Windows.Forms.ScrollBars]::Both; $tb.Dock = 'Fill'
+  $tb.Font = New-Object System.Drawing.Font('Consolas', 14)
+  $script:wheelLog = 0
+  $tb.Add_MouseWheel({ $script:wheelLog++ })
+  $form.Controls.Add($tb)
+  $form.Show(); $form.Refresh()
+  [Exec2Win]::Steal($form.Handle)
+  Start-Sleep -Milliseconds 250
+  $form.Activate() | Out-Null; $tb.Focus() | Out-Null
+  Pump 250
+  $rc = New-Object Exec2Win+RECT
+  [Exec2Win]::GetWindowRect($form.Handle, [ref]$rc) | Out-Null
+  $w = $rc.R - $rc.L; $h = $rc.B - $rc.T
+  $borderY = 40
+  $cx = [int]($rc.L + $w * 0.5); $cy = [int]($rc.T + $borderY + 14)
+
+  Step 'click_focus_type' {
+    Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy) }) | Out-Null
+    Pump 300
+    Invoke-Input (@{ action = 'type'; text = $Text; typingIntervalMs = 4 }) | Out-Null
+    Pump 900
+    $got = Norm $tb.Text; $want = Norm $Text
+    $checks.Add(("typeCJK_match=" + ($got -eq $want) + " (len " + $got.Length + "/" + $want.Length + ")"))
+  }
+
+  Step 'keypress_end_insert' {
+    Invoke-Input (@{ action = 'keypress'; keys = @('end') }) | Out-Null
+    Pump 200
+    Invoke-Input (@{ action = 'type'; text = 'TAIL'; typingIntervalMs = 0 }) | Out-Null
+    Pump 300
+    $checks.Add(("keypress_end_insert=" + ((Norm $tb.Text).EndsWith('TAIL'))))
+  }
+
+  Step 'keypress_home_insert' {
+    Invoke-Input (@{ action = 'keypress'; keys = @('home') }) | Out-Null
+    Pump 200
+    Invoke-Input (@{ action = 'type'; text = 'HEAD'; typingIntervalMs = 0 }) | Out-Null
+    Pump 300
+    $checks.Add(("keypress_home_insert=" + ((Norm $tb.Text).StartsWith('HEAD'))))
+  }
+
+  Step 'doubleclick_select' {
+    Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy + 18); action2 = 'double_click' }) | Out-Null
+    Pump 300
+    $s = $tb.SelectionLength
+    $checks.Add(("doubleclick_select=" + ($s -gt 0) + " (sel=" + $s + ")"))
+  }
+
+  Step 'drag_select' {
+    $sx = $rc.L + 8; $sy = $cy + 2; $emx = $rc.L + 200; $emy = $cy + 40
+    Invoke-Input (@{ action = 'drag'; start_coordinate = @($sx, $sy); end_coordinate = @($emx, $emy) }) | Out-Null
+    Pump 300
+    $s = $tb.SelectionLength
+    $checks.Add(("drag_select=" + ($s -gt 0) + " (sel=" + $s + ")"))
+  }
+
+  Step 'wheel_scroll' {
+    $before = $script:wheelLog
+    Invoke-Input (@{ action = 'scroll'; coordinate = @($cx, $cy + 80); direction = 'down'; clicks = 2 }) | Out-Null
+    Invoke-Input (@{ action = 'scroll'; coordinate = @($cx, $cy + 80); direction = 'up'; clicks = 2 }) | Out-Null
+    Pump 600
+    $ev = $script:wheelLog - $before
+    $checks.Add(("wheel_received=" + ($ev -gt 0) + " (events=" + $ev + ")"))
+  }
+
+  Step 'rightclick_ok' {
+    $rr = Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy + 18); action2 = 'right_click' })
+    Pump 300
+    $checks.Add(("rightclick_ok=" + ($rr -like '*ok*')))
+  }
+
+  $png = Join-Path (Join-Path $Root "tests\_artifacts") "exec2-text.png"
+  Step 'capture' {
+    $cap = Join-Path $Root "src\capture.ps1"
+    $cb = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes((@{ outPath = $png; scale = 1 } | ConvertTo-Json -Compress)))
+    & $PSExe -NoProfile -ExecutionPolicy Bypass -File $cap -Json $cb | Out-Null
+  }
+  $result = @{ ok = $true; checks = @($checks); steps = @($steps); png = $png }
+} catch {
+  $result = @{ ok = $false; checks = @($checks); steps = @($steps); error = $_.Exception.Message }
+}
+if ($form) { try { $form.Close(); $form.Dispose() } catch {} }
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-keypress.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-keypress.ps1
@@ -1,0 +1,67 @@
+# keypress mini-smoke: type "zzz", Home+insert HEAD, End+insert TAIL — proves key
+# chords/navigation keys really drive the focused control. Safe throwaway window.
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+Add-Type -TypeDefinition 'public class CUdpiK { [System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }'
+[CUdpiK]::SetProcessDPIAware() | Out-Null
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class KpWin {
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+  public static void Steal(IntPtr hwnd) { int f = FgTid(); uint m = GetCurrentThreadId(); AttachThreadInput(m, (uint)f, true); try { SetForegroundWindow(hwnd); } finally { AttachThreadInput(m, (uint)f, false); } }
+}
+'@
+function Pump($ms) { $sw = [System.Diagnostics.Stopwatch]::StartNew(); while ($sw.ElapsedMilliseconds -lt $ms) { [System.Windows.Forms.Application]::DoEvents(); Start-Sleep -Milliseconds 8 } }
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+$checks = [System.Collections.Generic.List[string]]::new()
+$form = $null
+try {
+  $form = New-Object System.Windows.Forms.Form
+  $form.Text = "CU-KP-$PID"
+  $form.Size = New-Object System.Drawing.Size(520, 240)
+  $form.StartPosition = 'Manual'; $form.Location = New-Object System.Drawing.Point(3060, 110)
+  $form.TopMost = $true
+  $tb = New-Object System.Windows.Forms.TextBox
+  $tb.Multiline = $true; $tb.Dock = 'Fill'; $tb.Font = New-Object System.Drawing.Font('Consolas', 16)
+  $form.Controls.Add($tb)
+  $form.Show(); $form.Refresh()
+  [KpWin]::Steal($form.Handle)
+  Start-Sleep -Milliseconds 250
+  $form.Activate() | Out-Null; $tb.Focus() | Out-Null
+  Pump 250
+  Invoke-Input (@{ action = 'click'; coordinate = @(3200, 200) }) | Out-Null   # roughly inside the TextBox
+  Pump 300
+  Invoke-Input (@{ action = 'type'; text = 'zzz'; typingIntervalMs = 0 }) | Out-Null
+  Pump 300
+  $checks.Add(("type_baseline=" + ($tb.Text -eq 'zzz')))
+  Invoke-Input (@{ action = 'keypress'; keys = @('home') }) | Out-Null
+  Pump 200
+  Invoke-Input (@{ action = 'type'; text = 'HEAD'; typingIntervalMs = 0 }) | Out-Null
+  Pump 300
+  $checks.Add(("home_insert_prefix=" + $tb.Text.StartsWith('HEAD')))
+  Invoke-Input (@{ action = 'keypress'; keys = @('end') }) | Out-Null
+  Pump 200
+  Invoke-Input (@{ action = 'type'; text = 'TAIL'; typingIntervalMs = 0 }) | Out-Null
+  Pump 300
+  $checks.Add(("end_insert_suffix=" + $tb.Text.EndsWith('TAIL')))
+  Invoke-Input (@{ action = 'keypress'; keys = @('ctrl', 'a') }) | Out-Null
+  Pump 200
+  $checks.Add(("ctrl_a_noerror=executed"))
+  $result = @{ ok = $true; text = $tb.Text; checks = @($checks) }
+} catch { $result = @{ ok = $false; checks = @($checks); error = $_.Exception.Message } }
+if ($form) { try { $form.Close(); $form.Dispose() } catch {} }
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-pointer.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-pointer.ps1
@@ -1,0 +1,113 @@
+# pointer mini-smoke: double-click select, drag select, wheel scroll — asserted
+# via TextBox state + MouseWheel event count. Safe throwaway window.
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+Add-Type -TypeDefinition 'public class CUdpiP { [System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }'
+[CUdpiP]::SetProcessDPIAware() | Out-Null
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class PtrWin {
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public struct RECT { public int L, T, R, B; }
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+  public static void Steal(IntPtr hwnd) { int f = FgTid(); uint m = GetCurrentThreadId(); AttachThreadInput(m, (uint)f, true); try { SetForegroundWindow(hwnd); } finally { AttachThreadInput(m, (uint)f, false); } }
+}
+'@
+# GetScrollInfo helper (read vertical scroll position of the TextBox's edit control)
+Add-Type -TypeDefinition @'
+using System; using System.Runtime.InteropServices;
+public class ScInfo {
+  [StructLayout(LayoutKind.Sequential)] public struct SCROLLINFO { public uint cbSize; public uint fMask; public int nMin; public int nMax; public uint nPage; public int nPos; public int nTrackPos; }
+  [DllImport("user32.dll")] public static extern bool GetScrollInfo(IntPtr h, int bar, ref SCROLLINFO si);
+}
+'@
+function GetVPos($h) {
+  $si = New-Object ScInfo+SCROLLINFO
+  $si.cbSize = [System.Runtime.InteropServices.Marshal]::SizeOf([type][ScInfo+SCROLLINFO])
+  $si.fMask = 0x17  # SIF_ALL
+  [ScInfo]::GetScrollInfo($h, 1, [ref]$si) | Out-Null
+  return $si
+}
+function Pump($ms) { $sw = [System.Diagnostics.Stopwatch]::StartNew(); while ($sw.ElapsedMilliseconds -lt $ms) { [System.Windows.Forms.Application]::DoEvents(); Start-Sleep -Milliseconds 8 } }
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+$checks = [System.Collections.Generic.List[string]]::new()
+$form = $null
+try {
+  $form = New-Object System.Windows.Forms.Form
+  $form.Text = "CU-PTR-$PID"
+  $form.Size = New-Object System.Drawing.Size(620, 420)
+  $form.StartPosition = 'Manual'; $form.Location = New-Object System.Drawing.Point(3040, 100)
+  $form.TopMost = $true
+  $tb = New-Object System.Windows.Forms.TextBox
+  $tb.Multiline = $true; $tb.ScrollBars = [System.Windows.Forms.ScrollBars]::Both; $tb.Dock = 'Fill'
+  $tb.Font = New-Object System.Drawing.Font('Consolas', 14)
+  $script:wheelLog = 0
+  $tb.Add_MouseWheel({ $script:wheelLog++ })
+  $form.Controls.Add($tb)
+  $form.Show(); $form.Refresh()
+  [PtrWin]::Steal($form.Handle)
+  Start-Sleep -Milliseconds 250
+  $form.Activate() | Out-Null; $tb.Focus() | Out-Null
+  Pump 250
+  $rc = New-Object PtrWin+RECT
+  [PtrWin]::GetWindowRect($form.Handle, [ref]$rc) | Out-Null
+  $cx = [int](($rc.L + $rc.R) / 2); $baseY = [int]($rc.T + 46)
+  # short content first (no scrolling involved) for double-click/drag assertions
+  Invoke-Input (@{ action = 'type'; text = "hello 中文 LINE1`r`nLINE two of the pointer smoke"; typingIntervalMs = 0 }) | Out-Null
+  Pump 800
+  $checks.Add(("type_short_len=" + $tb.Text.Length))
+  # double-click on the first line's first word -> word selected
+  $dblx = $rc.L + 55; $dbly = $baseY + 8
+  Invoke-Input (@{ action = 'click'; coordinate = @($dblx, $dbly); action2 = 'double_click' }) | Out-Null
+  Pump 400
+  $s1 = $tb.SelectionLength
+  $checks.Add(("doubleclick_word=" + ($s1 -gt 0) + " (sel=" + $s1 + ")"))
+  # plain click clears selection
+  Invoke-Input (@{ action = 'click'; coordinate = @($dblx, $dbly) }) | Out-Null
+  Pump 300
+  $checks.Add(("click_clears=" + ($tb.SelectionLength -eq 0)))
+  # drag over a few chars (payload keys are from/to, matching input.ps1)
+  $sx = $rc.L + 40; $sy = $baseY + 6; $exx = $rc.L + 220; $eyy = $baseY + 6
+  Invoke-Input (@{ action = 'drag'; from = @($sx, $sy); to = @($exx, $eyy) }) | Out-Null
+  Pump 300
+  $s2 = $tb.SelectionLength
+  $checks.Add(("drag_select=" + ($s2 -gt 0) + " (sel=" + $s2 + ")"))
+  # fill long content for scroll test, then wheel over the text area
+  $fill = $tb.Text
+  for ($i = 3; $i -le 40; $i++) { $fill += "`r`nLINE $i of the pointer smoke payload" }
+  $tb.Text = $fill
+  Pump 500
+  # click inside first so the wheel has a hover target with focus
+  Invoke-Input (@{ action = 'click'; coordinate = @($cx, $baseY + 150) }) | Out-Null
+  Pump 300
+  # scroll DOWN 3 ticks: scroll position must move toward max
+  $si0 = GetVPos $tb.Handle
+  $r1 = Invoke-Input (@{ action = 'scroll'; coordinate = @($cx, $baseY + 150); direction = 'down'; clicks = 3 })
+  Pump 900
+  $si1 = GetVPos $tb.Handle
+  # scroll UP 3 ticks: back toward top
+  $r2 = Invoke-Input (@{ action = 'scroll'; coordinate = @($cx, $baseY + 150); direction = 'up'; clicks = 3 })
+  Pump 900
+  $si2 = GetVPos $tb.Handle
+  $moved = ($si1.nPos -gt $si0.nPos)
+  $back = ($si2.nPos -lt $si1.nPos)
+  $ev = $script:wheelLog - 0
+  $checks.Add(("wheel_scrollmoved=" + $moved + " (nPos " + $si0.nPos + "->" + $si1.nPos + "->" + $si2.nPos + " max=" + $si0.nMax + ") back=" + $back + " events=" + $ev + " r1=" + ($r1 -like '*ok*') + " r2=" + ($r2 -like '*ok*')))
+  $result = @{ ok = ($s1 -gt 0 -and $s2 -gt 0); checks = @($checks) }
+} catch { $result = @{ ok = $false; checks = @($checks); error = $_.Exception.Message } }
+if ($form) { try { $form.Close(); $form.Dispose() } catch {} }
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/scripts/smoke-winforms.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/scripts/smoke-winforms.ps1
@@ -1,0 +1,133 @@
+# computer-user / scripts/smoke-winforms.ps1 — safe-window end-to-end smoke test.
+# Opens a throwaway WinForms window (unrelated to the user's apps), focuses its
+# TextBox via a real click, types ASCII + CJK text through the real SendInput
+# backend (input.ps1), then READS BACK the TextBox.Text to prove the physical
+# keyboard events actually landed, and captures a screenshot for OCR verification.
+# The window is closed at the end; nothing is left behind.
+# The text to type is passed as base64(UTF8) so command-line encoding (ANSI
+# codepage conversion in Windows PowerShell 5.1) can never garble CJK text.
+param([string]$TextB64 = "", [string]$OutPng = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+if ([string]::IsNullOrWhiteSpace($TextB64)) {
+  $Text = "hello 123!"
+} else {
+  $Text = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($TextB64))
+}
+$PSExe = "$env:WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe"
+$Root = Split-Path -Parent $PSScriptRoot
+$InputPs = Join-Path $Root "src\input.ps1"
+
+if ([string]::IsNullOrWhiteSpace($OutPng)) {
+  $OutPng = Join-Path (Join-Path $Root "tests\_artifacts") "winforms-text.png"
+}
+[System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($OutPng)) | Out-Null
+
+Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public struct RECT { public int L, T, R, B; }
+public class CUWin {
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool f);
+  public static int FgTid() { uint p; return (int)GetWindowThreadProcessId(GetForegroundWindow(), out p); }
+}
+'@
+# DPI-aware so screen coords match pixels (same technique as capture.ps1).
+Add-Type -TypeDefinition 'public class CUd { [System.Runtime.InteropServices.DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }' -ErrorAction SilentlyContinue
+[CUd]::SetProcessDPIAware() | Out-Null
+
+function Invoke-Input($payload) {
+  $b = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress)))
+  $r = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $InputPs -Json $b 2>&1
+  return ($r -join "`n")
+}
+
+# Steal foreground to our window: AttachThreadInput to the current foreground
+# thread, SetForegroundWindow, detach — works even under Windows foreground
+# restrictions because our IL matches the foreground app (Medium).
+function Steal-Foreground($hwnd) {
+  $fgTid = [CUWin]::FgTid()
+  $myTid = [CUWin]::GetCurrentThreadId()
+  [CUWin]::AttachThreadInput($myTid, $fgTid, $true) | Out-Null
+  try { [CUWin]::SetForegroundWindow($hwnd) | Out-Null } finally { [CUWin]::AttachThreadInput($myTid, $fgTid, $false) | Out-Null }
+}
+
+# Form.Show() is non-modal: the script thread must drive the message pump
+# manually or no WM_* message ever reaches the controls (PostMessage+SendInput
+# both succeed but nothing happens). Pump drains the queue with DoEvents.
+function Pump($ms) {
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  while ($sw.ElapsedMilliseconds -lt $ms) {
+    [System.Windows.Forms.Application]::DoEvents()
+    Start-Sleep -Milliseconds 8
+  }
+}
+
+$result = @{ ok = $false }
+$form = $null
+try {
+  $form = New-Object System.Windows.Forms.Form
+  $form.Text = "CU-SMOKE-$([System.Diagnostics.Process]::GetCurrentProcess().Id)"
+  $form.Size = New-Object System.Drawing.Size(560, 240)
+  $form.StartPosition = [System.Windows.Forms.FormStartPosition]::Manual
+  # top-right area of the screen — away from the user's IDE/EAC windows
+  $form.Location = New-Object System.Drawing.Point(3080, 120)
+  $form.TopMost = $true
+  $tb = New-Object System.Windows.Forms.TextBox
+  $tb.Multiline = $true
+  $tb.Dock = [System.Windows.Forms.DockStyle]::Fill
+  $tb.Font = New-Object System.Drawing.Font("Consolas", 18)
+  $form.Controls.Add($tb)
+  $form.Show()
+  $form.Refresh()
+  $hwnd = $form.Handle
+  $form.Activate() | Out-Null
+  Steal-Foreground $hwnd
+  Start-Sleep -Milliseconds 350
+  $rct = New-Object RECT
+  [CUWin]::GetWindowRect($hwnd, [ref]$rct) | Out-Null
+  $w = $rct.R - $rct.L; $h = $rct.B - $rct.T
+  $cx = [int]($rct.L + $w / 2); $cy = [int]($rct.T + $h * 0.55)  # inside the filled TextBox
+
+  # 1) real click to focus the TextBox (also activates the window)
+  $click = Invoke-Input (@{ action = 'click'; coordinate = @($cx, $cy) })
+  Pump 350
+  $tb.Focus() | Out-Null
+  # 2) real typing (SendInput) — the actual OS input path
+  $typed = Invoke-Input (@{ action = 'type'; text = $Text; typingIntervalMs = 15 })
+  Pump 900
+  # 3) read back what the TextBox actually received
+  $received = $tb.Text
+
+  # 4) capture for OCR verification
+  $payloadCap = @{ outPath = $OutPng; scale = 1 }
+  $cb = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($payloadCap | ConvertTo-Json -Compress)))
+  $capPs = Join-Path $Root "src\capture.ps1"
+  $shot = & $PSExe -NoProfile -ExecutionPolicy Bypass -File $capPs -Json $cb 2>&1
+
+  # 5) close window
+  $form.Close()
+  $form.Dispose()
+  $result = @{
+    ok = ($received -eq $Text)
+    hwnd = $hwnd.ToString()
+    sentText = $Text
+    receivedText = $received
+    match = ($received -eq $Text)
+    captured = $OutPng
+    windowRect = @($rct.L, $rct.T, $rct.R, $rct.B)
+    clickResult = ($click -join "`n")
+    typeResult = ($typed -join "`n")
+  }
+} catch {
+  $result.error = $_.Exception.Message
+  if ($form) { try { $form.Close(); $form.Dispose() } catch {} }
+}
+Write-Output ($result | ConvertTo-Json -Compress)

--- a/dsh-desktop/assets/plugins/computer-user/skills/computer-use.md
+++ b/dsh-desktop/assets/plugins/computer-user/skills/computer-use.md
@@ -1,0 +1,156 @@
+# Computer Use（电脑操作）—— 读屏 + 操作鼠标键盘（纯本地，不调用外部 API）
+
+computer-user 插件提供 9 个 `computer_*` 工具，让纯文本模型像人手一样操作本机
+Windows 桌面：读屏 → 定位目标 → 点击/输入/按键/滚动/拖拽 → 截图验证。与
+picturereader 配合构成「看 → 想 → 做 → 验」闭环。
+
+> **重要**：本方案**全程纯本地、绝不调用任何外部 API**。读屏用 computer-user 的
+> `computer_screenshot`（本地 PowerShell 截图），看屏用 picturereader 的
+> `image_scan` / `image_ocr` / `image_crop` / `image_compare`（本地像素分析 + 本机
+> OCR 引擎 windows / paddle / rapid），操作用 `computer_*`（本地 Win32 SendInput）。
+> 没有任何图像、坐标、页面元素会发往云端。隐私模式 = picturereader 的
+> `mode: privacy` + computer-user 任选模式（推荐「手动批准」）。
+
+---
+
+## 标准闭环（每步都按这个顺序）
+
+1. **看**：`computer_screenshot` 截屏 → 得到 `{ path, width, height, virtual_offset, scale }`。
+2. **定位窗口**（关键，先做）：目标应用窗口往往**不是全屏**，屏幕其余部分是
+   桌面图标/壁纸，会严重干扰 OCR 与点击。用窗口定位工具拿到目标窗口的
+   **物理像素边界**（Windows 下：DPI 感知的 `GetWindowRect`，见下「定位窗口」），
+   之后的截图/OCR/点击**全部只发生在该窗口矩形内**。
+3. **分析窗口内**：用 picturereader 的 `image_scan` / `image_ocr` 只读窗口区域
+   （先大块扫，再对命中的小块细分），得到目标元素的**虚拟屏坐标**。
+4. **做**：`computer_click` / `computer_type` / `computer_keypress` /
+   `computer_scroll` / `computer_drag` / `computer_move_mouse`，坐标填虚拟屏坐标。
+5. **验**：再 `computer_screenshot`（同一窗口区域），必要时 `image_compare`
+   对比前后，确认达到预期；`image_ocr` 确认文字变化。
+6. 等动画/加载用 `computer_wait`；看当前鼠标位置用 `computer_get_cursor_position`。
+
+---
+
+## 定位窗口（先定位窗口，才能避免背景干扰）
+
+**为什么必须先定位窗口**：桌面图标/壁纸会以文字形式混入 OCR 结果（例如
+「回收站」「此电脑」），让你把桌面上的元素误当成应用里的按钮，越点越偏。
+
+Windows 下标准做法（命令行/PowerShell 均可，纯本地）：
+
+1. 找到目标进程（如 `Get-Process -Name "*Deepseek Harness*"`），确定主窗口句柄。
+2. **必须用 DPI 感知的 `GetWindowRect`** 拿物理像素边界：
+   ```
+   Add-Type 'public class DpiAware { [DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }'
+   [DpiAware]::SetProcessDPIAware() | Out-Null
+   GetWindowRect(hwnd) → (left, top, right, bottom)   # 物理像素
+   ```
+   > 注意：**不调用 `SetProcessDPIAware()` 时拿到的 +逻辑坐标+ 是缩放过(如150%)
+   > 的值，与截图/点击的物理像素不一致**，会把窗口定位到错误位置（经验之谈：
+   > 会偏出窗口跑到桌面图标上）。
+3. 把窗口矩形换算成屏幕比例，截图时就只截这个 region：
+   `region: [left/W, top/H, right/W, bottom/H]`。
+4. 之后所有 OCR 的 region 也应落在窗口矩形内。
+
+---
+
+## 窗口内找元素：分块 OCR（文字） + 视觉识别（图标）
+
+- **先大块后细分**：把窗口区域切成几大块(行/列)，逐块 `image_ocr`（用配置里的
+  默认引擎，如 rapid/paddle），找到含目标文字的那块 → 再把那块切成小块继续 OCR
+  → 最后得到目标文字的精确像素框。**一次调用可以多读几块，但不要反复乱点。**
+- **纯图标、无文字的元素**（如齿轮设置按钮）：OCR 读不到，靠 `image_scan` 的
+  色块/结构判断——例如「侧边栏底部有个深色小图标区」，再从色块定位它的中心。
+  「底部有文字项 A、文字项 B」类的上下文也能帮你推断图标行位置。
+- **坐标换算**：截图返回 `virtual_offset:[vx,vy]`。OCR 返回的是**截图内坐标
+  (x,y)**，虚拟屏坐标 = `vx + x`（若截的是窗口 region，vx 就是窗口左上角）。
+  `computer_click` 等工具的 coordinate 一律填**虚拟屏坐标**。
+
+---
+
+## 一击即中：点击纪律
+
+- **确认坐标后再点**：OCR/视觉定位到的文字框，点击用它的**中心点**（不要点
+  边缘；文字框中心未必是按钮可点区，必要时在附近小范围试探一次）。
+- **不要连续多点**：许多 UI（设置页/浮层）是**点击开关**——点一次打开，再点
+  一次又关掉。点一次 → 截图验证 → 按结果决定下一步，绝不盲目连点。
+- **点击后必验证**：每次 `computer_click` 后 `computer_screenshot`（同窗口
+  region）确认是否达到预期；没达到再调整一小步（如 ±10px）。
+
+---
+
+## 运行模式（设置 → 电脑操作）
+
+| 模式 | 行为 |
+|---|---|
+| `disabled` 禁用 | 所有 computer_* 工具一律拒绝 |
+| `readonly` 只读 | 仅 `computer_screenshot` / `computer_get_cursor_position` / `computer_wait` 可用 |
+| `manual` 手动批准 | 有副作用工具需当前会话先 `/computer` 批准（一次批准后续轮次有效） |
+| `auto` 自动 | LLM 自由调用所有工具 |
+
+「手动批准」模式：当工具返回「需要批准：请在对话框输入 /computer」时，告知用户
+输入 `/computer` 解锁当前会话；批准后本会话后续轮次全部可用。
+
+**AI 自行修改运行模式**：
+- 默认**不允许**（设置项「AI 可自行修改运行模式」默认关闭）。
+- 开启后可用 `computer_set_mode(mode)` 切换模式（disabled/readonly/manual/auto）。
+- `computer_set_mode` 写的是**同一个设置命名空间**，因此**设置卡的运行模式下拉框会自动
+  同步显示 AI 修改后的值**；反过来用户在设置卡手动改模式也立即可见（热载）。
+- `disabled` 模式下 `computer_set_mode` 也被拒绝（防止 AI 自我解锁）。
+
+---
+
+## 输出规范（重要：这是给模型本人的纪律）
+
+0. **能用其它手段就别用 computer use**：computer use 是**最后手段**——凡是能用
+   非 GUI 自动化方式完成的（如直接调用 API / 读写文件 / pwsh 命令 / federated
+   接口 / fetch 等），**一律优先使用这些方式**，不要为了「演示」或「顺手」去操作
+   鼠标键盘。仅当**用户明确要求操作 GUI**，或**处于 plan 模式且必须真实点击/输入来
+   验证界面**时，才使用 `computer_*` 工具。用之前先在回复里说明「这里必须用
+   computer use，因为……」，用之后回归非 GUI 手段继续。
+1. **绝不在正文输出任何调用语法/伪标签**（这是最高优先级纪律，曾反复违反）：
+   回复正文**严禁出现**任何尖括号标签（如 `<invoke>`、`<使用…>` 等）、伪 XML、
+   残缺的 `computer_*` 调用片段，或把工具调用当代码块贴出来。要调用某能力就
+   **直接发起一次真正有效的工具调用**，正文只写自然语言。写完回复后自查正文：
+   若发现任何 `<…>` 或 `computer_xxx({…})` 文本出现在正文里，一律视为违规，必须
+   改成真实调用或删除。
+1.5 **容忍少量噪声，继续推进，别停摆**：即使正文/OCR 结果里混入了极少量脏字符
+   （如单独一个「客」字、残缺标签、OCR 把英文识别成中文等），**也不要中断流程、
+   不要反复道歉、不要停留在「清理格式」上**——直接继续用真实工具调用把当前任务
+   做完；遗留的微小噪声在任务收尾时顺带清理即可。OCR 的少量中文噪声通常不影响
+   坐标与语义判断，据此照常定位、点击、验证。
+2. **读屏用工具，不要用感觉**：找元素必须先 `computer_screenshot` + picturereader
+   （默认 OCR 引擎：读配置 `ocr_engine`；若引擎报错换 rapid）；坐标必须来自截图/OCR
+   的实测值，不是猜测。
+3. **一次多读、少点几次**：需要看多个位置时，一次截图后对多个 region 分别 OCR（或
+   全图 OCR），不要「点一下截一次」无谓循环；点击前先确认坐标，一击即中，点完截图
+   验证，绝不盲目连点。
+4. **分清目标窗口与背景**：永远先定位目标窗口（DPI 感知的 `GetWindowRect` 物理
+   边界），OCR/坐标只在窗口内取；桌面图标/壁纸的文字与坐标一律忽略。
+5. **坐标基准要核实**：带 `region` 的 OCR 返回的是**该 region 内的局部坐标**，必须
+   叠加 region 起点才是整图/虚拟屏坐标；全图 OCR 才是整图坐标。点击前用截图比例或
+   双源核对一次，特别是页面多列卡片时，别把坐标算到空白区。
+6. **回到可验证的中间态**：任何不确定时，先截图 + OCR 说明当前屏幕是什么，再决定
+   下一步；不猜、不赌。
+7. **隐私边界**：全程本地；不要把截图内容、OCR 文本或坐标拼进任何外部请求。
+
+---
+
+## 坐标系与精度
+
+- 坐标 = **相对多屏虚拟屏原点的物理像素**（`computer_screenshot` 的
+  `virtual_offset` 即该原点；capture.ps1 已 `SetProcessDPIAware`，与物理像素一致）。
+- 高分屏缩放：截图/输入都按物理像素，无系统缩放偏移；**窗口定位脚本同样要
+  DPI 感知**才能对齐（见上文经验）。
+- 多显示器：`virtual_offset` 可能是非零（副屏在原点左侧/上方时为负）。
+
+---
+
+## 安全规范
+
+- 动手前务必**先定位窗口**，再在窗口内 `image_ocr`/`image_scan` 确认目标，不盲点。
+- 只操作任务相关窗口；**不要操作 DSH/EAC 客户端自身的浮层按钮**除非任务就是
+  配置它（如设置卡验证）。
+- 输入含中文等任意文本都可靠（SendInput Unicode）。
+- 每步小操作后 `computer_wait`（300–800ms）等 UI 响应。
+- 破坏性操作（删除/覆盖/保存到重要位置）在「手动批准」模式下让用户先 `/computer`
+  再执行；自动模式下也要先截图确认目标再操作。

--- a/dsh-desktop/assets/plugins/computer-user/src/capture.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/src/capture.ps1
@@ -1,0 +1,92 @@
+# computer-user / capture.ps1 — full-virtual-screen (multi-monitor) screenshot.
+# DPI-aware so pixel coordinates match the physical screen (no drift on scaled displays).
+# Input:  -Json <base64(UTF8 JSON)>  { "outPath": string, "region": [x0,y0,x1,y1]|null (0..1), "scale": 0.1..1 }
+# Output: stdout { ok, path, width, height, virtual_offset:[vx,vy], scale } | { ok:false, error }
+param([string]$Json = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+function Fail($msg) { Write-Output (ConvertTo-Json -Compress @{ ok = $false; error = $msg }); exit 2 }
+
+try {
+  Add-Type -AssemblyName System.Windows.Forms, System.Drawing -ErrorAction Stop
+} catch { Fail("cannot load System.Windows.Forms/System.Drawing: $($_.Exception.Message)") }
+
+# DPI awareness (before reading screen bounds so coordinates match pixels).
+try {
+  Add-Type -TypeDefinition 'using System.Runtime.InteropServices; public class CUdpi { [DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }' -ErrorAction Stop
+  [CUdpi]::SetProcessDPIAware() | Out-Null
+} catch { /* non-fatal: falls back to virtualized coords */ }
+
+if ([string]::IsNullOrWhiteSpace($Json)) { Fail("missing -Json parameter") }
+$cfg = $null
+try {
+  $raw = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($Json))
+  $cfg = $raw | ConvertFrom-Json
+} catch { Fail("bad -Json: $($_.Exception.Message)") }
+
+$outPath = [string]$cfg.outPath
+if ([string]::IsNullOrWhiteSpace($outPath)) { Fail("outPath is required") }
+try {
+  $dir = [System.IO.Path]::GetDirectoryName($outPath)
+  if (-not [string]::IsNullOrWhiteSpace($dir)) { [System.IO.Directory]::CreateDirectory($dir) | Out-Null }
+} catch { Fail("cannot create output dir: $($_.Exception.Message)") }
+
+$scale = 1.0
+if ($null -ne $cfg.scale) { $scale = [double]$cfg.scale; if ($scale -le 0 -or $scale -gt 1) { $scale = 1.0 } }
+
+$vb = [System.Windows.Forms.SystemInformation]::VirtualScreen
+$vx = [int]$vb.X; $vy = [int]$vb.Y
+$vw = [int]$vb.Width; $vh = [int]$vb.Height
+
+$bmp = $null
+try {
+  $bmp = New-Object System.Drawing.Bitmap($vw, $vh)
+  $g = [System.Drawing.Graphics]::FromImage($bmp)
+  try {
+    $g.CopyFromScreen($vx, $vy, 0, 0, (New-Object System.Drawing.Size($vw, $vh)))
+  } finally { $g.Dispose() }
+} catch { if ($bmp) { $bmp.Dispose() }; Fail("CopyFromScreen failed: $($_.Exception.Message)") }
+
+# Optional fractional region crop [x0, y0, x1, y1] (0..1) -> pixel box.
+$dst = $bmp; $ownedDst = $false
+try {
+  if ($null -ne $cfg.region -and $cfg.region.Count -eq 4) {
+    $rx0 = [double]$cfg.region[0]; $ry0 = [double]$cfg.region[1]
+    $rx1 = [double]$cfg.region[2]; $ry1 = [double]$cfg.region[3]
+    $px0 = [int][Math]::Floor($rx0 * $vw); $py0 = [int][Math]::Floor($ry0 * $vh)
+    $px1 = [int][Math]::Ceiling($rx1 * $vw); $py1 = [int][Math]::Ceiling($ry1 * $vh)
+    if ($px1 -gt $px0 -and $py1 -gt $py0 -and $px0 -ge 0 -and $py0 -ge 0) {
+      $pw = $px1 - $px0; $ph = $py1 - $py0
+      $crop = New-Object System.Drawing.Bitmap($pw, $ph)
+      $cg = [System.Drawing.Graphics]::FromImage($crop)
+      try { $cg.DrawImage($bmp, (New-Object System.Drawing.Rectangle(0, 0, $pw, $ph)), (New-Object System.Drawing.Rectangle($px0, $py0, $pw, $ph)), [System.Drawing.GraphicsUnit]::Pixel) }
+      finally { $cg.Dispose(); $bmp.Dispose() }
+      $dst = $crop; $ownedDst = $true
+      $vw = $pw; $vh = $ph
+      $vx += $px0; $vy += $py0
+    }
+  }
+  if ($scale -lt 1.0) {
+    $sw = [int][Math]::Round($vw * $scale); $sh = [int][Math]::Round($vh * $scale)
+    if ($sw -gt 0 -and $sh -gt 0 -and $sw -ne $vw) {
+      $scaled = New-Object System.Drawing.Bitmap($sw, $sh)
+      $sg = [System.Drawing.Graphics]::FromImage($scaled)
+      try { $sg.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic; $sg.DrawImage($dst, 0, 0, $sw, $sh) }
+      finally { $sg.Dispose(); if ($ownedDst) { $dst.Dispose() } }
+      $dst = $scaled; $ownedDst = $true
+      $vw = $sw; $vh = $sh
+    }
+  }
+  $ext = [System.IO.Path]::GetExtension($outPath).ToLowerInvariant()
+  if ($ext -eq ".jpg" -or $ext -eq ".jpeg") {
+    $dst.Save($outPath, [System.Drawing.Imaging.ImageFormat]::Jpeg)
+  } else {
+    $dst.Save($outPath, [System.Drawing.Imaging.ImageFormat]::Png)
+  }
+} catch { Fail("image save failed: $($_.Exception.Message)") }
+finally { if ($dst) { $dst.Dispose() } }
+
+$result = @{ ok = $true; path = $outPath; width = $vw; height = $vh; virtual_offset = @($vx, $vy); scale = $scale }
+Write-Output ([System.Text.Encoding]::UTF8.GetString([Text.Encoding]::UTF8.GetBytes((ConvertTo-Json -Compress $result))))
+exit 0

--- a/dsh-desktop/assets/plugins/computer-user/src/config.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/config.js
@@ -1,0 +1,40 @@
+import z from '@deepseek-ai/schemastery';
+
+/** Settings namespace for this plugin (written to DSH settings.yaml). */
+export const NS = 'computer-user';
+
+/** Runtime settings schema (schemastery). Top fields are the "just-opened" card; the rest go to Advanced. */
+export const Config = z.object({
+  mode: z
+    .union([z.const('disabled'), z.const('readonly'), z.const('manual'), z.const('auto')])
+    .default('manual')
+    .description('运行模式：禁用=全部拒绝 | 只读=仅截图/读光标/等待 | 手动批准=需 /computer 批准后可用 | 自动=LLM自由调用'),
+  ai_can_change_mode: z
+    .boolean()
+    .default(false)
+    .description('AI 是否可自行修改运行模式（computer_set_mode 工具是否可用），默认不可。AI 修改后同步更新设置下拉框'),
+  screenshot_dir: z
+    .string()
+    .default('')
+    .description('截图输出目录（空 = 系统临时目录）'),
+  default_scale: z
+    .number()
+    .default(1)
+    .description('截图默认缩放 0.1..1（1=原分辨率整屏）'),
+  typing_interval_ms: z
+    .number()
+    .default(0)
+    .description('逐字输入间隔（毫秒），越大越稳但越慢'),
+  scroll_units: z
+    .number()
+    .default(1)
+    .description('滚动刻度：一次 scroll 滚动多少格（每格 120 WHEEL delta）'),
+  output_guard: z
+    .boolean()
+    .default(true)
+    .description('LLM 输出过滤器：把工具调用/伪XML写成对话文本时打回并提示，第二次同内容放行'),
+  debug: z
+    .boolean()
+    .default(false)
+    .description('调试日志'),
+});

--- a/dsh-desktop/assets/plugins/computer-user/src/index.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/index.js
@@ -1,0 +1,199 @@
+/**
+ * computer-user — Codex-style computer use for DeepSeek Harness (DSH).
+ *
+ * Reads the screen (computer_screenshot → PNG path) and drives the mouse &
+ * keyboard (click / type / keypress / scroll / drag / move_mouse / wait /
+ * get_cursor_position) via bundled PowerShell scripts using Win32 SendInput —
+ * zero native dependencies, so it works in the same Node host that runs the
+ * EAC desktop profile (same pattern as picturereader's Windows OCR).
+ *
+ * Pairs with picturereader: screenshot returns a file path that the model
+ * feeds to image_scan / image_ocr, then acts on it.
+ *
+ * Settings (namespace `computer-user`, hot-reloaded via a runtime snapshot):
+ *   mode — disabled / readonly / manual / auto
+ *   screenshot_dir / default_scale / typing_interval_ms / scroll_units / debug
+ *
+ * @module computer-user
+ */
+
+import { settingsNamespace } from '@deepseek-ai/dsh-settings';
+import { NS, Config } from './config.js';
+import { createComputerTools } from './tools.js';
+import { runPs, powerShellScript } from './ps.js';
+import { createOutputGuard } from './output-guard.js';
+
+export const name = 'computer-user';
+export const version = '0.3.0';
+
+/** Services required at runtime. */
+export const inject = ['tools'];
+
+/** In-memory set of session IDs that have been approved via /computer. */
+const approvedSessions = new Set();
+
+let sourceGetter = null;
+let sourceSetter = null;
+const getConfig = () => (sourceGetter ? sourceGetter() : undefined);
+
+/** Persist the runtime mode (used by computer_set_mode + /computer manual mode). */
+async function setMode(mode) {
+  if (typeof sourceSetter !== 'function') throw new Error('computer-user: 设置服务不可用');
+  await sourceSetter('mode', mode);
+}
+
+/**
+ * Resolve the session-target set affected by /computer from a command
+ * invocation: agent.id (SessionId) + session.header.sessionId, falling back
+ * to '__global__' when neither is present.
+ * @param {object} invocation
+ * @returns {Set<string>}
+ */
+export function sessionTargetsFromInvocation(invocation) {
+  const targets = new Set();
+  try {
+    if (invocation?.agent?.id) targets.add(String(invocation.agent.id));
+    if (invocation?.agent?.session?.header?.sessionId) targets.add(String(invocation.agent.session.header.sessionId));
+  } catch { /* ignore */ }
+  if (targets.size === 0) targets.add('__global__');
+  return targets;
+}
+
+/**
+ * Toggle approval for a set of session targets: if any target is already
+ * approved, revoke them all; otherwise approve them all.
+ * @param {Set<string>} approvedSessions
+ * @param {Set<string>} targets
+ * @returns {{approved:boolean, targets:Set<string>}}
+ */
+export function toggleApproval(approvedSessions, targets) {
+  const approved = [...targets].some((t) => approvedSessions.has(t));
+  if (approved) {
+    for (const t of targets) approvedSessions.delete(t);
+    return { approved: false, targets };
+  }
+  for (const t of targets) approvedSessions.add(t);
+  return { approved: true, targets };
+}
+
+export function apply(ctx, config) {
+  // ── register tools ──
+  ctx.effect(() => {
+    for (const tool of createComputerTools({ runPs, getConfig, approvedSessions, sessionId: undefined, setMode })) {
+      ctx.tools.register({
+        ...tool,
+        // Wrap execute to inject the current session ID at call time
+        async execute(args, exec) {
+          const sid = exec?.agent?.session?.header?.sessionId ?? exec?.sessionId ?? '';
+          // Rebuild gate closure with the real session ID
+          const tools = createComputerTools({ runPs, getConfig, approvedSessions, sessionId: sid, setMode });
+          const realTool = tools.find((t) => t.name === tool.name);
+          return realTool.execute(args, exec);
+        },
+      });
+    }
+  });
+
+  // ── settings namespace (hot reload) ──
+  try {
+    ctx.inject(['settings'], (sctx) => {
+      const settingsNs = settingsNamespace(NS);
+      const scope = sctx.settings.register(settingsNs, Config, { base: config });
+      sourceGetter = () => scope.get();
+      sourceSetter = (key, value) => scope.set(key, value);
+      scope.watch(() => { /* trigger hot reload */ });
+    });
+  } catch (error) {
+    ctx.logger?.warn?.(`[computer-user] settings disabled: ${String(error?.message ?? error)}`);
+    sourceGetter = () => ({ ...config, mode: config?.mode ?? 'manual' });
+  }
+
+  // ── /computer command for session approval ──
+  try {
+    ctx.inject(['commands'], (sctx) => {
+      sctx.commands.register({
+        name: 'computer',
+        description: '批准当前会话使用 computer-user 的全部工具（手动批准模式下需要）',
+        handler: async (invocation) => {
+          // /computer 是开关：第一次批准当前会话，再按一次撤销批准。
+          const targets = sessionTargetsFromInvocation(invocation);
+          const { approved } = toggleApproval(approvedSessions, targets);
+          const ids = [...targets].join(', ');
+          return approved
+            ? { kind: 'success', text: `✅ 已批准：computer-user 全部工具在当前会话可用（${ids}）。后续轮次持续生效；再按 /computer 可撤销。` }
+            : { kind: 'success', text: `🔒 已撤销批准：computer-user 有副作用工具需重新 /computer 批准（${ids}）。` };
+        },
+      });
+      ctx.logger?.info?.('[computer-user] /computer command registered');
+    });
+  } catch (error) {
+    ctx.logger?.warn?.(`[computer-user] commands service not available: ${String(error?.message ?? error)}`);
+  }
+
+  // ── LLM output guard: strip fake tool-call text written as conversation ──
+  //     text; first occurrence replaced with a coaching note, second chance
+  //     (same fingerprint) passes through. Off when output_guard=false.
+  try {
+    ctx.inject(['llm'], (sctx) => {
+      const llm = sctx.llm;
+      if (!llm || typeof llm.listProviders !== 'function') return;
+      const wrapProviders = () => {
+        let wrapped = 0;
+        for (const provider of llm.listProviders()) {
+          let reg;
+          try { reg = llm.registration(provider); } catch { continue; }
+          if (!reg || !reg.adapter) continue;
+          if (reg.adapter?.__cuOutputGuard) continue;
+          const orig = reg.adapter;
+          const origStream = orig.stream.bind(orig);
+          const guardProxy = new Proxy(orig, {
+            get(target, prop, receiver) {
+              if (prop === 'stream') {
+                return async function* (options) {
+                  const cfg = getConfig();
+                  if (cfg && cfg.output_guard === false) { yield* origStream(options); return; }
+                  const guard = createOutputGuard({ allowAfter: 2 });
+                  let noteShown = false;
+                  for await (const chunk of origStream(options)) {
+                    if (chunk && chunk.type === 'text-delta' && typeof chunk.text === 'string') {
+                      const decision = guard.sniff(chunk.text);
+                      if (decision.kind === 'reject') {
+                        if (!noteShown) {
+                          noteShown = true;
+                          yield { ...chunk, text: decision.note };
+                        }
+                        continue; // drop the polluted delta
+                      }
+                      // pass / pass-second → forward the original delta
+                    }
+                    yield chunk;
+                  }
+                };
+              }
+              const value = Reflect.get(target, prop, receiver);
+              return typeof value === 'function' ? value.bind(target) : value;
+            },
+          });
+          Object.defineProperty(guardProxy, '__cuOutputGuard', { value: true, enumerable: false, configurable: true });
+          reg.adapter = guardProxy;
+          wrapped++;
+        }
+        if (wrapped > 0) ctx.logger?.info?.(`[computer-user] output guard active on ${wrapped} provider(s)`);
+      };
+      wrapProviders();
+      // re-wrap if providers register later (best-effort; ignore failures)
+      if (typeof llm.on === 'function') {
+        try { llm.on('provider/register', () => { try { wrapProviders(); } catch { /* ignore */ } }); } catch { /* ignore */ }
+      }
+    });
+  } catch (error) {
+    ctx.logger?.warn?.(`[computer-user] output guard unavailable: ${String(error?.message ?? error)}`);
+  }
+
+  // ── debug helper ──
+  if (config?.debug) {
+    ctx.logger?.info?.(`[computer-user] scripts: ${powerShellScript('capture.ps1')}, ${powerShellScript('input.ps1')}`);
+  }
+}
+
+export default { name, version, inject, apply };

--- a/dsh-desktop/assets/plugins/computer-user/src/input.ps1
+++ b/dsh-desktop/assets/plugins/computer-user/src/input.ps1
@@ -1,0 +1,181 @@
+# computer-user / input.ps1 — mouse & keyboard automation via SendInput.
+# DPI-aware (SetProcessDPIAware) so virtual-screen pixel coordinates map to physical pixels.
+# Input:  -Json <base64(UTF8 JSON)>
+#    { "action": "move|click|rightclick|double|drag|scroll|type|keypress|getpos",
+#      "coordinate": [x,y], "from": [x,y], "to": [x,y],
+#      "action2": "click|right_click|double_click",
+#      "text": string, "sendEnter": bool,
+#      "keys": [names], "holdKeys": [names],
+#      "direction": "up|down|left|right", "clicks": int,
+#      "typingIntervalMs": int }
+# Output: stdout JSON { ok, cursor:[x,y], ... } | { ok:false, error }
+param([string]$Json = "")
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+function Fail($msg) { Write-Output (ConvertTo-Json -Compress @{ ok = $false; error = $msg }); exit 2 }
+function To-U32([int]$v) { if ($v -lt 0) { return [uint32]($v + 4294967296) }; return [uint32]$v }
+
+Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public class CU {
+  [StructLayout(LayoutKind.Sequential)] public struct MOUSEINPUT { public int dx; public int dy; public uint mouseData; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Sequential)] public struct KEYBDINPUT { public ushort wVk; public ushort wScan; public uint dwFlags; public uint time; public IntPtr dwExtraInfo; }
+  [StructLayout(LayoutKind.Sequential)] public struct HARDWAREINPUT { public uint uMsg; public ushort wParamL; public ushort wParamH; }
+  [StructLayout(LayoutKind.Explicit)] public struct INPUTUNION {
+    [FieldOffset(0)] public MOUSEINPUT mi;
+    [FieldOffset(0)] public KEYBDINPUT ki;
+    [FieldOffset(0)] public HARDWAREINPUT hi;
+  }
+  [StructLayout(LayoutKind.Sequential)] public struct INPUT { public uint type; public INPUTUNION U; }
+  [DllImport("user32.dll", SetLastError=true)] public static extern uint SendInput(uint n, INPUT[] p, int cb);
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int X, int Y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint f, uint dx, uint dy, uint d, UIntPtr e);
+  [DllImport("user32.dll")] public static extern bool GetCursorPos(out POINT pt);
+  [StructLayout(LayoutKind.Sequential)] public struct POINT { public int X; public int Y; }
+  public static INPUT K(ushort vk, ushort scan, uint flags) { INPUT i = new INPUT(); i.type = 1; i.U.ki.wVk = vk; i.U.ki.wScan = scan; i.U.ki.dwFlags = flags; i.U.ki.time = 0; i.U.ki.dwExtraInfo = IntPtr.Zero; return i; }
+  public static INPUT M(uint mouseData, uint flags) { INPUT i = new INPUT(); i.type = 0; i.U.mi.dx = 0; i.U.mi.dy = 0; i.U.mi.mouseData = mouseData; i.U.mi.dwFlags = flags; i.U.mi.time = 0; i.U.mi.dwExtraInfo = IntPtr.Zero; return i; }
+  public static void Send(INPUT[] a) { SendInput((uint)a.Length, a, Marshal.SizeOf(typeof(INPUT))); }
+  public static void Wheel(uint signedDelta) { INPUT[] a = new INPUT[1]; a[0] = M(signedDelta, 0x0800); Send(a); }
+  public static void KeyDown(ushort vk) { INPUT[] a = new INPUT[1]; a[0] = K(vk, 0, 0); Send(a); }
+  public static void KeyUp(ushort vk)   { INPUT[] a = new INPUT[1]; a[0] = K(vk, 0, 0x0002); Send(a); }
+  public static void CharDown(char c)   { INPUT[] a = new INPUT[1]; a[0] = K(0, (ushort)c, 0x0004); Send(a); }
+  public static void CharUp(char c)     { INPUT[] a = new INPUT[1]; a[0] = K(0, (ushort)c, 0x0004 | 0x0002); Send(a); }
+}
+'@ -ErrorAction Stop
+
+# DPI awareness so coordinates = physical pixels.
+try { Add-Type -TypeDefinition 'using System.Runtime.InteropServices; public class CUdpi { [DllImport("user32.dll")] public static extern bool SetProcessDPIAware(); }' -ErrorAction Stop; [CUdpi]::SetProcessDPIAware() | Out-Null } catch {}
+
+if ([string]::IsNullOrWhiteSpace($Json)) { Fail("missing -Json parameter") }
+$cfg = $null
+try { $cfg = ([System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($Json)) | ConvertFrom-Json) } catch { Fail("bad -Json: $($_.Exception.Message)") }
+$action = [string]$cfg.action
+if ([string]::IsNullOrWhiteSpace($action)) { Fail("action is required") }
+
+$VK = @{
+  'ctrl'=0x11; 'control'=0x11; 'shift'=0x10; 'alt'=0x12; 'super'=0x5B; 'meta'=0x5B; 'win'=0x5B; 'cmd'=0x5B;
+  'enter'=0x0D; 'return'=0x0D; 'tab'=0x09; 'esc'=0x1B; 'escape'=0x1B; 'space'=0x20; 'backspace'=0x08;
+  'delete'=0x2E; 'del'=0x2E; 'insert'=0x2D; 'home'=0x24; 'end'=0x23; 'pageup'=0x21; 'pagedown'=0x22;
+  'up'=0x26; 'down'=0x28; 'left'=0x25; 'right'=0x27; 'clear'=0x0C;
+  'pause'=0x13; 'prtsc'=0x2C; 'printscreen'=0x2C; 'scrolllock'=0x91; 'numlock'=0x90; 'capslock'=0x14;
+}
+for ($i = 1; $i -le 24; $i++) { $VK["f$i"] = 0x6F + $i }   # F1=0x70
+for ($i = 0; $i -lt 26; $i++) { $VK[[char](0x61 + $i)] = 0x41 + $i } # a-z -> A..Z VK
+for ($i = 0; $i -lt 10; $i++) { $VK[[string]$i] = 0x30 + $i }        # 0-9
+
+function Get-CursorJson { $p = New-Object CU+POINT; [CU]::GetCursorPos([ref]$p) | Out-Null; return @($p.X, $p.Y) }
+
+function Resolve-Key($name) {
+  $n = ([string]$name).Trim().ToLowerInvariant()
+  if ($VK.ContainsKey($n)) { return @{ vk = [UInt16]$VK[$n] } }
+  # single letters/digits map to VIRTUAL KEYS so they combine with modifiers
+  # (ctrl+a must be VK_A, not an injected Unicode 'a' which never triggers shortcuts).
+  if ($n.Length -eq 1) {
+    $c = $n[0]
+    if ($c -ge 'a' -and $c -le 'z') { return @{ vk = [UInt16](0x41 + ([int]$c - 97)) } }
+    if ($c -ge '0' -and $c -le '9') { return @{ vk = [UInt16](0x30 + ([int]$c - 48)) } }
+    return @{ ch = [char]$c }
+  }
+  return $null
+}
+
+switch ($action) {
+  "getpos" {
+    $c = Get-CursorJson
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; cursor = $c })
+    exit 0
+  }
+  "move" {
+    $x = [int]$cfg.coordinate[0]; $y = [int]$cfg.coordinate[1]
+    [CU]::SetCursorPos($x, $y) | Out-Null
+    Start-Sleep -Milliseconds 30
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; cursor = @($x, $y) })
+    exit 0
+  }
+  "click" {
+    $x = [int]$cfg.coordinate[0]; $y = [int]$cfg.coordinate[1]
+    $a = [string]$cfg.action2; if ([string]::IsNullOrWhiteSpace($a)) { $a = "click" }
+    [CU]::SetCursorPos($x, $y) | Out-Null; Start-Sleep -Milliseconds 30
+    if ($a -eq "right_click") {
+      [CU]::mouse_event(0x0008, 0, 0, 0, [UIntPtr]::Zero); Start-Sleep -Milliseconds 40
+      [CU]::mouse_event(0x0010, 0, 0, 0, [UIntPtr]::Zero)
+    } elseif ($a -eq "double_click") {
+      [CU]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero); Start-Sleep -Milliseconds 40
+      [CU]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero); Start-Sleep -Milliseconds 40
+      [CU]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero); Start-Sleep -Milliseconds 40
+      [CU]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+    } else {
+      [CU]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero); Start-Sleep -Milliseconds 40
+      [CU]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+    }
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; cursor = @($x, $y); action = $a })
+    exit 0
+  }
+  "drag" {
+    $sx = [int]$cfg.from[0]; $sy = [int]$cfg.from[1]
+    $tx = [int]$cfg.to[0];   $ty = [int]$cfg.to[1]
+    [CU]::SetCursorPos($sx, $sy) | Out-Null; Start-Sleep -Milliseconds 30
+    if ($null -ne $cfg.holdKeys -and $cfg.holdKeys.Count -gt 0) {
+      foreach ($hk in $cfg.holdKeys) { $r = Resolve-Key $hk; if ($null -ne $r -and $r.ContainsKey("vk")) { [CU]::KeyDown($r.vk) } }
+      Start-Sleep -Milliseconds 40
+    }
+    [CU]::mouse_event(0x0002, 0, 0, 0, [UIntPtr]::Zero); Start-Sleep -Milliseconds 50
+    $steps = 12
+    for ($i = 1; $i -le $steps; $i++) {
+      $px = [int]($sx + ($tx - $sx) * $i / $steps); $py = [int]($sy + ($ty - $sy) * $i / $steps)
+      [CU]::SetCursorPos($px, $py) | Out-Null
+      Start-Sleep -Milliseconds 12
+    }
+    [CU]::mouse_event(0x0004, 0, 0, 0, [UIntPtr]::Zero)
+    if ($null -ne $cfg.holdKeys -and $cfg.holdKeys.Count -gt 0) {
+      Start-Sleep -Milliseconds 30
+      $rev = @($cfg.holdKeys); [array]::Reverse($rev)
+      foreach ($hk in $rev) { $r = Resolve-Key $hk; if ($null -ne $r -and $r.ContainsKey("vk")) { [CU]::KeyUp($r.vk) } }
+    }
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; from = @($sx, $sy); to = @($tx, $ty); cursor = @($tx, $ty) })
+    exit 0
+  }
+  "scroll" {
+    $x = [int]$cfg.coordinate[0]; $y = [int]$cfg.coordinate[1]
+    $dir = [string]$cfg.direction; if ([string]::IsNullOrWhiteSpace($dir)) { $dir = "down" }
+    $clicks = [int]$cfg.clicks; if ($clicks -le 0) { $clicks = 1 }
+    [CU]::SetCursorPos($x, $y) | Out-Null; Start-Sleep -Milliseconds 20
+    $notches = 120 * $clicks
+    $vy = if ($dir -eq "down") { -$notches } else { $notches }
+    $hz = if ($dir -eq "right") { -$notches } else { $notches }
+    if ($dir -eq "left" -or $dir -eq "right") { [CU]::Wheel((To-U32 $hz)) }   # SendInput HWHEEL
+    if ($dir -eq "up" -or $dir -eq "down")   { [CU]::Wheel((To-U32 $vy)) }     # SendInput WHEEL
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; cursor = @($x, $y); direction = $dir; clicks = $clicks })
+    exit 0
+  }
+  "type" {
+    $text = [string]$cfg.text
+    $interval = [int]$cfg.typingIntervalMs; if ($interval -lt 0) { $interval = 0 }
+    $count = 0
+    foreach ($ch in $text.ToCharArray()) {
+      [CU]::CharDown($ch); Start-Sleep -Milliseconds 8; [CU]::CharUp($ch)
+      $count++
+      if ($interval -gt 0) { Start-Sleep -Milliseconds $interval }
+    }
+    if ($cfg.sendEnter) { [CU]::KeyDown(0x0D); Start-Sleep -Milliseconds 20; [CU]::KeyUp(0x0D) }
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; chars = $count; sendEnter = [bool]$cfg.sendEnter; cursor = (Get-CursorJson) })
+    exit 0
+  }
+  "keypress" {
+    $keys = @($cfg.keys)
+    if ($keys.Count -eq 0) { Fail("keypress requires at least one key") }
+    $down = @()
+    foreach ($k in $keys) { $r = Resolve-Key $k; if ($null -eq $r) { Fail("unknown key: $k") }; $down += ,$r }
+    # press modifiers/specials first (VK), then each remaining (char for punctuation)
+    foreach ($r in $down) { if ($r.ContainsKey("vk")) { [CU]::KeyDown($r.vk) } else { [CU]::CharDown($r.ch) } }
+    Start-Sleep -Milliseconds 50
+    $up = @($down); [array]::Reverse($up)
+    foreach ($r in $up) { if ($r.ContainsKey("vk")) { [CU]::KeyUp($r.vk) } else { [CU]::CharUp($r.ch) } }
+    Write-Output (ConvertTo-Json -Compress @{ ok = $true; keys = ($keys -join "+"); cursor = (Get-CursorJson) })
+    exit 0
+  }
+  default { Fail("unknown action: $action") }
+}

--- a/dsh-desktop/assets/plugins/computer-user/src/output-guard.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/output-guard.js
@@ -1,0 +1,97 @@
+/**
+ * computer-user / output-guard.js — LLM output filter (host side).
+ *
+ * Sits on the provider `stream()` exit and inspects the assistant TEXT output:
+ *
+ *  - If the model writes pseudo tool-call / XML markup as CONVERSATION TEXT
+ *    (e.g. `computer_click({ coordinate: [1,2] })` or `<invoke ...>` typed out
+ *    instead of a real tool call), that text is REJECTED (stripped from the
+ *    stream) and replaced with a one-time coaching note telling the model to
+ *    either call the tool properly or, if it really means to output that text,
+ *    output it again — the SECOND occurrence of the same fingerprint passes
+ *    through untouched (no infinite loop).
+ *
+ * The DSH adapter stream emits raw chunks: text arrives as `{ type:
+ * 'text-delta', text }`. We buffer text deltas, sniff the buffer, and decide
+ * per fingerprint.
+ *
+ * @module computer-user/output-guard
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Regexes for "fake tool call written as conversation text". */
+const FAKE_CALL_RE = [
+  // pseudo XML invoke / usage (e.g. <invoke name="computer_click">, <使用工具：…>)
+  /<\s*(?:invoke|use|使用|tool)[^>]*>/i,
+  // a bare tool-call-like snippet: computer_xxx({ ... })
+  /computer_[a-z_]+\s*\(\s*\{[^}]*\}\s*\)/i,
+  // leading "await computer_…" call line
+  /(?:\bawait\s+)?computer_[a-z_]+\(/,
+  // stray XML-ish closing or opening tags like </invoke> <tool_call>
+  /<\s*\/\s*(?:invoke|use|tool)[^>]*>/i,
+];
+
+/** Hash a fingerprint string for the pass-after-N decision. */
+function fingerprintOf(text) {
+  return createHash('sha1').update(String(text)).digest('hex').slice(0, 24);
+}
+
+/**
+ * Detect whether a buffered text chunk contains a fake tool-call written as
+ * plain conversation text. Returns the matched fingerprint or null.
+ * @param {string} text
+ * @returns {string|null}
+ */
+export function detectFakeToolText(text) {
+  if (!text || typeof text !== 'string') return null;
+  for (const re of FAKE_CALL_RE) {
+    const m = re.exec(text);
+    if (m) return fingerprintOf(m[0]);
+  }
+  return null;
+}
+
+/**
+ * Output guard state machine. Feed it text deltas as they stream; it keeps a
+ * buffer (pruned to a tail window) and a per-fingerprint counter.
+ *
+ * decide() returns:
+ *   { kind: 'pass' }              — nothing suspicious
+ *   { kind: 'reject', note }      — first occurrence: strip & emit coaching note
+ *   { kind: 'pass-second' }       — same fingerprint re-issued → allow through
+ */
+export function createOutputGuard({
+  bufferWindow = 4000,
+  allowAfter = 2, // allow the Nth same-fingerprint occurrence
+  noteFactory,
+} = {}) {
+  let buffer = '';
+  const counts = new Map();
+  const noteFactory2 = noteFactory || (() => (
+    '（输出已过滤：检测到把工具调用以对话文本形式输出了。' +
+    '若确实需要调用工具请改为真正的工具调用；若确实要原样输出该文本，请再输出一次，第二次将放行不拦截。）'
+  ));
+
+  /**
+   * Append one text delta (or full text piece) and optionally decide.
+   * @param {string} delta
+   * @returns {import('./output-guard.js').Decision}
+   */
+  function sniff(delta) {
+    if (typeof delta !== 'string') return { kind: 'pass' };
+    buffer = (buffer + delta).slice(-bufferWindow);
+    const fp = detectFakeToolText(buffer);
+    if (!fp) return { kind: 'pass' };
+    const n = (counts.get(fp) ?? 0) + 1;
+    counts.set(fp, n);
+    // reset buffer after consuming a hit so we don't re-detect the same text
+    buffer = '';
+    if (n >= allowAfter) return { kind: 'pass-second', fingerprint: fp, occurrence: n };
+    return { kind: 'reject', fingerprint: fp, occurrence: n, note: noteFactory2() };
+  }
+
+  return { sniff, counts, detectFakeToolText };
+}
+
+export default { detectFakeToolText, createOutputGuard };

--- a/dsh-desktop/assets/plugins/computer-user/src/ps.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/ps.js
@@ -1,0 +1,85 @@
+import { spawn } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to one of the bundled PowerShell scripts inside this package. */
+export function powerShellScript(name) {
+  return join(__dirname, name);
+}
+
+/**
+ * Run a bundled PowerShell script with a JSON payload (passed as base64 to avoid
+ * shell-quoting/encoding issues). The script prints one JSON object to stdout;
+ * it MUST carry a boolean `ok` field. `ok:true` resolves, otherwise we reject
+ * with `.error`. Stdout lines before the JSON are tolerated.
+ *
+ * @param {string} scriptName  'capture.ps1' | 'input.ps1'
+ * @param {object} payload     JSON payload object
+ * @param {{timeoutMs?:number, signal?:AbortSignal}} opts
+ * @returns {Promise<object>}  the parsed result object
+ */
+export function runPs(scriptName, payload, { timeoutMs = 25000, signal } = {}) {
+  return new Promise((resolve, reject) => {
+    const b64 = Buffer.from(JSON.stringify(payload ?? {}), 'utf8').toString('base64');
+    const child = spawn(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', powerShellScript(scriptName), '-Json', b64],
+      { windowsHide: true }
+    );
+    let out = '';
+    let err = '';
+    let settled = false;
+
+    const finish = (fn, v) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(v);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(reject, new Error(`computer-use: PowerShell ${scriptName} 执行超时（${timeoutMs}ms）`));
+    }, timeoutMs);
+
+    if (signal && typeof signal.addEventListener === 'function') {
+      signal.addEventListener('abort', () => {
+        child.kill();
+        finish(reject, new Error('computer-use: 已取消'));
+      }, { once: true });
+    }
+
+    child.stdout.on('data', (d) => { out += d; });
+    child.stderr.on('data', (d) => { err += d; });
+
+    child.on('error', (e) => {
+      finish(reject, new Error(`computer-use: 无法启动 PowerShell：${e.message}`));
+    });
+
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const lines = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+      for (let i = lines.length - 1; i >= 0; i -= 1) {
+        let parsed;
+        try { parsed = JSON.parse(lines[i]); } catch { continue; }
+        if (parsed && typeof parsed.ok === 'boolean') {
+          if (parsed.ok) return resolve(parsed);
+          return reject(new Error(`computer-use: ${parsed.error || 'PowerShell 执行失败'}`));
+        }
+      }
+      const detail = err.trim();
+      reject(new Error(
+        `computer-use: ${scriptName} 失败（exit ${code}）` +
+        (detail ? `：${detail.slice(0, 300)}` : '（无输出）')
+      ));
+    });
+
+    child.stdin.end();
+  });
+}
+
+export default runPs;

--- a/dsh-desktop/assets/plugins/computer-user/src/tools.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/tools.js
@@ -1,0 +1,345 @@
+import { join, resolve as pathResolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Build the computer_* tools. Coordinate system: pixels relative to the
+ * multi-monitor VIRTUAL SCREEN ORIGIN (returned by computer_screenshot as
+ * `virtual_offset`). All screen-reading/automation is delegated to bundled
+ * PowerShell scripts (capture.ps1 / input.ps1) with zero native dependencies.
+ *
+ * @param {{runPs:(script:string,payload:object,opts?:object)=>Promise<object>, getConfig:()=>object, approvedSessions?:Set<string>, sessionId?:string, setMode?:(mode:string)=>Promise<void>}} deps
+ * @returns {Array<object>} tool definitions ready for ctx.tools.register
+ */
+
+const COORD = {
+  type: 'array',
+  minItems: 2,
+  maxItems: 2,
+  items: { type: 'number' },
+  description: '相对多屏虚拟屏原点的像素坐标 [x, y]（原点是 computer_screenshot 返回的 virtual_offset）',
+};
+
+const HEAD =
+  '先调用 computer_screenshot 获取当前屏幕（>0.8 缩放即可），再用 picturereader 的 image_scan / image_ocr 分析，最后才执行本次操作。';
+
+/** Tools that are always safe (no side effects on the user's desktop). */
+const READONLY_TOOLS = new Set([
+  'computer_screenshot',
+  'computer_get_cursor_position',
+  'computer_wait',
+]);
+
+const MODES = ['disabled', 'readonly', 'manual', 'auto'];
+
+/**
+ * Mode gate: decide whether a tool call is allowed based on the current mode
+ * and the session's approval state.
+ *
+ * Returns void if allowed, or throws with `awaitingApproval=true` if
+ * the user needs to approve via /computer first.
+ */
+function modeGate(cfg, toolName, approvedSessions, sessionId) {
+  const mode = cfg.mode ?? 'manual';
+  if (mode === 'disabled') {
+    throw new Error('computer-user 已禁用：请在「设置 → 电脑操作」切换模式后再使用');
+  }
+  if (mode === 'readonly' && !READONLY_TOOLS.has(toolName)) {
+    throw new Error(`computer-user 只读模式：${toolName} 不允许执行，仅截图/读光标/等待可用`);
+  }
+  if (mode === 'manual' && !READONLY_TOOLS.has(toolName)) {
+    const approved = sessionId && approvedSessions && approvedSessions.has(sessionId);
+    if (!approved) {
+      const e = new Error(
+        '需要批准：当前为手动批准模式。请在对话框输入 /computer 批准后重试（批准后本轮及后续轮次均可使用）。'
+      );
+      e.awaitingApproval = true;
+      throw e;
+    }
+  }
+  // mode === 'auto' or readonly tool or approved manual → allow
+}
+
+/**
+ * Validate a mode value against the allowed enum.
+ * @returns the validated mode string.
+ */
+function validateMode(value) {
+  if (typeof value !== 'string' || !MODES.includes(value)) {
+    throw new Error(`computer_set_mode: mode 必须是 ${MODES.join('/')} 之一`);
+  }
+  return value;
+}
+
+function textOut(schema, prefixLines) {
+  const props = schema.properties ?? {};
+  const required = (schema.required ?? []).filter((k) => k in props);
+  return {
+    schema: { type: 'object', additionalProperties: true, properties: props, required },
+    render: (_args, value) => {
+      const head = prefixLines === undefined ? [] : (typeof prefixLines === 'function' ? prefixLines(value) : prefixLines);
+      const lines = [...head];
+      if (value && typeof value === 'object') {
+        for (const [k, v] of Object.entries(value)) {
+          if (k === 'ok') continue;
+          if (v === undefined || v === null) continue;
+          lines.push(`${k}: ${JSON.stringify(v)}`);
+        }
+      }
+      return [{ type: 'text', text: lines.join('\n') }];
+    },
+  };
+}
+
+export function createComputerTools({ runPs, getConfig, approvedSessions, sessionId, setMode }) {
+  if (typeof runPs !== 'function') throw new Error('computer-user: runPs is required');
+  if (typeof getConfig !== 'function') throw new Error('computer-user: getConfig is required');
+
+  const gate = (toolName) => modeGate(getConfig(), toolName, approvedSessions, sessionId);
+
+  // -- computer_screenshot ---------------------------------------------------
+  const computerScreenshot = {
+    name: 'computer_screenshot',
+    description: [
+      'Capture the whole virtual screen (all monitors) to a PNG file and return its path, so ' +
+      'picturereader\'s image_scan / image_ocr can analyze it (the look step of computer use).',
+      `${HEAD}`,
+      'Parameters: path (optional — where to save; when empty a unique file is written under the configured screenshot_dir, defaulting to the OS temp dir), region (optional [x0,y0,x1,y1] fractions in 0..1 to capture a sub-area), scale (optional 0.1..1 to downscale the saved image).',
+      'Returns { path, width, height, virtual_offset:[x,y], scale }. virtual_offset is the virtual-screen origin you must add to a monitor\'s local pixel when targeting that monitor.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        path: { type: 'string', description: 'Optional absolute or cwd-relative output path for the PNG. When empty a unique file is created under the configured screenshot_dir (default: OS temp).' },
+        region: { type: 'array', minItems: 4, maxItems: 4, items: { type: 'number' }, description: 'Optional [x0, y0, x1, y1] fractions (0..1) to capture only a sub-area of the virtual screen.' },
+        scale: { type: 'number', description: 'Optional 0.1..1 downscale for the saved image (default: the configured default_scale, 1 = full resolution).' },
+      },
+      required: [],
+    },
+    output: textOut({
+      required: ['path', 'width', 'height', 'virtual_offset', 'scale'],
+    }, ['screenshot saved (feed path to picturereader image_scan / image_ocr)']),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_screenshot');
+      if (exec?.signal?.aborted) throw new Error('computer_screenshot: cancelled');
+      const cfg = getConfig();
+      const cwd = exec?.agent?.session?.header?.cwd ?? process.cwd();
+      const dir = cfg.screenshot_dir?.trim() ? pathResolve(cwd, cfg.screenshot_dir) : join(tmpdir(), 'computer-user');
+      const outPath = args && args.path
+        ? pathResolve(cwd, String(args.path))
+        : join(dir, `shot-${Date.now()}-${randomBytes(4).toString('hex')}.png`);
+      const payload = {
+        outPath,
+        region: Array.isArray(args?.region) && args.region.length === 4 ? args.region : undefined,
+        scale: typeof args?.scale === 'number' ? args.scale : cfg.default_scale,
+      };
+      return runPs('capture.ps1', payload, { signal: exec?.signal });
+    },
+  };
+
+  // -- side-effecting tools --------------------------------------------------
+  const computerClick = {
+    name: 'computer_click',
+    description: [`Click at a coordinate. ${HEAD}`, 'Parameters: coordinate (required [x,y] pixels, relative to the virtual-screen origin), action (optional: click [default] | right_click | double_click).', 'Returns the clicked coordinate.'],
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: {
+        coordinate: { ...COORD, description: 'Relative to virtual-screen origin from computer_screenshot.virtual_offset.' },
+        action: { type: 'string', enum: ['click', 'right_click', 'double_click'], description: 'Default click.' },
+      },
+      required: ['coordinate'],
+    },
+    output: textOut({ required: ['clicked'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_click');
+      const res = await runPs('input.ps1', { action: 'click', coordinate: args.coordinate, action2: args.action ?? 'click' }, { signal: exec?.signal });
+      return { clicked: res.cursor };
+    },
+  };
+
+  const computerType = {
+    name: 'computer_type',
+    description: [`Type arbitrary UTF-16 text (supports Chinese) at the current focus. ${HEAD}`, 'Parameters: text (required string), send_enter (optional bool — press Enter after typing).', 'Input uses SendInput KEYEVENTF_UNICODE, so any character, including CJK, is entered reliably.' ],
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: { text: { type: 'string' }, send_enter: { type: 'boolean' } },
+      required: ['text'],
+    },
+    output: textOut({ required: ['chars'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_type');
+      const cfg = getConfig();
+      const res = await runPs('input.ps1', {
+        action: 'type', text: String(args.text), sendEnter: !!args.send_enter,
+        typingIntervalMs: cfg.typing_interval_ms || 0,
+      }, { signal: exec?.signal });
+      return { chars: res.chars };
+    },
+  };
+
+  const computerKeypress = {
+    name: 'computer_keypress',
+    description: [`Send a key chord (e.g. ["ctrl","c"], ["alt","tab"]). ${HEAD}`, 'Parameters: keys (required array of key names: ctrl/control, shift, alt, super/win/cmd, enter, tab, esc, space, backspace, delete, home, end, pageup, pagedown, up/down/left/right, f1..f24, single letters/digits, or single punctuation chars).'],
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: { keys: { type: 'array', items: { type: 'string' }, minItems: 1, description: 'Key names pressed together (modifiers first).' } },
+      required: ['keys'],
+    },
+    output: textOut({ required: ['keys'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_keypress');
+      const res = await runPs('input.ps1', { action: 'keypress', keys: args.keys }, { signal: exec?.signal });
+      return { keys: res.keys };
+    },
+  };
+
+  const computerScroll = {
+    name: 'computer_scroll',
+    description: [`Scroll at a coordinate. ${HEAD}`, 'Parameters: coordinate (required [x,y]), direction (optional: down [default] | up | left | right), clicks (optional number of wheel notches, default from config scroll_units).'],
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: {
+        coordinate: COORD,
+        direction: { type: 'string', enum: ['up', 'down', 'left', 'right'] },
+        clicks: { type: 'number' },
+      },
+      required: ['coordinate'],
+    },
+    output: textOut({ required: ['scrolled'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_scroll');
+      const cfg = getConfig();
+      const clicks = typeof args.clicks === 'number' && args.clicks > 0 ? args.clicks : (cfg.scroll_units || 1);
+      await runPs('input.ps1', { action: 'scroll', coordinate: args.coordinate, direction: args.direction ?? 'down', clicks }, { signal: exec?.signal });
+      return { scrolled: `${args.direction ?? 'down'} ${clicks} tick(s) at [${args.coordinate}]` };
+    },
+  };
+
+  const computerDrag = {
+    name: 'computer_drag',
+    description: [`Drag from start to end (press, interpolate, release). ${HEAD}`, 'Parameters: start_coordinate (required [x,y]), end_coordinate (required [x,y]), hold_keys (optional array, e.g. ["shift"] pressed while dragging).'],
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: {
+        start_coordinate: COORD,
+        end_coordinate: COORD,
+        hold_keys: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['start_coordinate', 'end_coordinate'],
+    },
+    output: textOut({ required: ['from', 'to'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_drag');
+      const res = await runPs('input.ps1', { action: 'drag', from: args.start_coordinate, to: args.end_coordinate, holdKeys: args.hold_keys ?? [] }, { signal: exec?.signal });
+      return { from: res.from, to: res.to };
+    },
+  };
+
+  const computerMoveMouse = {
+    name: 'computer_move_mouse',
+    description: [`Move the mouse cursor to a coordinate (without clicking). ${HEAD}`, 'Parameters: coordinate (required [x,y]).', 'Use computer_get_cursor_position to read the resulting position.'],
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: { coordinate: COORD },
+      required: ['coordinate'],
+    },
+    output: textOut({ required: ['moved_to'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_move_mouse');
+      const res = await runPs('input.ps1', { action: 'move', coordinate: args.coordinate }, { signal: exec?.signal });
+      return { moved_to: res.cursor };
+    },
+  };
+
+  const computerWait = {
+    name: 'computer_wait',
+    description: ['Wait for a short period (e.g. let a UI animation settle). No side effects.', 'Parameters: ms (required, duration in milliseconds).'],
+    parameters: { type: 'object', additionalProperties: true, properties: { ms: { type: 'number' } }, required: ['ms'] },
+    output: textOut({ required: ['waited'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, exec) {
+      gate('computer_wait');
+      const ms = Math.max(0, Number(args.ms) || 0);
+      await new Promise((resolve, reject) => {
+        const timer = setTimeout(resolve, ms);
+        exec?.signal?.addEventListener('abort', () => { clearTimeout(timer); reject(new Error('computer_wait: cancelled')); }, { once: true });
+      });
+      return { waited: ms };
+    },
+  };
+
+  const computerGetCursorPosition = {
+    name: 'computer_get_cursor_position',
+    description: ['Read the current mouse cursor position as virtual-screen pixels [x, y].', 'Useful to verify the result of computer_move_mouse / computer_click. No side effects.'],
+    parameters: { type: 'object', additionalProperties: true, properties: {}, required: [] },
+    output: textOut({ required: ['x', 'y'] }),
+    isConcurrencySafe: () => false,
+    async execute(_args, exec) {
+      gate('computer_get_cursor_position');
+      const res = await runPs('input.ps1', { action: 'getpos' }, { signal: exec?.signal });
+      return { x: res.cursor[0], y: res.cursor[1] };
+    },
+  };
+
+  // -- computer_set_mode: AI may change the runtime mode (if enabled) -------
+  const computerSetMode = {
+    name: 'computer_set_mode',
+    description: [
+      'Change the runtime mode to one of: disabled / readonly / manual / auto.',
+      'Only works when the setting「AI 可自行修改运行模式」(ai_can_change_mode) is on; otherwise this tool refuses.',
+      'Settings card dropdown stays in sync: the new mode is written to the computer-user settings namespace (same store the dropdown reads).',
+      'Parameters: mode (required, one of disabled/readonly/manual/auto).',
+    ].join(' '),
+    parameters: {
+      type: 'object', additionalProperties: true,
+      properties: {
+        mode: { type: 'string', enum: MODES, description: '目标运行模式：disabled/readonly/manual/auto' },
+      },
+      required: ['mode'],
+    },
+    output: textOut({ required: ['mode', 'changed_by'] }),
+    isConcurrencySafe: () => false,
+    async execute(args, _exec) {
+      if (typeof setMode !== 'function') throw new Error('computer_set_mode: 设置服务不可用');
+      const cfg = getConfig();
+      if (cfg.mode === 'disabled') {
+        throw new Error('computer-user 已禁用：无法在禁用模式下修改运行模式（需用户在设置中先解除禁用）');
+      }
+      if (cfg.ai_can_change_mode !== true) {
+        throw new Error('computer_set_mode: 当前未允许 AI 修改运行模式（设置「AI 可自行修改运行模式」未开启）');
+      }
+      const mode = validateMode(args.mode);
+      await setMode(mode);
+      return { mode, changed_by: 'ai' };
+    },
+  };
+
+  const tools = [
+    computerScreenshot,
+    computerClick,
+    computerType,
+    computerKeypress,
+    computerScroll,
+    computerDrag,
+    computerMoveMouse,
+    computerWait,
+    computerGetCursorPosition,
+    computerSetMode,
+  ];
+
+  for (const tool of tools) {
+    if (Array.isArray(tool.description)) tool.description = tool.description.join(' ');
+  }
+
+  return tools;
+}
+
+export default createComputerTools;

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -3209,6 +3209,8 @@ const COMPANION_PLUGINS = [
   // pnpm 安装会 hoist @deepseek-ai 核心包形成模块双实例（Symbol 冲突，
   // 插件命名空间注册失效，即 "设置命名空间不可用" 故障的根因）。
   { id: 'picturereader', name: 'picturereader', dir: 'picturereader' },
+  // 读屏 + 鼠标键盘自动化（Codex-style computer use，配 picturereader；纯本地）。
+  { id: 'computer-user', name: 'computer-user', dir: 'computer-user' },
   // config.path 必须随行写入：v2.0.0 只写了 id+name，而当时插件 schema 的
   // path 是 required 无默认值，全新安装校验失败拖垮整个插件树（dsh web
   // 退出码 1，应用持续闪退“启动失败”）。schema 现已带默认值，这里显式
@@ -3333,6 +3335,7 @@ const COMPANION_PLUGINS = [
 // ---------------------------------------------------------------------------
 const PLUGIN_UPDATE_SOURCES = {
   'picturereader': { npm: 'picturereader' },
+  'computer-user': { npm: 'computer-user' },
   'soul-md': { npm: 'dsh-soul-md' },
   'dsh-pet': { npm: 'dsh-pet' },
   'better-sidebar': { npm: 'dsh-better-sidebar' },


### PR DESCRIPTION
将 community 插件 computer-user（Codex-style computer use：读屏 + 鼠标/键盘自动化，纯本地 PowerShell+Win32 SendInput，配 picturereader 让纯文本模型也能驱动桌面）内置分发，内置形态与 picturereader 一致：

- dsh-desktop/assets/plugins/computer-user：随应用内置（src / client / skills / scripts；无运行时依赖，peerDeps 由宿主提供）
- main.js COMPANION_PLUGINS 注册 { id: computer-user, name: computer-user, dir: computer-user }
- main.js PLUGIN_UPDATE_SOURCES 登记 computer-user → npm: computer-user
- README（根 + dsh-desktop）插件清单补 computer-user 行

本地检查：scripts/check-syntax.js 通过；node --test test/*.test.mjs 609/609 通过；插件包结构与 picturereader 内置一致（dsh.bundle.patch / dsh.client.platform=web / exports["./client"]）。