### PR TITLE
fix: remove duplicate patch rows conflicting with bundle entry ids (closes #172)

### DIFF
--- a/dsh-desktop/plugin-guard.js
+++ b/dsh-desktop/plugin-guard.js
@@ -396,7 +396,7 @@ function createGuard(opts) {
 
     if (list.some((f) => f.code === 'PATCH_DUP_ID' || f.code === 'PATCH_SOUL_CONFIG')) {
       try {
-        const { healSoulMdPatchRow, removeBundledRowDuplicates } = require('./patch-row-heal');
+        const { healSoulMdPatchRow, removeBundledRowDuplicates, collectBundleEntryIds } = require('./patch-row-heal');
         const file = path.join(dir, 'cordis.patch.yml');
         let patch = fs.readFileSync(file, 'utf8');
         const healed = healSoulMdPatchRow(patch);
@@ -405,7 +405,8 @@ function createGuard(opts) {
         for (const id of patchRowIds(patch)) ids[id] = ids[id] || null;
         let bundled = [];
         try { bundled = readJson(path.join(dir, 'package.json'))?.dsh?.profile?.bundles || []; } catch { bundled = []; }
-        const { patch: deduped, removed } = removeBundledRowDuplicates(patch, ids, bundled, new Set());
+        const declaredBundleIds = collectBundleEntryIds(bundled, path.join(dir, 'node_modules'));
+        const { patch: deduped, removed } = removeBundledRowDuplicates(patch, ids, bundled, declaredBundleIds);
         if (removed.length) {
           patch = deduped;
           applied.push('移除与 bundle 重复的 patch 行: ' + removed.join(', '));

--- a/dsh-desktop/test/plugin-guard.test.mjs
+++ b/dsh-desktop/test/plugin-guard.test.mjs
@@ -240,3 +240,48 @@ test('snapshot pruning keeps at most 10', () => {
   assert.equal(guard.listSnapshots().length, 10);
   rmSync(home, { recursive: true, force: true });
 });
+
+test('repair removes duplicate patch rows that conflict with bundle entry ids (issue #172)', () => {
+  const t0 = { after: (fn) => fn };
+  const { home, profile, guard } = makeHome(t0);
+
+  // 模拟市场安装的 bundle 插件：在 node_modules 中有自己的 cordis.patch.yml
+  const bundleDir = join(profile, 'node_modules', 'ui-skin-whale-song');
+  mkdirSync(join(bundleDir, 'lib'), { recursive: true });
+  writeFileSync(join(bundleDir, 'package.json'), JSON.stringify({
+    name: 'ui-skin-whale-song',
+    version: '1.0.0',
+    dsh: { bundle: { patch: 'cordis.patch.yml' } },
+  }));
+  writeFileSync(join(bundleDir, 'cordis.patch.yml'),
+    '- insert:\n    - id: ui-skin-whale-song\n      name: \'ui-skin-whale-song\'\n');
+
+  // 模拟 overlay 重复写入：bundle 的 entry id 和 overlay 的重复
+  writeFileSync(join(profile, 'package.json'), JSON.stringify({
+    name: 'dsh-profile-web-desktop',
+    dsh: { profile: { bundles: ['ui-skin-whale-song'] } },
+  }));
+  writeFileSync(join(profile, 'cordis.patch.yml'),
+    '- insert:\n    - id: ui-skin-whale-song\n      name: \'ui-skin-whale-song\'\n' +
+    '- insert:\n    - id: ui-skin-whale-song\n      name: \'ui-skin-whale-song\'\n');
+
+  // healthCheck 应检测到重复
+  const { findings } = guard.healthCheck();
+  assert.ok(findings.some((f) => f.code === 'PATCH_DUP_ID'), 'duplicate row id must be flagged');
+
+  // repair 应自动修复（移除 overlay 中与 bundle 重复的行）
+  const result = guard.repair(findings);
+  assert.ok(result.applied.some((msg) => msg.includes('移除与 bundle 重复的 patch 行')),
+    'repair must remove duplicate rows, got: ' + JSON.stringify(result.applied));
+
+  // 修复后不应再有重复
+  const patchAfter = readFileSync(join(profile, 'cordis.patch.yml'), 'utf8');
+  const ids = [];
+  const re = /^\s*-\s*id:\s*([\w.-]+)\s*$/gm;
+  let m;
+  while ((m = re.exec(patchAfter)) !== null) ids.push(m[1]);
+  const dups = ids.filter((id, i) => ids.indexOf(id) !== i);
+  assert.equal(dups.length, 0, 'no duplicate ids should remain after repair, found: ' + JSON.stringify(dups));
+
+  rmSync(home, { recursive: true, force: true });
+});


### PR DESCRIPTION
## 问题描述

Issue #172: dsh web 可正常使用，但启动时弹出错误提示「dsh web 启动失败（退出码 1）」

根本原因是插件树加载时遇到重复的 loader entry id，例如：
\\\
Error: duplicate loader entry id: ui-skin-whale-song
\\\

## 根本原因

在 plugin-guard.js 的 repair 函数中，修复 PATCH_DUP_ID 问题时调用 removeBundledRowDuplicates 传入了空的 new Set() 作为 bundleEntryIds 参数。

这导致只能通过包名匹配重复项，无法通过 entry id 匹配。当 bundle 的 entry id 与 overlay 行的包名不一致时（如市场安装的皮肤插件），重复项无法被检测到，导致插件树崩溃。

## 修复方案

调用 collectBundleEntryIds 函数收集 bundle 包的实际 entry id，然后传给 removeBundledRowDuplicates，与 main.js 中 syncCompanionPlugins 的行为保持一致。

## 测试

添加了新测试验证修复效果：
\\\
✔ repair removes duplicate patch rows that conflict with bundle entry ids (issue #172)
\\\

Closes #172