### PR TITLE
fix: 审核模式切换后自动审核定时器未取消导致幽灵触发

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-change-review/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-change-review/lib/client.js
@@ -179,13 +179,16 @@ window.__ModuleLoader__.load({
         cap.retry = 0;
         cap.timer = setTimeout(function attempt() {
           cap.timer = null;
+          // 重新校验当前模式：用户可能已在此期间切换到手动/关闭
+          var nowCfg = loadConfig();
+          if (nowCfg.mode !== "auto") return;
           var ok = fireReview(sessionId);
           if (!ok && cap.pendingChanges.length > 0 && cap.retry < MAX_RETRY) {
             cap.retry += 1;
             cap.timer = setTimeout(attempt, RETRY_MS);
           }
         }, AUTO_DEBOUNCE_MS);
-      }, [sessionId, changes && changes.changes && changes.changes.length]);
+      }, [sessionId, changes && changes.changes]);
 
       return null;
     }
@@ -265,6 +268,14 @@ window.__ModuleLoader__.load({
                 var next = { mode: m.value };
                 setCfg(next);
                 saveConfig(next);
+                // 切换模式时清理当前会话的自动审核定时器
+                var sid = currentId;
+                var cap = sid && sessions.get(sid);
+                if (cap && cap.timer) {
+                  clearTimeout(cap.timer);
+                  cap.timer = null;
+                  cap.retry = 0;
+                }
               }
             }, m.label);
           })


### PR DESCRIPTION
## 修复内容

修复 #42 中描述的 dsh-change-review 插件的三个缺陷：

### 1. 定时器回调开头重新校验模式 (第 182-184 行)
`js
// 重新校验当前模式：用户可能已在此期间切换到手动/关闭
var nowCfg = loadConfig();
if (nowCfg.mode !== "auto") return;
`
用户在 20 秒防抖期间切换到手动/关闭时，定时器触发前会检查当前模式并提前退出。

### 2. 模式切换时清理定时器 (第 271-278 行)
`js
// 切换模式时清理当前会话的自动审核定时器
var sid = currentId;
var cap = sid && sessions.get(sid);
if (cap && cap.timer) {
  clearTimeout(cap.timer);
  cap.timer = null;
  cap.retry = 0;
}
`
切换到手动/关闭时主动清除已排定的定时器和重试计数，防止幽灵触发。

### 3. 修正 useEffect 依赖项 (第 191 行)
`diff
- }, [sessionId, changes && changes.changes && changes.changes.length]);
+ }, [sessionId, changes && changes.changes]);
`
改为监听 changes.changes 引用而非仅监听数量，确保同一文件多次修改时能正确触发增量逻辑。

---

**测试建议：**
1. 设置审核模式为「自动」
2. 触发文件变更，在 20 秒内切换到「手动」或「关闭」
3. 验证不会出现审核请求

Closes #42