### PR TITLE
fix: 修复 pwsh 超时后会话卡死问题 (issue #162)

### DIFF
--- a/dsh-desktop/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
+++ b/dsh-desktop/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
@@ -1,0 +1,1026 @@
+import { closeSync, constants, mkdtempSync, openSync, readFileSync, readSync, readdirSync, unlinkSync, writeSync } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { delimiter, extname, isAbsolute, join, resolve } from "node:path";
+import * as nodePty from "node-pty";
+import { SubprocessRuntime, scrubbedParentEnv } from "@deepseek-ai/dsh-subprocess";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { constants as constants$1, tmpdir } from "node:os";
+import { setTimeout as setTimeout$1 } from "node:timers/promises";
+import { MAX_TIMER_DELAY_MS } from "@deepseek-ai/dsh-timeout";
+import { Buffer as Buffer$1 } from "node:buffer";
+import { PassThrough } from "node:stream";
+//#region lib/types/process-inspector.js
+/** Platform process-table inspection for terminal readiness, signals, and teardown. */
+/* v8 ignore start -- thin OS bindings; injected logic is unit-tested and real platform composition exercises them. */
+const DEFAULT_INTERNALS = {
+	readFile: (path) => readFileSync(path, "utf8"),
+	readDir: (path) => readdirSync(path),
+	open: (path) => openSync(path, "r"),
+	read: (fd, buffer, length, position) => readSync(fd, buffer, 0, length, position),
+	close: closeSync,
+	exec: (file, args) => execFileSync(file, args, { encoding: "utf8" }),
+	kill: (pid, signal) => process.kill(pid, signal)
+};
+/**
+* Parse fields used from Linux `/proc/<pid>/stat`, including parenthesized comm text.
+* @param text - complete stat line.
+* @returns Parsed identity/group fields, or undefined for malformed input.
+*/
+function parseProcStat(text) {
+	const open = text.indexOf("(");
+	const close = text.lastIndexOf(")");
+	if (open <= 0 || close <= open) return void 0;
+	const pid = Number(text.slice(0, open).trim());
+	const rest = text.slice(close + 2).trim().split(/\s+/);
+	const state = rest[0] || "";
+	const parentPid = Number(rest[1]);
+	const pgrp = Number(rest[2]);
+	const session = Number(rest[3]);
+	const tpgid = Number(rest[5]);
+	const started = rest[19];
+	if (![
+		pid,
+		parentPid,
+		pgrp,
+		session,
+		tpgid
+	].every(Number.isSafeInteger) || state.length !== 1 || started === void 0) return void 0;
+	return {
+		pid,
+		parentPid,
+		pgrp,
+		session,
+		state,
+		tpgid,
+		started
+	};
+}
+function readLinuxStat(internals, pid) {
+	try {
+		return parseProcStat(internals.readFile(`/proc/${pid}/stat`));
+	} catch (_unreadableProcEntry) {
+		return;
+	}
+}
+/**
+* Report whether a Linux process group has an executing member. `false`
+* means the group contains only zombie/dead entries; `undefined` means the
+* process table could not prove either outcome.
+* @param processGroupId - POSIX process-group id to inspect.
+* @param internals - injectable process-table operations.
+* @returns Live-member presence, or `undefined` when unavailable/absent.
+*/
+function linuxProcessGroupHasLiveMembers(processGroupId, internals = DEFAULT_INTERNALS) {
+	let entries;
+	try {
+		entries = internals.readDir("/proc");
+	} catch (_unreadableProcDirectory) {
+		return;
+	}
+	let matched = false;
+	for (const entry of entries) {
+		if (!/^\d+$/.test(entry)) continue;
+		const stat = readLinuxStat(internals, Number(entry));
+		if (stat?.pgrp !== processGroupId) continue;
+		matched = true;
+		if (!/^[ZXx]$/.test(stat.state)) return true;
+	}
+	return matched ? false : void 0;
+}
+function numericEntries(internals, path) {
+	try {
+		return internals.readDir(path).filter((entry) => /^\d+$/.test(entry)).map(Number);
+	} catch (_unreadableProcDirectory) {
+		return [];
+	}
+}
+function readSyscall(internals, pid, tid) {
+	try {
+		const text = internals.readFile(`/proc/${pid}/task/${tid}/syscall`).trim();
+		if (text === "running" || text.startsWith("-1 ")) return void 0;
+		const fields = text.split(/\s+/);
+		const number = Number(fields[0]);
+		const args = fields.slice(1, 7).map((field) => Number.parseInt(field, 16));
+		if (!Number.isSafeInteger(number) || args.some((value) => !Number.isSafeInteger(value))) return void 0;
+		return {
+			number,
+			args
+		};
+	} catch (_unreadableSyscall) {
+		return;
+	}
+}
+function readMemory(internals, pid, address, length) {
+	let fd;
+	try {
+		fd = internals.open(`/proc/${pid}/mem`);
+		const buffer = Buffer.alloc(length);
+		const count = internals.read(fd, buffer, length, address);
+		return buffer.subarray(0, count);
+	} catch (_unreadableProcessMemory) {
+		return;
+	} finally {
+		if (fd !== void 0) internals.close(fd);
+	}
+}
+function fdSetHasStdin(internals, pid, address) {
+	return address !== 0 && (readMemory(internals, pid, address, 8)?.[0] ?? 0) % 2 === 1;
+}
+function pollHasStdin(internals, pid, address, count) {
+	if (address === 0 || count <= 0) return false;
+	const memory = readMemory(internals, pid, address, Math.min(count, 1024) * 8);
+	if (memory === void 0) return false;
+	for (let offset = 0; offset + 8 <= memory.length; offset += 8) if (memory.readInt32LE(offset) === 0 && (memory.readInt16LE(offset + 4) & 1) !== 0) return true;
+	return false;
+}
+function epollHasStdin(internals, pid, epfd) {
+	try {
+		return internals.readFile(`/proc/${pid}/fdinfo/${epfd}`).split("\n").some((line) => /^tfd:\s+0\b/.test(line.trim()));
+	} catch (_unreadableFdInfo) {
+		return false;
+	}
+}
+const SYSCALLS = {
+	x64: {
+		read: 0,
+		select: 23,
+		pselect: 270,
+		poll: 7,
+		ppoll: 271,
+		epollWait: 232,
+		epollPwait: 281
+	},
+	arm64: {
+		read: 63,
+		pselect: 72,
+		ppoll: 73,
+		epollPwait: 22
+	}
+};
+function syscallWaitsOnStdin(internals, pid, syscall, table) {
+	const [a0 = 0, a1 = 0, a2 = 0] = syscall.args;
+	if (syscall.number === table.read) return a0 === 0;
+	if (syscall.number === table.select || syscall.number === table.pselect) return a0 >= 1 && fdSetHasStdin(internals, pid, a1);
+	if (syscall.number === table.poll || syscall.number === table.ppoll) return a1 >= 1 && pollHasStdin(internals, pid, a0, a1);
+	if (syscall.number === table.epollWait || syscall.number === table.epollPwait) return a2 >= 1 && epollHasStdin(internals, pid, a0);
+	return false;
+}
+var PosixProcessInspector = class {
+	internals;
+	constructor(internals) {
+		this.internals = internals;
+	}
+	signalGroup(pgid, signal) {
+		this.internals.kill(-pgid, signal);
+	}
+	signalProcess(identity, signal) {
+		if (this.isAlive(identity)) this.internals.kill(identity.pid, signal);
+	}
+};
+function processTree(entries, rootPid) {
+	const root = new Map(entries.map((entry) => [entry.pid, entry])).get(rootPid);
+	if (root === void 0) return [];
+	const byParent = /* @__PURE__ */ new Map();
+	for (const entry of entries) {
+		const children = byParent.get(entry.parentPid) ?? [];
+		children.push(entry);
+		byParent.set(entry.parentPid, children);
+	}
+	const visited = /* @__PURE__ */ new Set();
+	const result = [];
+	const visit = (entry) => {
+		if (visited.has(entry.pid)) return;
+		visited.add(entry.pid);
+		for (const child of byParent.get(entry.pid) ?? []) visit(child);
+		result.push({
+			pid: entry.pid,
+			started: entry.started
+		});
+	};
+	visit(root);
+	return result;
+}
+var LinuxProcessInspector = class extends PosixProcessInspector {
+	arch;
+	constructor(arch, internals) {
+		super(internals);
+		this.arch = arch;
+	}
+	foregroundPgid(shellPid) {
+		const tpgid = readLinuxStat(this.internals, shellPid)?.tpgid;
+		return tpgid !== void 0 && tpgid > 0 ? tpgid : void 0;
+	}
+	isStdinWaiting(pgid) {
+		const table = SYSCALLS[this.arch];
+		if (table === void 0) return false;
+		for (const pid of numericEntries(this.internals, "/proc")) {
+			if (readLinuxStat(this.internals, pid)?.pgrp !== pgid) continue;
+			for (const tid of numericEntries(this.internals, `/proc/${pid}/task`)) {
+				const syscall = readSyscall(this.internals, pid, tid);
+				if (syscall !== void 0 && syscallWaitsOnStdin(this.internals, pid, syscall, table)) return true;
+			}
+		}
+		return false;
+	}
+	processTree(rootPid) {
+		return processTree(numericEntries(this.internals, "/proc").flatMap((pid) => {
+			const stat = readLinuxStat(this.internals, pid);
+			return stat === void 0 ? [] : [{
+				pid,
+				parentPid: stat.parentPid,
+				started: stat.started
+			}];
+		}), rootPid);
+	}
+	processSession(sessionId) {
+		return numericEntries(this.internals, "/proc").flatMap((pid) => {
+			const stat = readLinuxStat(this.internals, pid);
+			return stat?.session === sessionId ? [{
+				pid,
+				started: stat.started
+			}] : [];
+		});
+	}
+	isAlive(identity) {
+		const stat = readLinuxStat(this.internals, identity.pid);
+		return stat?.started === identity.started && !/^[ZXx]$/.test(stat.state);
+	}
+};
+function macProcessTable(internals) {
+	return internals.exec("/bin/ps", ["-axo", "pid=,ppid=,lstart="]).split("\n").flatMap((line) => {
+		const match = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/.exec(line);
+		if (match?.[1] === void 0 || match[2] === void 0 || match[3] === void 0) return [];
+		return [{
+			pid: Number(match[1]),
+			parentPid: Number(match[2]),
+			started: match[3]
+		}];
+	});
+}
+var MacProcessInspector = class extends PosixProcessInspector {
+	foregroundPgid(shellPid) {
+		try {
+			const value = Number(this.internals.exec("/bin/ps", [
+				"-o",
+				"tpgid=",
+				"-p",
+				String(shellPid)
+			]).trim());
+			return Number.isSafeInteger(value) && value > 0 ? value : void 0;
+		} catch (_missingProcess) {
+			return;
+		}
+	}
+	isStdinWaiting(_pgid) {
+		return false;
+	}
+	processTree(rootPid) {
+		return processTree(macProcessTable(this.internals), rootPid);
+	}
+	processSession(_sessionId) {
+		return [];
+	}
+	isAlive(identity) {
+		return macProcessTable(this.internals).some((entry) => entry.pid === identity.pid && entry.started === identity.started);
+	}
+};
+/**
+* Create the supported platform inspector or fail at plugin load.
+* @param platform - target Node platform.
+* @param arch - target CPU architecture for Linux syscall numbers.
+* @param internals - filesystem/process boundary, injectable for deterministic tests.
+* @returns Platform process inspector.
+*/
+function createProcessInspector(platform = process.platform, arch = process.arch, internals = DEFAULT_INTERNALS) {
+	if (platform === "linux") return new LinuxProcessInspector(arch, internals);
+	if (platform === "darwin") return new MacProcessInspector(internals);
+	throw new Error(`subprocess-local: terminal inspection is unsupported on platform ${platform}`);
+}
+//#endregion
+//#region lib/types/spawn.js
+/**
+* Process plumbing for the local subprocess service: detached process-tree
+* spawn with per-stream stdio dispositions, tail-keep collection with spill
+* files, tree-scoped signalling (POSIX groups; Windows taskkill), and the
+* SIGTERM→SIGKILL escalation. This layer reacts to an abort signal; callers
+* own deadlines, teardown ladders, and cause classification.
+* @module dsh-subprocess-local/spawn
+*/
+/**
+* Build a child environment: explicit caller entries override the scrubbed
+* parent base using the target platform's environment-key semantics. A string
+* deliberately restores or overrides an entry; an explicit `undefined`
+* tombstone removes an ordinary ambient entry.
+* @param extra - explicit caller entries and tombstones, merged after the scrub.
+* @returns the environment to hand to `spawn` for the child process.
+*/
+function childEnv(extra) {
+	const env = scrubbedParentEnv();
+	if (process.platform !== "win32") return {
+		...env,
+		...extra
+	};
+	let entries = Object.entries(env);
+	for (const [key, value] of Object.entries(extra ?? {})) {
+		const normalized = key.toUpperCase();
+		entries = entries.filter(([inherited]) => inherited.toUpperCase() !== normalized);
+		entries.push([key, value]);
+	}
+	return Object.fromEntries(entries);
+}
+/**
+* Liveness-poll cadence for tree-exit waits. The timer stays ref'd: an
+* awaited teardown must keep the event loop alive until the tree really
+* exits, or the parent can exit while claiming quiescence and orphan the
+* survivors it promised to reap.
+*/
+function sleepTick() {
+	return setTimeout$1(15);
+}
+let spillCounter = 0;
+let defaultSpillDir;
+/**
+* The default spill location: a private (0700) per-process directory under
+* the OS tmpdir, created lazily. Predictable world-readable paths would let
+* other local users read command output or pre-create symlinks.
+*/
+function privateSpillDir() {
+	defaultSpillDir ??= mkdtempSync(join(tmpdir(), "dsh-subprocess-"));
+	return defaultSpillDir;
+}
+/**
+* Collects one stream with a bounded in-memory tail. With a spill cap, on
+* first overflow a spill file is created and every chunk (including those
+* already collected) is appended there while the full stream remains within
+* the cap; without one, only the in-memory tail is ever retained (the
+* diagnostic-tail shape — a language server's stderr).
+*
+* Tail-keep rationale (pi/OpenCode): errors and final results cluster at the
+* end of command output; the spill file covers the head.
+*/
+var OutputCollector = class {
+	maxBytes;
+	maxSpillBytes;
+	label;
+	spillDir;
+	chunks = [];
+	bytes = 0;
+	dropped = false;
+	spillFd;
+	spillFile;
+	spillDisabled;
+	/** Total bytes ever pushed (not just retained). */
+	total = 0;
+	constructor(maxBytes, maxSpillBytes, label, spillDir) {
+		this.maxBytes = maxBytes;
+		this.maxSpillBytes = maxSpillBytes;
+		this.label = label;
+		this.spillDir = spillDir;
+		this.spillDisabled = maxSpillBytes === void 0;
+	}
+	/**
+	* Ingest one stream chunk, counting it toward the whole-stream total. On
+	* first overflow of the in-memory cap a spill file is opened (when spilling
+	* is enabled) and every chunk (already-collected ones included) is appended
+	* there from then on; the in-memory tail then drops whole chunks from its
+	* head (or the head of a single over-cap chunk) until it fits the cap again.
+	* @param chunk - the raw bytes from one stream 'data' event.
+	*/
+	push(chunk) {
+		this.total += chunk.length;
+		const overflows = this.bytes + chunk.length > this.maxBytes;
+		if (!this.spillDisabled && (overflows || this.spillFd !== void 0)) this.spillAll(chunk);
+		this.chunks.push(chunk);
+		this.bytes += chunk.length;
+		while (this.bytes > this.maxBytes) {
+			const head = this.chunks[0];
+			const excess = this.bytes - this.maxBytes;
+			if (head.length <= excess) {
+				this.chunks.shift();
+				this.bytes -= head.length;
+			} else {
+				this.chunks[0] = head.subarray(excess);
+				this.bytes -= excess;
+			}
+			this.dropped = true;
+		}
+	}
+	/** Open the spill file lazily and append `chunk` (and any prior chunks once). */
+	spillAll(chunk) {
+		if (this.maxSpillBytes !== void 0 && this.total > this.maxSpillBytes) {
+			this.discardSpill();
+			return;
+		}
+		if (this.spillFd === void 0) {
+			this.spillFile = join(this.spillDir, `dsh-subprocess-${process.pid}-${++spillCounter}-${randomBytes(6).toString("hex")}-${this.label}.log`);
+			this.spillFd = openSync(this.spillFile, "wx", 384);
+			for (const prior of this.chunks) writeSync(this.spillFd, prior);
+		}
+		writeSync(this.spillFd, chunk);
+	}
+	/** Stop spilling and remove the file once it can no longer hold the complete stream. */
+	discardSpill() {
+		const fd = this.spillFd;
+		const file = this.spillFile;
+		this.spillFd = void 0;
+		this.spillFile = void 0;
+		this.spillDisabled = true;
+		if (fd !== void 0) try {
+			closeSync(fd);
+		} catch {
+			this.spillFd = fd;
+		}
+		if (file !== void 0) try {
+			unlinkSync(file);
+		} catch {}
+	}
+	/**
+	* Incremental read in whole-stream byte coordinates: returns everything
+	* pushed since `fromByte`. When `fromByte` has already slid out of the
+	* in-memory tail window, the read is `lossy` — it returns the whole
+	* retained tail and the gap is only recoverable from the spill file.
+	* @param fromByte - whole-stream offset to resume from (a prior read's `nextOffset`; 0 for the first read).
+	* @returns the delta text, the offset for the next read, the `lossy` flag, and the spill path when one was created.
+	*/
+	readFrom(fromByte) {
+		const windowStart = this.total - this.bytes;
+		const buffer = Buffer.concat(this.chunks);
+		const lossy = fromByte < windowStart;
+		return {
+			text: (lossy ? buffer : buffer.subarray(fromByte - windowStart)).toString("utf8"),
+			nextOffset: this.total,
+			lossy,
+			...this.spillFile !== void 0 ? { spillPath: this.spillFile } : {}
+		};
+	}
+	/**
+	* Close the spill file once the stream has ended. A failed close (delayed
+	* writeback fault) stops advertising the spill path — the file may be
+	* missing its tail — while every in-memory read keeps working. Idempotent;
+	* the spawn path seals both collectors at settlement so reads after exit
+	* never point at a still-open file.
+	*/
+	seal() {
+		if (this.spillFd === void 0) return;
+		try {
+			closeSync(this.spillFd);
+		} catch {
+			this.spillFile = void 0;
+		}
+		this.spillFd = void 0;
+	}
+	/**
+	* Seal the spill file and return the final output.
+	* @returns the final collected output: tail text, truncation flag, and the spill path when intact.
+	*/
+	finalize() {
+		this.seal();
+		return {
+			text: Buffer.concat(this.chunks).toString("utf8"),
+			truncated: this.dropped,
+			...this.spillFile !== void 0 ? { spillPath: this.spillFile } : {}
+		};
+	}
+};
+/**
+* Terminate one Windows process tree with `taskkill /T /F`. Contained like
+* POSIX group signalling — delivery races tree exit, so an absent tree, a
+* nonzero status, or a missing taskkill binary must not break idempotent
+* teardown.
+* @param pid - root process id; non-positive is a no-op.
+*/
+function taskkillProcessTree(pid) {
+	if (pid <= 0) return;
+	spawnSync("taskkill", [
+		"/PID",
+		String(pid),
+		"/T",
+		"/F"
+	], { stdio: "ignore" });
+}
+/**
+* Signal a detached process tree with platform-correct semantics: POSIX
+* signals the negative process-group id and falls back to the direct child
+* when the group is gone; Windows terminates the tree via taskkill (any
+* signal value force-terminates — Node maps signals to TerminateProcess).
+*/
+function signalTree(platform, pid, sig, child, taskkill) {
+	if (platform === "win32") {
+		taskkill(pid);
+		return;
+	}
+	/* v8 ignore next -- kill/terminate gate on treeAlive(), which is false for pid -1; this guard protects direct callers only. */
+	if (pid <= 0) return;
+	try {
+		process.kill(-pid, sig);
+	} catch {
+		/* v8 ignore start -- the fallback needs a live child whose group signal fails
+		(EPERM-style), which POSIX CI cannot stage; the swallow keeps teardown idempotent. */
+		try {
+			child.kill(sig);
+		} catch {}
+	}
+}
+/**
+* Spawn one isolated detached process tree with the spec's per-stream stdio
+* dispositions. Runtime exits resolve `done` as {@link SubprocessOutcome};
+* only spawn failures reject.
+* @param spec - fully resolved argv, cwd, stdio, grace, cancellation, environment.
+* @param internals - test-only spill-directory, platform, and taskkill overrides.
+* @returns live subprocess handle.
+* @throws when `graceMs` cannot be represented by one Node timer.
+*/
+function spawnSubprocess(spec, internals = {}) {
+	if (!Number.isFinite(spec.graceMs) || spec.graceMs <= 0 || spec.graceMs > MAX_TIMER_DELAY_MS) throw new Error(`subprocess graceMs must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}`);
+	const spillDir = internals.spillDir ?? privateSpillDir();
+	const platform = internals.platform ?? process.platform;
+	const taskkill = internals.taskkill ?? taskkillProcessTree;
+	const linuxGroupHasLiveMembers = internals.linuxProcessGroupHasLiveMembers ?? linuxProcessGroupHasLiveMembers;
+	if (spec.signal?.aborted) throw new Error(`aborted before spawn: ${String(spec.signal.reason ?? "aborted")}`);
+	const [program, ...args] = spec.argv;
+	if (program === void 0 || program.length === 0) throw new Error("invalid argv: expected a non-empty program name at argv[0]");
+	const isCollect = (mode) => mode !== "pipe" && mode !== "inherit";
+	const outMode = spec.stdio.stdout;
+	const errMode = spec.stdio.stderr;
+	const stdinMode = spec.stdio.stdin;
+	const env = childEnv(spec.env);
+	const child = spawn(program, args, {
+		cwd: spec.cwd,
+		env,
+		stdio: [
+			stdinMode === "ignore" ? "ignore" : "pipe",
+			outMode === "inherit" ? "inherit" : "pipe",
+			errMode === "inherit" ? "inherit" : "pipe"
+		],
+		detached: platform !== "win32"
+	});
+	const collectStream = (mode, stream, label) => {
+		if (!isCollect(mode) || stream === null) return void 0;
+		const collector = new OutputCollector(mode.maxBytes, mode.spill?.maxBytes, label, spillDir);
+		stream.on("data", (chunk) => {
+			collector.push(chunk);
+		});
+		return collector;
+	};
+	const stdoutCollector = collectStream(outMode, child.stdout, "stdout");
+	const stderrCollector = collectStream(errMode, child.stderr, "stderr");
+	let graceTimer;
+	let treeExitObserved = false;
+	let treeExitObservation;
+	let settled = false;
+	let doneResolve;
+	const pid = child.pid ?? -1;
+	/** Whether the detached tree's root (or POSIX group) is still alive. */
+	const treeAlive = () => {
+		/* v8 ignore next -- only a timer callback already queued when the observer settles can enter here;
+		the guard is the final defense against probing an id after its tree was confirmed absent. */
+		if (treeExitObserved) return false;
+		if (pid <= 0) return false;
+		if (platform === "win32") return child.exitCode === null && child.signalCode === null;
+		try {
+			process.kill(-pid, 0);
+			if (settled && platform === "linux" && linuxGroupHasLiveMembers(pid) === false) return false;
+			return true;
+		} catch (error) {
+			const code = error.code;
+			/* v8 ignore next 2 -- POSIX reports an absent group as ESRCH; child-reaping timing
+			makes observing the other arm platform-dependent. */
+			if (code === "ESRCH") return false;
+			/* v8 ignore start -- EPERM and non-POSIX negative-pid failures are platform defenses; CI runs
+			tree-lifecycle tests on POSIX hosts where absence reports ESRCH. */
+			if (code === "EPERM") return true;
+			return child.exitCode === null && child.signalCode === null;
+		}
+	};
+	/**
+	* Start or reuse the handle's single whole-tree exit observer. The first
+	* confirmed absence is a permanent no-more-signals boundary: it cancels a
+	* pending escalation before this process-group id can be reused.
+	*/
+	const observeTreeExit = () => {
+		treeExitObservation ??= (async () => {
+			while (treeAlive()) await sleepTick();
+			treeExitObserved = true;
+			if (graceTimer !== void 0) clearTimeout(graceTimer);
+			graceTimer = void 0;
+		})();
+		return treeExitObservation;
+	};
+	const kill = (sig) => {
+		/* v8 ignore next -- the shared exit observer cancels the ordinary dead-tree timer;
+		this remains the timer/death race guard and cannot be staged deterministically. */
+		if (!treeAlive()) return;
+		signalTree(platform, pid, sig, child, taskkill);
+	};
+	const terminate = () => {
+		if (treeExitObserved || graceTimer !== void 0) return;
+		observeTreeExit();
+		if (treeExitObserved) return;
+		kill("SIGTERM");
+		graceTimer = setTimeout(() => {
+			kill("SIGKILL");
+		}, spec.graceMs);
+	};
+	const terminateForHostExit = () => {
+		kill("SIGKILL");
+	};
+	const onAbort = () => {
+		terminate();
+		// 如果进程在 graceMs 后仍未退出，强制 resolve done promise
+		setTimeout(() => {
+			if (!settled && doneResolve) {
+				doneResolve({ exitCode: null, signal: null });
+			}
+		}, spec.graceMs);
+	};
+	spec.signal?.addEventListener("abort", onAbort, { once: true });
+	if (typeof stdinMode === "object" && child.stdin !== null) {
+		child.stdin.on("error", () => {});
+		child.stdin.end(stdinMode.data);
+	}
+	const done = new Promise((resolve, reject) => {
+		doneResolve = resolve;
+		let pipeDrainTimer;
+		const settle = (exitCode, signal) => {
+			if (settled) return;
+			settled = true;
+			doneResolve = null;
+			if (stdoutCollector !== void 0) child.stdout?.destroy();
+			if (stderrCollector !== void 0) child.stderr?.destroy();
+			stdoutCollector?.seal();
+			stderrCollector?.seal();
+			cleanup();
+			resolve({
+				exitCode,
+				signal
+			});
+		};
+		child.on("error", (error) => {
+			settled = true;
+			cleanup();
+			reject(error);
+		});
+		child.on("exit", (exitCode, signal) => {
+			pipeDrainTimer = setTimeout(() => {
+				settle(exitCode, signal);
+			}, spec.graceMs);
+		});
+		child.on("close", settle);
+		function cleanup() {
+			if (pipeDrainTimer !== void 0) clearTimeout(pipeDrainTimer);
+			spec.signal?.removeEventListener("abort", onAbort);
+		}
+	});
+	const waitForExit = async (signal) => {
+		const observed = observeTreeExit();
+		if (treeExitObserved) return true;
+		if (signal?.aborted) return false;
+		if (signal === void 0) {
+			await observed;
+			return true;
+		}
+		const aborted = Promise.withResolvers();
+		const onAbort = () => {
+			aborted.resolve(false);
+		};
+		signal.addEventListener("abort", onAbort, { once: true });
+		/* v8 ignore next -- closes the event-loop race between the preceding aborted check and listener registration. */
+		if (signal.aborted) onAbort();
+		try {
+			return await Promise.race([observed.then(() => true), aborted.promise]);
+		} finally {
+			signal.removeEventListener("abort", onAbort);
+		}
+	};
+	return {
+		pid,
+		/* v8 ignore start -- pipe-mode fds exist on every spawn Node returns; the null-coalesces guard a nonconforming ChildProcess only. */
+		stdin: stdinMode === "pipe" ? child.stdin ?? void 0 : void 0,
+		stdout: outMode === "pipe" ? child.stdout ?? void 0 : void 0,
+		stderr: errMode === "pipe" ? child.stderr ?? void 0 : void 0,
+		/* v8 ignore stop */
+		collected: {
+			...stdoutCollector !== void 0 ? { stdout: stdoutCollector } : {},
+			...stderrCollector !== void 0 ? { stderr: stderrCollector } : {}
+		},
+		done,
+		terminate,
+		terminateForHostExit,
+		waitForExit
+	};
+}
+//#endregion
+//#region lib/types/terminal.js
+/** Local node-pty terminal-process implementation for the subprocess seam. */
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+function signalName(number) {
+	if (number === void 0 || number === 0) return null;
+	for (const [name, value] of Object.entries(constants$1.signals)) if (value === number) return name;
+	return null;
+}
+/**
+* A local terminal whose process-session ownership stays below the PTY backend.
+* The seam's terminate() promise — no write, inspection, or signal in flight
+* after settlement — holds here without operation tracking only because every
+* handle call completes synchronously under the hood (node-pty write, ps-based
+* inspection). A first genuinely asynchronous step in any handle call must add
+* the tracking a remote provider needs.
+*/
+var LocalTerminalHandle = class {
+	terminal;
+	inspector;
+	graceMs;
+	pid;
+	output = new PassThrough();
+	done;
+	outcome = Promise.withResolvers();
+	dataDisposable;
+	exitDisposable;
+	cleanup;
+	exited = false;
+	trackedDescendants = [];
+	/** The spawned shell's start identity; scans stop adopting members once the root pid no longer carries it. */
+	rootIdentity;
+	/**
+	* @param terminal - allocated node-pty process.
+	* @param inspector - platform process/session operations.
+	* @param graceMs - TERM-to-KILL and exit-wait grace.
+	*/
+	constructor(terminal, inspector, graceMs) {
+		this.terminal = terminal;
+		this.inspector = inspector;
+		this.graceMs = graceMs;
+		this.pid = terminal.pid;
+		this.rootIdentity = inspector.processTree(this.pid).find((member) => member.pid === this.pid);
+		this.done = this.outcome.promise;
+		this.dataDisposable = terminal.onData((data) => {
+			this.output.write(Buffer$1.from(data, "utf8"));
+		});
+		this.exitDisposable = terminal.onExit(({ exitCode, signal: exitSignal }) => {
+			if (this.exited) return;
+			this.exited = true;
+			this.output.end();
+			this.outcome.resolve({
+				exitCode: exitSignal === void 0 || exitSignal === 0 ? exitCode : null,
+				signal: signalName(exitSignal)
+			});
+		});
+	}
+	async write(data) {
+		if (this.exited) throw new Error("terminal process has exited");
+		this.terminal.write(data);
+	}
+	async inspectForeground() {
+		this.descendants();
+		const processGroupId = this.inspector.foregroundPgid(this.pid);
+		if (processGroupId === void 0) return void 0;
+		return {
+			processGroupId,
+			inputWaiting: this.inspector.isStdinWaiting(processGroupId)
+		};
+	}
+	async signalForeground(signal) {
+		const foreground = await this.inspectForeground();
+		if (foreground === void 0) throw new Error(`cannot resolve foreground process group for terminal ${this.pid}`);
+		if (signal === "SIGKILL" && foreground.processGroupId === this.pid) throw new Error("refusing to SIGKILL the terminal shell; terminate the terminal session instead");
+		this.inspector.signalGroup(foreground.processGroupId, signal);
+		return foreground.processGroupId;
+	}
+	terminate() {
+		if (this.cleanup !== void 0) return this.cleanup;
+		const cleanup = this.closeOnce();
+		this.cleanup = cleanup;
+		cleanup.catch(() => {
+			this.cleanup = void 0;
+		});
+		return cleanup;
+	}
+	/**
+	* Force-terminate the observable session synchronously during Node's exit
+	* event. This does not claim quiescence and does not replace terminate().
+	*/
+	terminateForHostExit() {
+		this.forceStopDescendants();
+		this.forceStopShell();
+		this.forceStopDescendants();
+	}
+	forceStopShell() {
+		if (this.exited) return;
+		if (this.rootIdentity !== void 0) {
+			try {
+				this.inspector.signalProcess(this.rootIdentity, "SIGKILL");
+			} catch (_rootExitedDuringHostExit) {}
+			return;
+		}
+		try {
+			this.terminal.kill("SIGKILL");
+		} catch (_unidentifiedShellExitedDuringHostExit) {}
+	}
+	survivors(members) {
+		return members.filter((member) => this.inspector.isAlive(member));
+	}
+	descendants() {
+		const tree = this.inspector.processTree(this.pid);
+		const root = tree.find((member) => member.pid === this.pid);
+		const rootVerified = this.rootIdentity !== void 0 && root !== void 0 && root.started === this.rootIdentity.started;
+		this.trackedDescendants = this.survivors(this.unionMembers(this.trackedDescendants, ...rootVerified ? [tree, this.inspector.processSession(this.pid)] : []).filter((member) => member.pid !== this.pid));
+		return this.trackedDescendants;
+	}
+	async waitForMembers(members) {
+		const until = Date.now() + this.graceMs;
+		let survivors = this.survivors(members);
+		while (survivors.length > 0 && Date.now() < until) {
+			await delay(Math.min(25, Math.max(1, until - Date.now())));
+			survivors = this.survivors(members);
+		}
+		return survivors;
+	}
+	signalMembers(members, signal) {
+		for (const member of members) try {
+			this.inspector.signalProcess(member, signal);
+		} catch (_alreadyExitedDuringSignal) {}
+	}
+	forceStopDescendants() {
+		let members = this.trackedDescendants;
+		try {
+			members = this.descendants();
+		} catch (_processTableUnavailableDuringHostExit) {}
+		this.signalMembers(members, "SIGKILL");
+	}
+	unionMembers(...groups) {
+		const members = [];
+		const seen = /* @__PURE__ */ new Set();
+		for (const group of groups) for (const member of group) {
+			const key = `${member.pid}:${member.started}`;
+			if (seen.has(key)) continue;
+			seen.add(key);
+			members.push(member);
+		}
+		return members;
+	}
+	async stopDescendants() {
+		const captured = this.descendants();
+		this.signalMembers(captured, "SIGTERM");
+		const capturedSurvivors = await this.waitForMembers(captured);
+		const members = this.unionMembers(capturedSurvivors, this.descendants());
+		this.signalMembers(members, "SIGKILL");
+		const survivors = await this.waitForMembers(members);
+		return this.survivors(this.unionMembers(survivors, this.descendants()));
+	}
+	async stopShell() {
+		if (!this.exited) {
+			try {
+				this.terminal.kill("SIGTERM");
+			} catch (_topLevelAlreadyExitedDuringTerm) {}
+			await Promise.race([this.done.then(() => void 0), delay(this.graceMs)]);
+		}
+		if (!this.exited) {
+			try {
+				this.terminal.kill("SIGKILL");
+			} catch (_topLevelAlreadyExitedDuringKill) {}
+			await Promise.race([this.done.then(() => void 0), delay(this.graceMs)]);
+		}
+		if (!this.exited) throw new Error(`terminal cleanup failed; surviving pid: ${this.pid}`);
+	}
+	async closeOnce() {
+		let survivors = await this.stopDescendants();
+		if (survivors.length > 0) throw new Error(`terminal cleanup failed; surviving pids: ${survivors.map((member) => member.pid).join(", ")}`);
+		await this.stopShell();
+		survivors = await this.stopDescendants();
+		if (survivors.length > 0) throw new Error(`terminal cleanup failed; surviving pids: ${survivors.map((member) => member.pid).join(", ")}`);
+		this.dataDisposable.dispose();
+		this.exitDisposable.dispose();
+	}
+};
+//#endregion
+//#region lib/types/index.js
+/**
+* Local Service Provider for the subprocess capability seam. Each spawn is a detached
+* process tree with the spec's per-stream stdio dispositions. Normal disposal
+* terminates and joins live trees; Node's synchronous exit phase force-stops
+* any trees the service still owns. It has no config: every disposition and
+* limit arrives on the spec, so the deployment-varying choices stay with the
+* caller's config (the bash executor's, the LSP host's, …).
+* @module @deepseek-ai/dsh-subprocess-local
+*/
+/**
+* Local subprocess service: detached process trees, Node-shaped stdio
+* dispositions (raw pipes, inherit, bounded tail-keep collection with spill
+* files), credential-scrubbed environment, and tree-scoped signalling with
+* SIGTERM→grace→SIGKILL escalation, plus synchronous final termination during
+* JavaScript-observable host exit.
+*/
+var LocalSubprocessRuntime = class extends SubprocessRuntime {
+	/** Live handles retained for normal disposal and synchronous host-exit finalization. */
+	live = /* @__PURE__ */ new Set();
+	/** Live terminals retained through normal quiescence or host-exit finalization. */
+	terminals = /* @__PURE__ */ new Set();
+	/** Test hook: spill and platform knobs forwarded to spawnSubprocess. */
+	internals = {};
+	/** Test hook for platform process inspection; production resolves lazily on terminal spawn. */
+	terminalInspector;
+	constructor(ctx) {
+		super(ctx);
+		ctx.effect(() => {
+			const onHostExit = () => {
+				this.terminateForHostExit();
+			};
+			process.prependListener("exit", onHostExit);
+			return async () => {
+				try {
+					await this.disposeManagedProcesses();
+				} finally {
+					process.off("exit", onHostExit);
+				}
+			};
+		}, "local subprocess teardown");
+	}
+	terminateForHostExit() {
+		for (const handle of this.live) try {
+			handle.terminateForHostExit();
+		} catch (_ordinaryTreeTerminationFailed) {}
+		for (const terminal of this.terminals) try {
+			terminal.terminateForHostExit();
+		} catch (_terminalTerminationFailed) {}
+	}
+	async disposeManagedProcesses() {
+		const pending = [];
+		for (const handle of this.live) {
+			handle.terminate();
+			pending.push(handle.done.catch(() => {}).then(() => handle.waitForExit()));
+		}
+		for (const terminal of this.terminals) pending.push(terminal.terminate());
+		const failures = (await Promise.allSettled(pending)).flatMap((outcome) => outcome.status === "rejected" ? [outcome.reason] : []);
+		if (failures.length > 0) this.terminateForHostExit();
+		this.live.clear();
+		this.terminals.clear();
+		if (failures.length === 1) throw failures[0];
+		if (failures.length > 1) throw new AggregateError(failures, "local subprocess teardown failed");
+	}
+	async resolveExecutable(command, env, signal) {
+		if (command.length === 0) throw new Error("subprocess-local: executable must be non-empty");
+		signal?.throwIfAborted();
+		const environment = childEnv(env);
+		const absolute = isAbsolute(command);
+		if (!absolute && (command.includes("/") || process.platform === "win32" && command.includes("\\"))) throw new Error(`subprocess-local: command ${JSON.stringify(command)} is a relative path; use an absolute path or a bare PATH name`);
+		const candidates = absolute ? [command] : this.executableCandidates(command, environment);
+		for (const candidate of candidates) {
+			signal?.throwIfAborted();
+			try {
+				if (!(await stat(candidate)).isFile()) continue;
+				await access(candidate, constants.X_OK);
+				signal?.throwIfAborted();
+				return candidate;
+			} catch {}
+		}
+		signal?.throwIfAborted();
+		throw new Error(absolute ? `subprocess-local: command ${JSON.stringify(command)} is not an executable file` : `subprocess-local: command ${JSON.stringify(command)} was not found on PATH`);
+	}
+	executableCandidates(command, env) {
+		const path = environmentValue(env, "PATH") ?? "";
+		const extensions = process.platform === "win32" && extname(command) === "" ? (environmentValue(env, "PATHEXT") ?? ".COM;.EXE;.BAT;.CMD").split(";") : [""];
+		return path.split(delimiter).flatMap((directory) => extensions.map((extension) => resolve(process.cwd(), directory, command + extension)));
+	}
+	spawn(spec) {
+		const handle = spawnSubprocess(spec, this.internals);
+		this.live.add(handle);
+		const release = () => handle.waitForExit().then(() => {
+			this.live.delete(handle);
+		});
+		handle.done.then(release, release);
+		return handle;
+	}
+	async spawnTerminal(spec) {
+		const file = spec.argv[0];
+		if (file === void 0 || file.length === 0) throw new Error("subprocess-local: terminal argv must contain a program");
+		spec.signal?.throwIfAborted();
+		const options = {
+			name: "dumb",
+			rows: spec.rows,
+			cols: spec.cols,
+			cwd: spec.cwd,
+			env: childEnv(spec.env)
+		};
+		const inspector = this.terminalInspector ?? createProcessInspector();
+		const handle = new LocalTerminalHandle(nodePty.spawn(file, [...spec.argv.slice(1)], options), inspector, spec.graceMs);
+		this.terminals.add(handle);
+		const release = async () => {
+			await handle.terminate();
+			this.terminals.delete(handle);
+		};
+		handle.done.then(release, release).catch(() => {});
+		return handle;
+	}
+};
+/** Read a Windows environment key using the platform's case-insensitive semantics. */
+function environmentValue(env, name) {
+	const exact = env[name];
+	if (exact !== void 0 || process.platform !== "win32") return exact;
+	const normalized = name.toUpperCase();
+	return Object.entries(env).find(([key]) => key.toUpperCase() === normalized)?.[1];
+}
+//#endregion
+export { LocalSubprocessRuntime, LocalSubprocessRuntime as default };

--- a/dsh-desktop/package-lock.json
+++ b/dsh-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-desktop",
-  "version": "4.4.1",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-desktop",
-      "version": "4.4.1",
+      "version": "4.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -531,7 +531,6 @@
       "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
       "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2",
         "@standard-schema/spec": "^1.1.0"
@@ -557,7 +556,6 @@
       "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.1.tgz",
       "integrity": "sha512-E1NThkFB3jn3TCqa6Oc++1zQHqLejF3W2wDwv2BlL3UEmgtBXL1K1j1koc+j676RuiOXtJkUJlPcOntRGKLWBQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
@@ -585,7 +583,6 @@
       "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.6.tgz",
       "integrity": "sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2",
         "js-yaml": "^4.1.0"
@@ -600,7 +597,6 @@
       "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.2.tgz",
       "integrity": "sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2"
       },
@@ -709,7 +705,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.0-rc.7.tgz",
       "integrity": "sha512-AqBQavJYgbCUUYBHP7OGCaw8WN5082NXYQOoOfNRO72bub3E+/nWkl8b4B7BAJdFfyLo9ce+Kgb1BCHSJU/JLg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
@@ -725,7 +720,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.0-rc.7.tgz",
       "integrity": "sha512-zHtD4FAqxzidyNiyx1bpvLHdOTTsKnmjlHRqDS1KegIMSTNFmmp1B2bHdAUXp/OH7fPDmv+1ZXzDoJhBNUY9jA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -782,7 +776,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.0-rc.7.tgz",
       "integrity": "sha512-T/VcMV7lrXCFmRKrtoMTAz5DAdUmku6hz95wbikRvRc0WizIwQ3R04ke9KIeDiQcxK8xkE8cx+IYqEWa9C5gPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "js-yaml": "^4.1.0"
@@ -820,7 +813,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.0-rc.7.tgz",
       "integrity": "sha512-g39W2HSWum6ghJG3src3rLVR8mnCsc0xCBSRpef1Fxgsjjn1LS2KNstKThXQtn7lYQZM/DNE7uiaOmsLxayeJQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -833,7 +825,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.0-rc.7.tgz",
       "integrity": "sha512-tcoOuHMSqYqCtMxLjWBHKN+glS56XaUo3ImphvDvUkB84FyU3btHNJbYeAt2oXoWbHfOedcIRWpfNN4tSmhPwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       },
@@ -849,7 +840,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.0-rc.7.tgz",
       "integrity": "sha512-dsP69u0avHRcJTPzngudqCm73UaTxNvGi/557DNPi3cOSoIh1SyPzPgk8W8rQQEFTL07rkwt8KfdQoMU5ga1fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7"
       },
@@ -902,7 +892,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.0-rc.7.tgz",
       "integrity": "sha512-LxRx6K8FJ8bXZHiNhH6Rvj+jh/ZIpolmsmi138XrvMUGvbOBWE6QLbdzcgTgwrYZm5GP2kqqLe/3gQlgtt2bXA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -913,7 +902,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.0-rc.7.tgz",
       "integrity": "sha512-rsR/xVNOGIig8gXxhrKnkd6YD7aYliGtA/e7b4DlPawMpLhsItAh0HQ832n8LJn1aGZxKf68y9PRgzfljsveOQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -1030,7 +1018,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.0-rc.7.tgz",
       "integrity": "sha512-fsw2Ex5ExyX4A62P1+fodbnUG4PXOSyHAM4YtaLg2kcPcElLwatYNPG3gEuulxwbpWDlx/OWvbjHThnJUuzaoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -1072,7 +1059,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.0-rc.7.tgz",
       "integrity": "sha512-JZWDKCbwKHOUcm7+JadKA3aJCSEB34XfPycCtPgdWfABIiHMaSpnmSVy/8Jed4hw6hxhnR6A3rnvW02Xr2yqwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
         "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
@@ -1110,7 +1096,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.0-rc.7.tgz",
       "integrity": "sha512-1onX79wXJfAzdwIJPUI9jEVYeVQJfWwyQvyL/OmGrnkCs8srJHIXBdYtsUC7ILlR13y5nOY4j6bifBOAoGRn6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -1132,7 +1117,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.0-rc.7.tgz",
       "integrity": "sha512-hczFl0TRH5sLt/dS0+TMCtQvfDoeLw/r88L6n3rXfY6Q1e4Yddg6RAv4kGsUoMoLYgWi7qPwD6HcUGgyKkDPHg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -1143,7 +1127,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-runtime/-/dsh-client-runtime-0.1.0-rc.7.tgz",
       "integrity": "sha512-Ish2uFML2FibTpzo7QyVSt29jf/iG4j9BFQ41ychVMPRR3trJGM3h8CMuam3oKWlvB8OXVXFd6gO929w6PI0Ew==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
         "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
@@ -1174,7 +1157,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-schema-form/-/dsh-client-schema-form-0.1.0-rc.7.tgz",
       "integrity": "sha512-acGeXjGl2lMqCO+jY1z9/FKbIiskk7FZO266OSBOwHJQP6yBd5MBnrvtPJUB3glP6xsQK8neFLLtRwVgRJ+GqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -1208,7 +1190,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.0-rc.7.tgz",
       "integrity": "sha512-IRA778yZpOaoJEkODlfydd6yuASf7hF229s64IY5zaY+22K7D+X1cmDo8D13UylxQXFPAomTlHtQtQpCtghKXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-attachment": "^0.1.0-rc.7",
         "@deepseek-ai/dsh-client-ui-primitives": "^0.1.0-rc.7",
@@ -1226,7 +1207,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.0-rc.7.tgz",
       "integrity": "sha512-gLuzEmgVhEIjVeLlmIAdKX/SEEFavnVOD0mQPlHIMqFAX/80yzYfRD7CMxXc0amOj7uBcw7qsSa4WzFvaWso3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -1249,7 +1229,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.0-rc.7.tgz",
       "integrity": "sha512-CyjFjP+oRJQ4ydX8WVrKUeloQnAJRA/fN6RRY6NAHldFC9pd1l8YogmTcR1JuCIlqzMnLRyYlGODQBYz8WOjmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1324,7 +1303,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.0-rc.7.tgz",
       "integrity": "sha512-5lj27c68wWqroyIOXmFPGUDFQxICDYEcYAJSuV5ZbnHXyN2cBTTDTW4zJPwisY5GhKfiJXjhS0YZqLi54/Xn+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -1344,7 +1322,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.0-rc.7.tgz",
       "integrity": "sha512-SZ9NuuIDrBjHJsEcnqwhbiCZknjkyNd0ZBHDl453p2WHkfA8zwDMUJRdAMWd0sC95WH2Yu4rMzkAVYjZwCBjVw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
@@ -1378,7 +1355,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.0-rc.7.tgz",
       "integrity": "sha512-Sfn4YlS6dKm/ojGRyZL5oq34+GSeyirzGkmqhtoX7hpjHAhBVmugz2jku2ijYEjjFtD6YKYdWwvQxHdRaHFZ+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -1510,7 +1486,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-primitives/-/dsh-client-ui-primitives-0.1.0-rc.7.tgz",
       "integrity": "sha512-x3cnIAeOdDMd7no8JwP65q7J9Fj4xQWAZPPJY4MzgfQAAOcHJb0T0d5Uo4FXMiCcTeU/73n7BssS5PE7jjgiDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@shikijs/langs": "^4.3.1",
         "@types/mdast": "^4.0.4",
@@ -1543,7 +1518,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.0-rc.7.tgz",
       "integrity": "sha512-I02BGKw3/yG25yf5omsMwmwJ2CnFyxTvbxqgRgSmTCUxATkLT87K8SxcemRZqXnFXQZhm6Il6bwVCpVfRfmNoA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-api-remotes": "^0.1.0-rc.7",
@@ -1643,7 +1617,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.0-rc.7.tgz",
       "integrity": "sha512-YduvLROf3gniqYggfRfkvNDMtqvWlREmwxVtxullWTXhrgXmcPya7GCKJeru8ZuyrF3FU1XqOR8KJT+OzLSv7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -1681,7 +1654,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-slots/-/dsh-client-ui-slots-0.1.0-rc.7.tgz",
       "integrity": "sha512-5rPP/6IWZflhiegVHU56IOPGHtrhLgBV44mOFn2JNVwiwxxmKeIhEcnYD4M0eKkI+pRiJIO5WvkRYokIGgyFiA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -1713,7 +1685,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.0-rc.7.tgz",
       "integrity": "sha512-T5YaUZEJv0XHL0VYuP4/Vg+tbQGgRq0+gqsbqryuU5nq59PPISDED81zpCSb1jkZ/xFNc5Weq68+54cUGndpQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -1738,7 +1709,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.0-rc.7.tgz",
       "integrity": "sha512-smo+6QWddCdtLQb4AUVbaaxsu3h8ImQlMDTBYK4qeoxlVTQdKgrNdgtQe5YoB8bvuGLQd6obVVwwScPNaD73xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -1823,7 +1793,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.0-rc.7.tgz",
       "integrity": "sha512-+8TmQprJ4y1J9AyM+/ABkndWsv6/lwA7by6HlRup4Ks2auQBhejFG7FjZPFACjkWLuJaIgDUN1aRQ5MNFCanfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clsx": "^2.0.0"
       },
@@ -1864,7 +1833,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-client-web-react/-/dsh-client-web-react-0.1.0-rc.7.tgz",
       "integrity": "sha512-aw8s6RgMVJNNPTHB4TzVmKsuROp9yZDMKKXsMEEha8CESlHhCF1c+qxLsjAcilwY5CYCwin2T/3lot88k+ITiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
         "react": "^18.2.0",
@@ -1929,7 +1897,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.0-rc.7.tgz",
       "integrity": "sha512-DM/EGrz8vvgRJSxV4UAWtyJpxFi1v8gWkj/iT9q5iGex0zNdDO4Ml0/u/e73brmN3bsGyubsdUuIdkGsl8n/Ig==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-anonymous-user-id": "^0.1.0-rc.7",
@@ -1956,7 +1923,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.0-rc.7.tgz",
       "integrity": "sha512-SYrQpJZQ4fvfyfw3IJ5j0goUiOFZb1ZhcANgUp99HVlhhN/l1oEOAvEZL1efaSE7KIG6qp4JEn7iLtNdo8+mEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -2031,7 +1997,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.0-rc.7.tgz",
       "integrity": "sha512-D8A93lu2T1/QfT9yRErxI3ptgTyGwJUIorzf5WQe4+3/buv1LUKCXJHabm0fknaDiQdUOge+MjdZDNV2SoYGvw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
@@ -2050,7 +2015,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.0-rc.7.tgz",
       "integrity": "sha512-A7R39cSNsLwjm+P54bUFBUd5+YbdyKkC5cLQqYt12STt0Z06az10Qt5rsL25rnWkxW7x7Ql0wVA83tOmO2oy0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "zod": "^4.4.3"
@@ -2072,7 +2036,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.0-rc.7.tgz",
       "integrity": "sha512-24oY36x90GN3QG2BASlryjzsO5eLA1U9vsvH1tPtBRJ1pBC6JqnW2v0SfDI/pcMT0ZbWo0uEATiik8rrv6xRpA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -2103,7 +2066,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.0-rc.7.tgz",
       "integrity": "sha512-l4jEcfjrV7hWTQo6sH0oXntg4pz1nVuDXRcprps6NhZ0/OOer/9SzUx7J9aLnLeX9XDtExXsFbxkXW5Js3ZFwg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -2117,7 +2079,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.0-rc.7.tgz",
       "integrity": "sha512-gbiH8xBrBw/1iRM3MLwI9zlFqLRg+1d+hNs8Etdn240xjWPuFdv5Hjg+eu4V5I+lU3M/lZieahEUpwYRScGuVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "koffi": "^3.1.0"
@@ -2158,7 +2119,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.0-rc.7.tgz",
       "integrity": "sha512-/pI2o0YcP21ReT+OQx7aA8SyUsnuEHxTQtMbu3DvN9ChvaFeptCTXGvHWocwVtzEEi48mdvAXF4Mx0Ptj1LJYA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "zod": "^4.4.3"
@@ -2215,7 +2175,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.0-rc.7.tgz",
       "integrity": "sha512-9Bu0eAbPw/FfCNpiX9hvyP5wedMUUQBc2sVTtU+xtH27/iUPxXoamFtBt3ydBJUeuVhja/leuhJ/d3MRhXO9fQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -2294,7 +2253,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.0-rc.7.tgz",
       "integrity": "sha512-yVHhAPK61gurrgys+xKia3RCr2OlwFCSb/XGzSDuzkVtAmqtG03oWTvnMiNpRKUyGCRFdgN0TP3QDg46rRlQ/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -2309,7 +2267,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.0-rc.7.tgz",
       "integrity": "sha512-CMHnPXL0oqwCnwt4TVRBAUfM4GNwkcZ1yURLlUo11ISBYh11LbOCXri3LoDjXzdCaZ21CWEKl25sZHnHnQ2GWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-host-directory-picker": "^0.1.0-rc.7",
         "@deepseek-ai/dsh-native-command": "^0.1.0-rc.7",
@@ -2339,7 +2296,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.0-rc.7.tgz",
       "integrity": "sha512-B8ITfMnBAdgkkuvoMrBdVgydhsCYGnP8XIGXIouOQyT9/eWbD3WqO76XG+u+e2G36ACXu2NaIxsRh3ijzyorwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -2356,7 +2312,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.0-rc.7.tgz",
       "integrity": "sha512-ip6HeN9YpWJXgWKAWsL3JUrI8j+MHEvbQ/m3U5ubP/Pc0AQ9x+6xZ/nYe+22112I12rihiwb85ykFwFfx0QbKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -2370,7 +2325,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.0-rc.7.tgz",
       "integrity": "sha512-PnO1F4aZGUmqZPyuPJpBUfQ4DZmjCGCNGr0yuN2iURTP/e6h0kGnTNTYgR2NqMvAtpP66WNiHhvH2LMqumk1+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -2383,7 +2337,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.0-rc.7.tgz",
       "integrity": "sha512-+omM89dEsaiAL1XtsSTMmRF46POp5g25Qs5KVj+Zfrk7whlXjLXwFiaukt/htdVdHIOM51qM+tCleqlHOU0Chw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
@@ -2414,7 +2367,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.0-rc.7.tgz",
       "integrity": "sha512-ATVyi47hyAWFINOxi8TGurRF8rShW/WzqWKqjxEQU5gLZbWtAMgkpAc+hwlyo/lXytGaj5cMXyzeyjpD6URHFg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -2425,7 +2377,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.0-rc.7.tgz",
       "integrity": "sha512-VaB9kQ8XOA+R5jtsWf92QMc1WpaatEAFUvQePGUYrzQ7Z86b9VhQQzmchh5VmknT4oRSSdn0re5tReCvfcYNXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -2482,7 +2433,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.0-rc.7.tgz",
       "integrity": "sha512-yyn5Yqth6vdScgmcYDF7L3a1jbfcu2y205HyTx9d84H+eU+h9m8k0Mc+1l8VCJbv9GILPCvoijP8wFTPDas7gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -2521,7 +2471,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.0-rc.7.tgz",
       "integrity": "sha512-P/Inw7dQMZCC6I6NC6G0UF9SeOVlpQxOBg2+LoCdvyTt40itDow2wmlThqkQDIt4UMHLT4yRc0Gd6a4gmTNJ2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "zod": "^4.4.3"
@@ -2552,7 +2501,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.0-rc.7.tgz",
       "integrity": "sha512-bhmSfXIaLWLrYwC4ziMZ7GkNy5i9ltGBvlNZ5eB7NZoDAMh0Du7pKkMY+oqm2ajvx5O5qiFkHEhYoypRpEB56g==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -2563,7 +2511,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.0-rc.7.tgz",
       "integrity": "sha512-AC6cyrinc3fQ2/TKmm8V1r/32f3VekR/w6rS1+RWGefRm6PDGnNo4T96/U4EoMyWDq0VBCn1Oye+uqhWPtl/3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "zod": "^4.4.3"
@@ -2600,7 +2547,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.0-rc.7.tgz",
       "integrity": "sha512-VXUxBvmZ9PYinVbYsu7GmT8BZMXCfAbqExNMoR4RoZm+leOLzZOkWOKea9THoJwIik0lUbAO5lzrqaeVKa99Dw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -2627,7 +2573,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.0-rc.7.tgz",
       "integrity": "sha512-AImknM43+7bIR9BzEatmbZMvhjgBgAt7MWqJzmTo1KnBNTY1j7r/RmOiQTBX4R+tpsLXMza5oW7svHSAYw/ypw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -2674,7 +2619,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.0-rc.7.tgz",
       "integrity": "sha512-he43z39/SC8cMzPDsoP7EEXiXKjav3VClj/U943pxycvRL78JGkNEQQjv21n5mnuto0ti/gFBquybSI4sBAFqA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
@@ -2705,7 +2649,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.0-rc.7.tgz",
       "integrity": "sha512-TnOy1SnnSNPVZyw9UFNwQ7eE2lGxQBU6kye7+aAwDbNvSnudCJDEnQJhjTvGewHWA6PYA0O60XERKcCQAnK+dw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -2752,7 +2695,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.0-rc.7.tgz",
       "integrity": "sha512-8gn+sANXhpv+9egbNwq49/uI3XhbmB33obo9yMyzyzruan3zFoxeH4UV54jTC2hjbu8gFNPsyNam9AAtRV8/Cg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -2763,7 +2705,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session/-/dsh-session-0.1.0-rc.7.tgz",
       "integrity": "sha512-02WVTkqIH+TyDL7dhMN3Hm+qcTEdhD0fVDC0aIAyND2fBdXj3CagEXXvpmt3mzwWfKwOTGL1RdxtC6pMA4Bl1A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -2811,7 +2752,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.0-rc.7.tgz",
       "integrity": "sha512-NFH1uIGQDgMFOijgAv8lLWRiY3eHFEZW2alwuHlu4C32P4+jdChh9fjPlzBar3ZZTq0ZW0qWCdbYZS02DNxsvA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -2873,7 +2813,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.0-rc.7.tgz",
       "integrity": "sha512-JKlEpByllYQU9JZLadrS3ClWCVZMcKRB4nc6iCWuNExyRi/Whwa5GicKFs+jXwGKe/rdSbTCom/jYLwkqipjuw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -2934,7 +2873,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.0-rc.7.tgz",
       "integrity": "sha512-ryf7HSYdmLbrTv4HQmeW/h0bHLiCNnSZYiY9RoBrzg2qh89MU8S+Q/a9CLVWA06TRXKt7tNbizF82dCj2/O0bQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -2951,7 +2889,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.0-rc.7.tgz",
       "integrity": "sha512-6f5U7nt5Iqwh5RAFBqV2Ib7LJU2o89Et0r0eV7bskYws+PNM7ZRRW/Nw4a12ZcnuTp1eKPyVE8H6oJua6/7XLA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
@@ -2988,7 +2925,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.0-rc.7.tgz",
       "integrity": "sha512-jhFiZa/C58zchuJkBodnkiPil7AEK8mHfB/hMOAW3N/7tUg5nbMLBERNqHdDMbIrvhTndrF4SN9qy+ltUf0cOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "zod": "^4.4.3"
@@ -3024,7 +2960,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.0-rc.7.tgz",
       "integrity": "sha512-mpQo/1x4jaWNdQAXckOs68U59u+/WHJlb/BX1zAvr02eJPV3Wac2/7NP+/vTw5TElEyzIAU8k0f3PMgvozUk0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -3042,7 +2977,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.0-rc.7.tgz",
       "integrity": "sha512-cS1+StK2xIVykrskw+KrO+hKJxYaVVgY2Jex2we5zASTNLHYCj74WQluPlaFjFgnXoZ1RYz8HNXL5/Ho6h1Ynw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -3073,7 +3007,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.0-rc.7.tgz",
       "integrity": "sha512-in3ifbq80tn5cf1ICBBsRdwKjURB0g0dIRdCVUgl/GDqCdC/S0TjMLXw4nmFdCssYLm7JbG5a59BfJG0KFuz6Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7",
@@ -3087,7 +3020,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.0-rc.7.tgz",
       "integrity": "sha512-joSBNw/d54gq/VjkHLGSJ6y/Qr+594sObF4ApbJi2eEopx41L0Ky7kNW/W7cbrGIIN3KBGRDdiGv1s1paWzsMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -3105,7 +3037,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.0-rc.7.tgz",
       "integrity": "sha512-tDaqB1TOs27fSt6FZdjvPs4THXAFKoKOEgQG+iFUv63O5bm+glyLY3K1LTK8JeofB4lg3+4JIAeWRslnLJH57w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -3178,7 +3109,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.0-rc.7.tgz",
       "integrity": "sha512-EdX5AZElelHlCKlbflZipl4KRDiEHWLN/8smgnkzAhJgpXFq5dyp9jK58dO5v7cuODeq+/SfeDyUE5Mffdhh8Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.7",
@@ -3224,7 +3154,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.0-rc.7.tgz",
       "integrity": "sha512-M+6+SOjWWcfYoGASBMx+b1sHmWPFAHXF57rE/Mew9k5tHC5bEV8+owWwYOWQfv41eO1FfRMibZd0rH6mwPNApg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -3235,7 +3164,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.0-rc.7.tgz",
       "integrity": "sha512-UxXwoCB0q4+/F+zddvi8I4LknTIlGD/1ec57Ym52kWRb7a8qGgrcIYrOC3yPCozn8rkirAuhEAkyAhR6AO5QDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1",
         "zod": "^4.4.3"
@@ -3265,7 +3193,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.0-rc.7.tgz",
       "integrity": "sha512-PEpA9XT6E4hg7N8m7GYQyDLwFUwoqWTz0Cm9SrdAoNcju4byG08qy4+muDZbG0a1tm3PR4rxNB5zKcobDhDocg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "zod": "^4.4.3"
       },
@@ -3336,7 +3263,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.0-rc.7.tgz",
       "integrity": "sha512-YleMt6xtXmW8LkHZ95MLPq1urIt1+sBUK908GCQ2EhV6nyfUwNog4XVDlVbzf3GXzc+3z/xiMW2GvVp3IQ5NIA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
@@ -3368,7 +3294,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.0-rc.7.tgz",
       "integrity": "sha512-xiHD61S2trIZ0CzhSMgXxZJVyJ2c76DkX4eqP3Of4mBEnm6C7g7FChII6uL0z5v1bnOnTmpHzwPX8YCwqb7dbg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -3395,7 +3320,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.0-rc.7.tgz",
       "integrity": "sha512-Rair2ZkzgoIIr+UstYVYeqeUgORNPIW1LNcsXz3Zjglx4FGjsmzs0UALdNYvSBpBvCLNmt4E6+XQIrBbS/s9jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -3411,7 +3335,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.0-rc.7.tgz",
       "integrity": "sha512-B22qppmKWvw5Ez9eMKnppHiaMrikIcHmfmvyd296EspnhTBJAvXDnc9NggT0DUnSvm+2gh5ffohhMJel9A2pSA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
@@ -3458,7 +3381,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.0-rc.7.tgz",
       "integrity": "sha512-Ufl9G7zP7Tky/zkXscavEiolEfAwutfbPeLb5sUU/tPQlDykhh1NwGrarNJ11fdR723zmA/3co4LgxtDtWCOEQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-invariants": "^0.1.0-rc.7"
@@ -3832,7 +3754,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.0-rc.7.tgz",
       "integrity": "sha512-EF9qbGiCK+SdFhckVcS8o4F0Rrib4VEbt5yCe0njj4UrHubjz5Ldmz68TqdrvFqw6mvQ11SUqAm1ookp5hp8gA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -3852,7 +3773,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.0-rc.7.tgz",
       "integrity": "sha512-7Kq3EEv354aNcxbS0NRfxxyJiZhCsvFV/03a3MdkYO/gG2eM9+E4xQum0N2FL5bw7JiGlgw8jdLMkcNGmavEaA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -3898,7 +3818,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.0-rc.7.tgz",
       "integrity": "sha512-7AQNJLNZTw7/5DzjbfBy4dRqr6VSwc74HBOSPpxm0zzzbmXOEqRCRzMps25IByoAeltRz1ZyY4fzN3tcYa+XwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.7",
         "zod": "^4.4.3"
@@ -3932,7 +3851,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.0-rc.7.tgz",
       "integrity": "sha512-dfT6pj84lJdhrtbW2pV6hRftoKDkqx0aJevrhUhOy7Lv3CqTOheuLwwyT69Lww+n/q80Z+yp41qJq9loCkrOaw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
@@ -3945,7 +3863,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-web/-/dsh-web-0.1.0-rc.7.tgz",
       "integrity": "sha512-v3Wx/Kn57RyLDqvEhmz0m0p4YluLGSabmMp7dRVJSemYUzT6ZB0JCtMhWkXh6O3kNHSBGpfxeY9Pk+8k80X11Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"
       },
@@ -4064,7 +3981,6 @@
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.0-rc.7.tgz",
       "integrity": "sha512-PRGT0iF2KcOTxDC1DDIrNOe9bID3zZms902ScrxGAGj8AksRO97kj+3U2MOhRPfHkkNhSQMHCLt42DiclYhWtA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
@@ -4483,6 +4399,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -4504,6 +4421,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -5500,7 +5418,6 @@
       "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
       "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
@@ -5554,7 +5471,6 @@
       "resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7012,7 +6928,6 @@
       "resolved": "https://registry.npmmirror.com/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -7504,7 +7419,6 @@
       "resolved": "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7742,7 +7656,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7989,7 +7904,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -8170,6 +8084,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8190,6 +8105,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -8205,6 +8121,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -8215,6 +8132,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8432,7 +8350,6 @@
       "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9126,7 +9043,6 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.13.2.tgz",
       "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9262,7 +9178,6 @@
       "resolved": "https://registry.npmmirror.com/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -10655,6 +10570,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -11420,6 +11336,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -11437,6 +11354,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -11673,7 +11591,6 @@
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11686,7 +11603,6 @@
       "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11884,6 +11800,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12533,6 +12450,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -13181,7 +13099,6 @@
       "resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## 问题描述

Issue #162 中报告：在 run_code 中调用 tools.pwsh 杀进程（taskkill /F /T）时，pwsh 超时后工具调用不返回，没有 tool/result 事件，整个回合卡死。

## 根本原因

当 pwsh 命令超时后，abort 信号触发 terminate 函数，但 done promise 可能没有正确 resolve，导致 await 永久挂起。

## 修复方案

在 dsh-subprocess-local 的 spawnSubprocess 函数中，当 abort 信号触发时，设置一个定时器，在 spec.graceMs 后强制 resolve done promise（如果尚未 settle）。这确保超时后工具调用能够正常返回。

### 修改文件
- dsh-desktop/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js

### 具体修改
1. 添加 doneResolve 变量存储 resolve 函数
2. 在 done promise 中赋值 doneResolve = resolve
3. 在 onAbort 函数中添加超时强制 resolve 逻辑

## 测试

- 运行现有测试（610 个测试全部通过）
- 该修复确保超时后 done promise 能够 resolve，避免会话卡死

## 注意事项

此修复是在 node_modules 中的临时修改。长期解决方案需要在 @deepseek-ai/dsh-subprocess-local 包的源代码中修复，并发布新版本。

Fixes #162