### PR TITLE
fix: 修复 exe 文件属性 description 乱码问题

### DIFF
--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -2,7 +2,7 @@
   "name": "dsh-desktop",
   "productName": "Deepseek Harness EAC",
   "version": "4.6.0",
-  "description": "DeepSeek Harness (dsh) 寮€绠卞嵆鐢ㄧ殑 Windows 妗岄潰瀹㈡埛绔細鍐呯疆 dsh CLI 涓?Node 杩愯鏃讹紝涓€閿惎鍔?Web UI",
+  "description": "DeepSeek Harness (dsh) 开箱即用的 Windows 桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI",
   "main": "main.js",
   "author": "DSH Desktop",
   "license": "MIT",
@@ -53,3 +53,4 @@
     "electron-builder": "^26.15.3"
   }
 }
+


### PR DESCRIPTION
修复 package.json 中 description 字段编码错误导致 exe 文件属性显示乱码的问题。

将乱码的 description 修复为正确的中文描述：
- 原文：DeepSeek Harness (dsh) 寮€绠卞嵆鐢ㄧ殑 Windows 妗岄潰瀹㈡埛绔︼細鍐呯疆 dsh CLI 涓?Node 杩愯鏃讹紝涓€閿惎鍔?Web UI
- 修复后：DeepSeek Harness (dsh) 开箱即用的 Windows 桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI

已通过本地编译验证和测试。