### PR TITLE
fix: 增加更新停滞超时时间，解决更新卡住问题 (fix #170, #150)

### DIFF
--- a/dsh-desktop/updater.js
+++ b/dsh-desktop/updater.js
@@ -31,8 +31,8 @@ const IS_WIN = process.platform === 'win32';
 // 自动切换。切换与结果都会经 onProgress 上报给更新弹窗提示。
 const NPM_MIRRORS = ['https://registry.npmmirror.com', 'https://registry.npmjs.org'];
 // 单个 npm 命令「无任何输出」的停滞上限：超过即判死并切换镜像源
-//（npm 解析依赖时可能长时间静默，阈值取 150 秒）。
-const NPM_STALL_MS = 150 * 1000;
+//（npm 解析依赖时可能长时间静默，阈值取 300 秒）。
+const NPM_STALL_MS = 300 * 1000;
 
 let activeProc = null;
 


### PR DESCRIPTION
## 问题描述

Issues #170 和 #150 报告更新过程中卡住，特别是卡在「已获取126项」阶段。

## 根本原因

更新停滞超时时间设置过短（150秒），npm 在解析依赖时可能长时间没有输出，导致被误判为停滞并切换镜像源重试。

## 修复方案

将停滞超时时间从 150 秒增加到 300 秒（5分钟），给 npm 更多时间完成依赖解析。

## 修改文件

- dsh-desktop/updater.js - 增加 NPM_STALL_MS 从 150 秒到 300 秒

## 临时解决方案

如果更新仍然失败，用户可以：
1. **手动下载**：从 GitHub Releases 页面手动下载最新版本
2. **使用加速工具**：使用 steam++、Watt Toolkit 等免费加速工具优化 GitHub 访问
3. **更换网络环境**：尝试使用代理或 VPN

## 验证

此修改不影响正常更新流程，只给慢速网络环境更多时间完成依赖解析。

Fixes #170, Fixes #150