### PR TITLE
fix: 修复插件安装到错误profile的问题 (fix #57)

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
@@ -135,7 +135,10 @@ function dshHome() {
 //  一键检测/修复失效的根因 —— 修复点）。
 function desktopProfile() {
   const p = process.env.DSH_DESKTOP_PROFILE || process.env.DSH_PROFILE
-  return p && /^[A-Za-z0-9_-]+$/.test(p) ? p : 'web'
+  if (p && /^[A-Za-z0-9_-]+$/.test(p)) return p
+  // 桌面环境下默认使用 web-desktop，避免插件安装到 web profile 而加载时使用 web-desktop profile
+  if (process.env.DSH_DESKTOP === '1') return 'web-desktop'
+  return 'web'
 }
 
 /**


### PR DESCRIPTION
## 问题描述

Issue #57 报告插件下载成功后不显示在插件列表里，插件列表里也开不了插件。

用户自查发现：插件全在 web profile 里，但加载的是 web-desktop profile。

## 根本原因

桌面客户端（EAC）使用 web-desktop 作为专属 profile（通过 DSH_DESKTOP_PROFILE 环境变量设置），但插件安装时可能被安装到了 web profile 目录。

desktopProfile() 函数在 DSH_DESKTOP_PROFILE 环境变量未设置时返回 'web'，导致插件安装到了错误的 profile。

## 修复方案

修改 desktopProfile() 函数，在桌面环境下（检测 DSH_DESKTOP 环境变量）默认返回 'web-desktop'，避免插件安装到错误的 profile。

## 修改文件

- dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js - 修改 desktopProfile() 函数

## 修复效果

- 桌面环境下，插件将正确安装到 web-desktop profile
- 插件列表将正确显示已安装的插件
- 插件将正常生效

## 验证

1. 在桌面客户端安装插件
2. 检查插件是否显示在插件列表
3. 检查插件是否正常工作

Fixes #57