### PR TITLE
fix: 禁用深海女仆工坊皮肤(maid-atelier)以防止客户端崩溃

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -4255,8 +4255,16 @@ function syncCompanionPlugins() {
       }
     }
     // 内置皮肤：行 id 取皮肤包 skin.json 的 wiring.id（ui-skin-*）。
+    // 禁用的皮肤黑名单（因兼容性问题或崩溃而禁用）
+    const DISABLED_SKINS = ['maid-atelier'];
+    
     for (const entry of fs.readdirSync(SKINS_DIR, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
+      // 跳过禁用的皮肤
+      if (DISABLED_SKINS.includes(entry.name)) {
+        log('boot', `跳过禁用的皮肤: ${entry.name}`);
+        continue;
+      }
       const src = path.join(SKINS_DIR, entry.name);
       const pkg = readJsonFile(path.join(src, 'package.json'));
       if (!pkg || typeof pkg.name !== 'string' || !pkg.name.includes('/')) continue;


### PR DESCRIPTION
## 问题描述

深海女仆工坊皮肤（maid-atelier）在新版本中会导致客户端崩溃。

## 修复方案

在皮肤同步逻辑中添加黑名单机制，跳过有问题的皮肤，使其不在皮肤列表中显示。

## 修改文件

- dsh-desktop/main.js - 在皮肤同步循环中添加黑名单检查

## 技术实现

1. **黑名单定义**：在皮肤同步循环前定义禁用皮肤列表
   `javascript
   const DISABLED_SKINS = ['maid-atelier'];
   `

2. **跳过逻辑**：在遍历皮肤目录时检查是否在黑名单中
   `javascript
   if (DISABLED_SKINS.includes(entry.name)) {
     log('boot', 跳过禁用的皮肤: );
     continue;
   }
   `

3. **日志记录**：记录跳过的皮肤，便于调试

## 修复效果

- 深海女仆工坊皮肤将不会被同步到用户配置
- 皮肤列表中不会显示该皮肤
- 避免因该皮肤导致的客户端崩溃
- 保留皮肤文件，便于后续修复后重新启用

## 验证

1. 启动客户端，检查皮肤列表
2. 确认深海女仆工坊皮肤不在列表中
3. 确认其他皮肤正常显示和切换
4. 检查启动日志，确认皮肤被跳过

## 后续步骤

如果皮肤问题修复，可以从黑名单中移除，重新启用该皮肤。