### PR TITLE
feat: 在托盘右键菜单中添加完全重启选项

### DIFF
--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -3132,6 +3132,7 @@ function createTray() {
       { type: 'separator' },
       // V4（用户建议④）：不关闭应用重启 dsh web 服务（皮肤/插件生效路径）。
       { label: '重启 Web 服务', click: () => { showMainWindow(); restartWebServiceCore(); } },
+      { label: '完全重启', click: () => { forceQuit = true; app.relaunch(); app.quit(); } },
       { type: 'separator' },
       { label: '反馈建议…', click: () => { showMainWindow(); shell.openExternal('https://github.com/zouyuxuan122/Deepseek-Harness-EAC/issues'); } },
       { type: 'separator' },


### PR DESCRIPTION
## 功能描述

在系统托盘右键菜单中，在「重启 Web 服务」选项下方添加「完全重启」选项，用于完全重启整个应用程序。

## 修改文件

- dsh-desktop/main.js - 在托盘菜单模板中添加「完全重启」菜单项

## 技术实现

在托盘菜单的「重启 Web 服务」选项后添加新的菜单项：

`javascript
{ label: '完全重启', click: () => { forceQuit = true; app.relaunch(); app.quit(); } },
`

## 功能说明

- **完全重启**：退出当前应用程序实例并重新启动
- **与重启 Web 服务的区别**：
  - 重启 Web 服务：只重启 dsh web 服务器，应用程序本身不退出
  - 完全重启：退出整个 Electron 应用程序并重新启动
- **适用场景**：
  - 应用程序出现异常需要完全重置
  - 更新了需要重启才能生效的配置
  - 应用程序卡死或无响应

## 验证方法

1. 右键点击系统托盘图标
2. 检查菜单中是否显示「完全重启」选项
3. 点击「完全重启」，确认应用程序退出并重新启动
4. 确认应用程序重启后正常工作

## 注意事项

- 完全重启会退出当前应用程序实例，未保存的数据可能会丢失
- 重启过程中会有短暂的黑屏，属于正常现象
- 如果应用程序卡死，可以使用此功能强制重启