### PR TITLE
fix(updater): wait for update helper readiness

### DIFF
--- a/dsh-desktop/client-updater.js
+++ b/dsh-desktop/client-updater.js
@@ -1087,12 +1087,10 @@ function waitForInstalledHelperReady(child, readyPath, readyToken, timeoutMs = 5
     const poll = setInterval(() => {
       if (isReady()) finish();
     }, 25);
-    if (typeof poll.unref === 'function') poll.unref();
     const timer = setTimeout(() => {
       try { child.kill(); } catch {}
       finish(new Error('更新助手启动超时，未写入就绪标记'));
     }, timeoutMs);
-    if (typeof timer.unref === 'function') timer.unref();
     child.once('error', (err) => finish(new Error('更新助手启动失败: ' + err.message)));
     child.once('exit', (code, signal) => {
       if (!isReady()) finish(new Error(`更新助手在就绪前退出（code=${code}, signal=${signal || 'none'}）`));

--- a/dsh-desktop/client-updater.js
+++ b/dsh-desktop/client-updater.js
@@ -724,6 +724,8 @@ function buildInstalledApplyScript() {
     '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$CurrentVersion,',
     '  [Parameter(Mandatory = $true)][AllowEmptyString()][string]$NewVersion,',
     '  [Parameter(Mandatory = $true)][int]$AppPid,',
+    '  [Parameter(Mandatory = $true)][string]$ReadyPath,',
+    '  [Parameter(Mandatory = $true)][string]$ReadyToken,',
     '  [Parameter(Mandatory = $true)][string]$LogPath,',
     '  [int]$WaitTimeoutSeconds = 20',
     ')',
@@ -741,10 +743,13 @@ function buildInstalledApplyScript() {
     '  if ($WaitTimeoutSeconds -lt 1 -or $WaitTimeoutSeconds -gt 120) { throw "Invalid wait timeout" }',
     '  $LogDir = Split-Path -Parent $LogPath',
     '  if ($LogDir) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }',
-    '  Set-Content -LiteralPath $LogPath -Value "" -Encoding UTF8',
-    '  Write-ApplyLog ("installed apply-update start; appPid=" + $AppPid)',
+    '  if (-not $ReadyPath) { throw "Ready path missing" }',
+    '  if (-not $ReadyToken) { throw "Ready token missing" }',
     '  if (-not (Test-Path -LiteralPath $SetupPath -PathType Leaf)) { throw "Setup not found" }',
     '  if (-not (Test-Path -LiteralPath $ActionScriptPath -PathType Leaf)) { throw "Action script not found" }',
+    "  Set-Content -LiteralPath $ReadyPath -Value $ReadyToken -Encoding ascii",
+    '  Set-Content -LiteralPath $LogPath -Value "" -Encoding UTF8',
+    '  Write-ApplyLog ("installed apply-update start; appPid=" + $AppPid)',
     '  Write-ApplyLog "waiting for app exit"',
     '  $Deadline = [DateTime]::UtcNow.AddSeconds($WaitTimeoutSeconds)',
     '  while ((Get-AppProcess) -and [DateTime]::UtcNow -lt $Deadline) {',
@@ -1035,6 +1040,8 @@ function buildInstalledPowerShellArgs(script, {
   currentVersion,
   newVersion,
   appPid,
+  readyPath,
+  readyToken,
   logPath,
   waitTimeoutSeconds = 20,
 }) {
@@ -1056,9 +1063,42 @@ function buildInstalledPowerShellArgs(script, {
     '-CurrentVersion', currentVersion || '',
     '-NewVersion', newVersion || '',
     '-AppPid', String(appPid),
+    '-ReadyPath', readyPath,
+    '-ReadyToken', readyToken,
     '-LogPath', logPath,
     '-WaitTimeoutSeconds', String(waitTimeoutSeconds),
   ];
+}
+
+function waitForInstalledHelperReady(child, readyPath, readyToken, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const isReady = () => {
+      try { return fs.readFileSync(readyPath, 'ascii').trim() === readyToken; } catch { return false; }
+    };
+    let done = false;
+    const finish = (err) => {
+      if (done) return;
+      done = true;
+      clearInterval(poll);
+      clearTimeout(timer);
+      if (err) reject(err);
+      else resolve();
+    };
+    const poll = setInterval(() => {
+      if (isReady()) finish();
+    }, 25);
+    if (typeof poll.unref === 'function') poll.unref();
+    const timer = setTimeout(() => {
+      try { child.kill(); } catch {}
+      finish(new Error('更新助手启动超时，未写入就绪标记'));
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+    child.once('error', (err) => finish(new Error('更新助手启动失败: ' + err.message)));
+    child.once('exit', (code, signal) => {
+      if (!isReady()) finish(new Error(`更新助手在就绪前退出（code=${code}, signal=${signal || 'none'}）`));
+    });
+    if (isReady()) finish();
+  });
 }
 
 function applyUpdate(ctx, pending, opts) {
@@ -1066,6 +1106,8 @@ function applyUpdate(ctx, pending, opts) {
   const portable = isPortable();
   const oldExe = process.env.PORTABLE_EXECUTABLE_FILE || process.execPath;
   const updateDir = path.join(ctx.userDataDir, 'updates');
+  const readyPath = path.join(updateDir, 'apply-update.ready');
+  const readyToken = crypto.randomBytes(16).toString('hex');
   const logPath = path.join(updateDir, 'apply-update.log');
   const userDataDir = (opts && opts.userDataDir) || ctx.userDataDir || '';
   const dshHome = (opts && opts.dshHome) || process.env.DSH_HOME || '';
@@ -1076,6 +1118,7 @@ function applyUpdate(ctx, pending, opts) {
   const nodeExe = (opts && opts.nodeExe) || '';
   let script;
   let child;
+  let ready = Promise.resolve();
   if (isTauriPortable()) {
     // Tauri 便携：exe + sidecar + dsh-desktop 目录树整体交换（P4/R6）。
     // 等待对象是壳进程 PID（Rust spawn sidecar 时经 DSH_SHELL_PID 注入）。
@@ -1115,6 +1158,7 @@ function applyUpdate(ctx, pending, opts) {
     });
     fs.writeFileSync(actionScript, actionLines.join('\r\n') + '\r\n');
     fs.writeFileSync(script, buildInstalledApplyScript().join('\r\n') + '\r\n', 'ascii');
+    try { fs.rmSync(readyPath, { force: true }); } catch {}
     const powershell = path.join(
       process.env.SystemRoot || 'C:\\Windows',
       'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'
@@ -1131,6 +1175,8 @@ function applyUpdate(ctx, pending, opts) {
       currentVersion,
       newVersion,
       appPid: process.pid,
+      readyPath,
+      readyToken,
       logPath,
     });
     child = spawn(powershell, args, {
@@ -1138,11 +1184,15 @@ function applyUpdate(ctx, pending, opts) {
       stdio: 'ignore',
       windowsHide: true,
     });
+    ready = waitForInstalledHelperReady(child, readyPath, readyToken);
   }
   ctx.log('client-update', `启动更新助手: ${script}（新: ${newExe}，旧: ${oldExe}，备份根: ${userDataDir}\\backups\\<ts>，node: ${nodeExe || '(无，跳过备份)'}）`);
-  child.once('error', (err) => ctx.log('client-update', '更新助手启动失败: ' + err.message));
+  if (portable || isTauriPortable()) {
+    child.once('error', (err) => ctx.log('client-update', '更新助手启动失败: ' + err.message));
+  }
+  ready.catch((err) => ctx.log('client-update', err.message));
   child.unref();
-  return script;
+  return { script, ready };
 }
 
-module.exports = { checkLatest, selectAsset, downloadFile, downloadWithSourceSwitch, downloadRelease, releaseFallbacks, applyUpdate, buildApplyScript, buildInstalledApplyScript, buildInstalledPowerShellArgs, buildSpawnCommandLine, buildTauriPortableApplyScript, isPortable, isTauriPortable, resolveRepos, normalizeRelease, computeSha256, fetchSumsMap, expectedSha256, isNoSpaceError, githubProxyUrl, downloadUrls, DEFAULT_REPOS };
+module.exports = { checkLatest, selectAsset, downloadFile, downloadWithSourceSwitch, downloadRelease, releaseFallbacks, applyUpdate, buildApplyScript, buildInstalledApplyScript, buildInstalledPowerShellArgs, buildSpawnCommandLine, buildTauriPortableApplyScript, isPortable, isTauriPortable, resolveRepos, normalizeRelease, computeSha256, fetchSumsMap, expectedSha256, isNoSpaceError, githubProxyUrl, downloadUrls, DEFAULT_REPOS, waitForInstalledHelperReady };

--- a/dsh-desktop/lib/desktop/client-update.ts
+++ b/dsh-desktop/lib/desktop/client-update.ts
@@ -19,7 +19,7 @@ const clientUpdater = require('../../client-updater') as {
   checkLatest(c: ReturnType<typeof updCtx>, currentVersion: string): Promise<{ isNewer: boolean; version: string; source: string; body?: string }>;
   releaseFallbacks(c: ReturnType<typeof updCtx>, release: unknown): Promise<unknown[]>;
   downloadRelease(c: ReturnType<typeof updCtx>, release: unknown, opts: Record<string, unknown>): Promise<{ filePath: string; size: number }>;
-  applyUpdate(c: ReturnType<typeof updCtx>, pending: unknown, opts: Record<string, unknown>): void;
+  applyUpdate(c: ReturnType<typeof updCtx>, pending: unknown, opts: Record<string, unknown>): { script: string; ready: Promise<void> };
 };
 
 /** 注入接口：由宿主（Electron main / Tauri sidecar）在启动时提供。 */
@@ -165,7 +165,6 @@ export async function runClientUpdateFlow(manual: boolean): Promise<void> {
       cancelId: 1,
     });
     if (r2 === 0) {
-      await mod.prepareQuitForClientUpdate();
       const clientUpdateOpts = {
         userDataDir: mod.getUserDataDir(),
         dshHome: mod.getDshHome(),
@@ -175,7 +174,9 @@ export async function runClientUpdateFlow(manual: boolean): Promise<void> {
         newVersion: release.version,
         nodeExe: nodeExe(),
       };
-      clientUpdater.applyUpdate(ctx, settings.pendingClientUpdate, clientUpdateOpts);
+      const updateAssistant = clientUpdater.applyUpdate(ctx, settings.pendingClientUpdate, clientUpdateOpts);
+      await updateAssistant.ready;
+      await mod.prepareQuitForClientUpdate();
       setTimeout(() => mod.exitProcess(), 400);
     }
   } catch (err) {
@@ -218,17 +219,29 @@ export function offerPendingClientUpdate(): void {
     cancelId: 1,
   }).then(async ({ response }) => {
     if (response !== 0) return;
-    await mod.prepareQuitForClientUpdate();
-    const clientUpdateOpts2 = {
-      userDataDir: mod.getUserDataDir(),
-      dshHome: mod.getDshHome(),
-      installDir: mod.getExecDir(),
-      profileDir: path.join(mod.getDshHome() || '', 'profiles', desktopProfile()),
-      currentVersion: mod.getAppVersion(),
-      newVersion: pending.version,
-      nodeExe: nodeExe(),
-    };
-    clientUpdater.applyUpdate(ctx, pending, clientUpdateOpts2);
-    setTimeout(() => mod.exitProcess(), 400);
+    try {
+      const clientUpdateOpts2 = {
+        userDataDir: mod.getUserDataDir(),
+        dshHome: mod.getDshHome(),
+        installDir: mod.getExecDir(),
+        profileDir: path.join(mod.getDshHome() || '', 'profiles', desktopProfile()),
+        currentVersion: mod.getAppVersion(),
+        newVersion: pending.version,
+        nodeExe: nodeExe(),
+      };
+      const updateAssistant = clientUpdater.applyUpdate(ctx, pending, clientUpdateOpts2);
+      await updateAssistant.ready;
+      await mod.prepareQuitForClientUpdate();
+      setTimeout(() => mod.exitProcess(), 400);
+    } catch (err) {
+      mod.log('client-update', '安装待处理更新失败: ' + (err as Error).message);
+      await mod.showBox({
+        type: 'error',
+        title: '更新失败',
+        message: '未能启动客户端更新助手，仍使用当前版本。',
+        detail: (err as Error).message,
+        buttons: ['确定'],
+      });
+    }
   });
 }

--- a/dsh-desktop/test/client-updater-apply.test.mjs
+++ b/dsh-desktop/test/client-updater-apply.test.mjs
@@ -8,6 +8,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,6 +17,7 @@ import {
   buildInstalledApplyScript,
   buildInstalledPowerShellArgs,
   buildSpawnCommandLine,
+  waitForInstalledHelperReady,
 } from '../client-updater.js';
 
 const SYSTEM_ROOT = process.env.SystemRoot || 'C:\\Windows';
@@ -84,6 +86,8 @@ function runInstalledHelper({
   currentVersion = '4.4.0',
   newVersion = '4.4.1',
   waitTimeoutSeconds = 20,
+  readyPath,
+  readyToken = 'test-ready-token',
   env = process.env,
 }) {
   return spawn(POWERSHELL, buildInstalledPowerShellArgs(script, {
@@ -97,6 +101,8 @@ function runInstalledHelper({
     currentVersion,
     newVersion,
     appPid,
+    readyPath: readyPath || log + '.ready',
+    readyToken,
     logPath: log,
     waitTimeoutSeconds,
   }), {
@@ -168,9 +174,41 @@ test('installed helper has bounded waits and synchronously invokes the hidden ac
   assert.match(helper, /\$LASTEXITCODE/);
   assert.match(helper, /waiting for app exit/);
   assert.match(helper, /update action exit code/);
+  assert.ok(helper.indexOf('Setup not found') < helper.indexOf('Set-Content -LiteralPath $ReadyPath'),
+    'readiness must be written only after Setup is preflighted');
   assert.match(action, /call "%SETUP%" \/S/);
   assert.match(action, /setup exit code %errorlevel%/);
   assert.match(action, /update applied/);
+});
+
+test('installed helper readiness requires the current token, not a stale marker', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-ready-token-'));
+  const readyPath = path.join(dir, 'apply-update.ready');
+  const child = new EventEmitter();
+  child.kill = () => {};
+  try {
+    fs.writeFileSync(readyPath, 'stale-token');
+    const ready = waitForInstalledHelperReady(child, readyPath, 'fresh-token', 1000);
+    setTimeout(() => fs.writeFileSync(readyPath, 'fresh-token'), 30);
+    await ready;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('installed helper readiness rejects when it exits before writing the current token', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-ready-exit-'));
+  const readyPath = path.join(dir, 'apply-update.ready');
+  const child = new EventEmitter();
+  child.kill = () => {};
+  try {
+    fs.writeFileSync(readyPath, 'stale-token');
+    const ready = waitForInstalledHelperReady(child, readyPath, 'fresh-token', 1000);
+    child.emit('exit', 1, null);
+    await assert.rejects(ready, /就绪前退出/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('installed failure paths keep artifacts and relaunch the old executable', () => {
@@ -228,6 +266,8 @@ test('installed PowerShell arguments preserve paths and request a hidden non-int
     currentVersion: '4.4.0',
     newVersion: '4.4.1',
     appPid: 4321,
+    readyPath: 'C:\\用户 A\\Deepseek Harness EAC\\updates\\apply-update.ready',
+    readyToken: 'test-ready-token',
     logPath: log,
   });
 
@@ -247,6 +287,8 @@ test('installed PowerShell arguments preserve paths and request a hidden non-int
   assert.equal(args[args.indexOf('-CurrentVersion') + 1], '4.4.0');
   assert.equal(args[args.indexOf('-NewVersion') + 1], '4.4.1');
   assert.equal(args[args.indexOf('-AppPid') + 1], '4321');
+  assert.equal(args[args.indexOf('-ReadyPath') + 1], 'C:\\用户 A\\Deepseek Harness EAC\\updates\\apply-update.ready');
+  assert.equal(args[args.indexOf('-ReadyToken') + 1], 'test-ready-token');
   assert.equal(args[args.indexOf('-LogPath') + 1], log);
   assert.equal(args[args.indexOf('-WaitTimeoutSeconds') + 1], '20');
 });

--- a/dsh-desktop/test/recovery-integration.test.mjs
+++ b/dsh-desktop/test/recovery-integration.test.mjs
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
 const mainSrc = readFileSync(join(ROOT, 'main.js'), 'utf8');
 const preloadSrc = readFileSync(join(ROOT, 'preload.js'), 'utf8');
+const clientUpdateSrc = readFileSync(join(ROOT, 'lib', 'desktop', 'client-update.ts'), 'utf8');
 
 test('main.js requires the renderer-recovery module', () => {
   assert.ok(/require\('\.\/renderer-recovery'\)/.test(mainSrc), "main.js must require('./renderer-recovery')");
@@ -65,6 +66,19 @@ test('main.js serves the local recovery page IPC endpoints', () => {
 test('every quit path marks a clean exit for the watchdog', () => {
   const marks = mainSrc.match(/markCleanExit\(\)/g) || [];
   assert.ok(marks.length >= 3, `expected markCleanExit() on before-quit + restart + app.exit paths, found ${marks.length}`);
+});
+
+test('client update waits for its detached helper to become ready before exiting', () => {
+  const starts = [...clientUpdateSrc.matchAll(/const updateAssistant = clientUpdater\.applyUpdate\(/g)].map((m) => m.index);
+  assert.equal(starts.length, 2, 'both immediate and pending client-update paths must start a helper');
+  for (const start of starts) {
+    const ready = clientUpdateSrc.indexOf('await updateAssistant.ready;', start);
+    const prepare = clientUpdateSrc.indexOf('await mod.prepareQuitForClientUpdate();', start);
+    const exit = clientUpdateSrc.indexOf('setTimeout(() => mod.exitProcess(), 400);', start);
+    assert.ok(ready > start, 'must wait for the helper readiness marker');
+    assert.ok(prepare > ready, 'quit preparation and clean-exit marking must wait until the helper is ready');
+    assert.ok(exit > ready, 'app must not exit before the helper is ready');
+  }
 });
 
 test('preload sends renderer heartbeats and exposes the recovery bridge', () => {


### PR DESCRIPTION
## 问题

安装版客户端更新在启动 PowerShell 更新助手后约 400ms 即退出，但没有确认助手已开始执行。

当助手启动失败或在脚本入口前退出时，旧版客户端会直接关闭；用户手动重新打开后仍是旧版本，并反复收到更新提示。由于标准输出被忽略，原流程也缺少可观测的失败反馈。

Fixes #167

## 变更

- 为每次安装版更新生成随机就绪令牌。
- PowerShell 助手在验证 Setup 与动作脚本存在后，写入带令牌的就绪文件。
- 客户端仅在读取到本次令牌后，才写入正常退出标记并退出。
- 助手启动报错、就绪前退出或 5 秒超时时，终止助手并保留客户端，显示明确错误。
- 陈旧的就绪文件不会被误判为本次更新助手已启动。
- 两个客户端更新入口均接入等待逻辑。

## 验证

- `node --test test/client-updater-apply.test.mjs test/client-updater-node-arg.test.mjs test/recovery-integration.test.mjs test/watchdog-behavior.test.mjs`
  - 31/31 通过
- `node scripts/check-syntax.js`
  - 通过
- `git diff --check`
  - 通过

## 兼容性

`applyUpdate()` 现在返回 `{ script, ready }`，仓库内现有调用已全部适配；该调整用于让调用方在退出前等待更新助手完成启动握手。