### PR TITLE
模式选择布局优化：第三方模式收进二级菜单；修了一些bug

### DIFF
--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -53,6 +53,7 @@ files:
   # 运行时脚本：koffi 预检探针（scripts/koffi-preflight.cjs）、会话删除补丁与
   # 插件启停手术脚本（main.js 启动时 require）等必须在成品里存在。
   - scripts/koffi-preflight.cjs
+  - scripts/patch-deps.js
   - scripts/patch-session-manage.js
   - scripts/plugin-manager-patch.js
   - scripts/onboarding.js

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -56,6 +56,7 @@ const { buildErrorDetail } = require('./error-detail');
 const { SessionWatcher, scanZstdFrames } = require('./session-watcher');
 const { isEncodingMismatch, healSessionEncodingConflicts } = require('./session-encoding-heal');
 const { patchSessionManage } = require('./scripts/patch-session-manage');
+const { patchAgentPresetMenu, patchMenuSubmenuScroll } = require('./scripts/patch-deps.js');
 const { togglePluginInPatch, removePluginFromPatch, hasEntryId } = require('./scripts/plugin-manager-patch');
 const { collectPluginRows } = require('./plugin-manager-state');
 const onboardingLogic = require('./scripts/onboarding');
@@ -3924,6 +3925,23 @@ function applySessionManageFix() {
   }
 }
 
+// 模式选择二级菜单 + Menu 二级菜单滚动（dsh-client-ui-agent-preset /
+// dsh-client-ui-primitives）：agent 更新会换掉 overlay 整树，与对话删除补丁
+// 同样随每次启动重放（幂等）。锚点不匹配时静默跳过，绝不损坏文件。
+function applyAgentPresetFix() {
+  for (const root of runtimePatchRoots()) {
+    if (!root || !fs.existsSync(root)) continue;
+    try {
+      const presetFile = path.join(root, '@deepseek-ai', 'dsh-client-ui-agent-preset', 'lib', 'client.js');
+      if (patchAgentPresetMenu(presetFile)) log('boot', '模式菜单补丁: 已应用到 ' + root);
+      const primitivesFile = path.join(root, '@deepseek-ai', 'dsh-client-ui-primitives', 'lib', 'index.js');
+      if (patchMenuSubmenuScroll(primitivesFile)) log('boot', '二级菜单滚动补丁: 已应用到 ' + root);
+    } catch (err) {
+      log('boot', '模式菜单补丁失败(' + root + '): ' + err.message);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // 插件启停管理（V4，移植自上游）：设置页「插件 → 管理」标签的数据与写盘。
 // dsh:plugin-list / dsh:plugin-set-enabled 两个 IPC 驱动；写盘用纯文本手术
@@ -4227,6 +4245,8 @@ function syncCompanionPlugins() {
     // V4 运行时补丁（幂等，随启动 / 服务重启 / agent 更新后重放）：
     //  · 对话删除/归档 —— dsh-session-manager 插件的全链路前置依赖；
     applySessionManageFix();
+    //  · 模式选择二级菜单 / Menu 二级菜单滚动 —— agent-preset 补丁同链路；
+    applyAgentPresetFix();
     const profileDirP = desktopProfileDir();
     // 内置社区 agent preset（anchored-standard：首请求锚定 Minimal 工具对，
     // 首次工具调用/回复后开放完整 Standard 目录）：安装到用户 preset 根。

--- a/dsh-desktop/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
+++ b/dsh-desktop/node_modules/@deepseek-ai/dsh-subprocess-local/lib/index.js
@@ -569,7 +569,6 @@ function spawnSubprocess(spec, internals = {}) {
 	let treeExitObserved = false;
 	let treeExitObservation;
 	let settled = false;
-	let doneResolve;
 	const pid = child.pid ?? -1;
 	/** Whether the detached tree's root (or POSIX group) is still alive. */
 	const treeAlive = () => {
@@ -625,13 +624,24 @@ function spawnSubprocess(spec, internals = {}) {
 	const terminateForHostExit = () => {
 		kill("SIGKILL");
 	};
+	let pipeDrainTimer;
+	let resolveDone;
+	const settle = (exitCode, signal) => {
+		if (settled) return;
+		settled = true;
+		if (stdoutCollector !== void 0) child.stdout?.destroy();
+		if (stderrCollector !== void 0) child.stderr?.destroy();
+		stdoutCollector?.seal();
+		stderrCollector?.seal();
+		cleanup();
+		resolveDone({ exitCode, signal });
+	};
 	const onAbort = () => {
 		terminate();
-		// 如果进程在 graceMs 后仍未退出，强制 resolve done promise
+		// 如果进程树在 graceMs 后仍未退出，强制 settle done promise（防调用挂死）。
+		// 必须走 settle()：直接 resolve 会跳过 collector seal / stdio destroy / cleanup。
 		setTimeout(() => {
-			if (!settled && doneResolve) {
-				doneResolve({ exitCode: null, signal: null });
-			}
+			if (!settled) settle(null, null);
 		}, spec.graceMs);
 	};
 	spec.signal?.addEventListener("abort", onAbort, { once: true });
@@ -640,22 +650,7 @@ function spawnSubprocess(spec, internals = {}) {
 		child.stdin.end(stdinMode.data);
 	}
 	const done = new Promise((resolve, reject) => {
-		doneResolve = resolve;
-		let pipeDrainTimer;
-		const settle = (exitCode, signal) => {
-			if (settled) return;
-			settled = true;
-			doneResolve = null;
-			if (stdoutCollector !== void 0) child.stdout?.destroy();
-			if (stderrCollector !== void 0) child.stderr?.destroy();
-			stdoutCollector?.seal();
-			stderrCollector?.seal();
-			cleanup();
-			resolve({
-				exitCode,
-				signal
-			});
-		};
+		resolveDone = resolve;
 		child.on("error", (error) => {
 			settled = true;
 			cleanup();
@@ -667,11 +662,11 @@ function spawnSubprocess(spec, internals = {}) {
 			}, spec.graceMs);
 		});
 		child.on("close", settle);
-		function cleanup() {
-			if (pipeDrainTimer !== void 0) clearTimeout(pipeDrainTimer);
-			spec.signal?.removeEventListener("abort", onAbort);
-		}
 	});
+	function cleanup() {
+		if (pipeDrainTimer !== void 0) clearTimeout(pipeDrainTimer);
+		spec.signal?.removeEventListener("abort", onAbort);
+	}
 	const waitForExit = async (signal) => {
 		const observed = observeTreeExit();
 		if (treeExitObserved) return true;

--- a/dsh-desktop/node_modules/@deepseek-ai/dsh-tool-bash/lib/index.js
+++ b/dsh-desktop/node_modules/@deepseek-ai/dsh-tool-bash/lib/index.js
@@ -162,11 +162,9 @@ function presentBashResult(args, result) {
 		}]
 	};
 	const { body, ...exit } = parseExitStatus(raw);
-	// 如果输出过长，使用可折叠的 details 标签
-	const output = body.length > 1000 ? `<details><summary>Bash Output (${body.length} characters) - Click to expand</summary>\n\n${body}\n\n</details>` : body;
 	return {
 		card: "terminal",
-		output: output,
+		output: body,
 		...exit
 	};
 }

--- a/dsh-desktop/scripts/patch-deps.js
+++ b/dsh-desktop/scripts/patch-deps.js
@@ -75,9 +75,135 @@ function patchSettingsNavScroll() {
   console.log('[patch-deps] 已补丁 settings-general：设置弹窗左栏可滚动，底部条目不再被裁掉');
 }
 
+// 模式选择菜单二级化补丁：agent preset 选择器把 user trust（自定义 / EAC 内置）
+// 的 preset 收进「第三方模式」二级菜单（Menu 原生 submenu），官方内置（system
+// trust）保留主列表。幂等 marker: dsh-desktop:third-party（preset id 规则不允许
+// 冒号，不会与真实 preset id 冲突）。目标代码是编译产物，锚点失配告警跳过。
+const AGENT_PRESET_MARKER = 'dsh-desktop:third-party';
+const AGENT_PRESET_FILE = path.join(root, 'node_modules', '@deepseek-ai', 'dsh-client-ui-agent-preset', 'lib', 'client.js');
+const AGENT_PRESET_SEAT_START = 'items: state.options.map((option) => {';
+const AGENT_PRESET_SEAT_TAIL = '}),\n\t\t\t\tselectedId: state.current,';
+const AGENT_PRESET_ROW_START = 'items: options.map((option) => {';
+const AGENT_PRESET_ROW_TAIL = '}),\n\t\t\t\tselectedId,';
+const AGENT_PRESET_ZH_ANCHOR = 'presetCordisName: "创造模式",';
+const AGENT_PRESET_EN_ANCHOR = 'presetCordisName: "Creator mode",';
+
+function patchAgentPresetMenu(file) {
+  const target = file || AGENT_PRESET_FILE;
+  if (!fs.existsSync(target)) {
+    console.log('[patch-deps] dsh-client-ui-agent-preset 不存在，跳过');
+    return false;
+  }
+  let src = fs.readFileSync(target, 'utf8');
+  if (src.includes(AGENT_PRESET_MARKER)) {
+    console.log('[patch-deps] agent-preset 模式菜单补丁已应用，跳过');
+    return true;
+  }
+  const seatStart = src.indexOf(AGENT_PRESET_SEAT_START);
+  const seatTail = seatStart >= 0 ? src.indexOf(AGENT_PRESET_SEAT_TAIL, seatStart) : -1;
+  const rowStart = src.indexOf(AGENT_PRESET_ROW_START);
+  const rowTail = rowStart >= 0 ? src.indexOf(AGENT_PRESET_ROW_TAIL, rowStart) : -1;
+  if (seatStart < 0 || seatTail < 0 || rowStart < 0 || rowTail < 0 || !src.includes(AGENT_PRESET_ZH_ANCHOR) || !src.includes(AGENT_PRESET_EN_ANCHOR)) {
+    console.log('[patch-deps] agent-preset 未匹配到目标代码（版本可能已更新），跳过');
+    return false;
+  }
+  const seatBody = src.slice(seatStart + AGENT_PRESET_SEAT_START.length, seatTail);
+  const rowBody = src.slice(rowStart + AGENT_PRESET_ROW_START.length, rowTail);
+  // composer 座位：官方保留主列表，第三方收进「第三方模式」submenu（label 复用原两行渲染体）
+  const seatNew =
+    'items: [...state.options.filter((option) => option.trust !== "user").map((option) => {' + seatBody +
+    '\n\t\t\t\t}), ...(function () {\n' +
+    '\t\t\t\t\tconst user = state.options.filter((option) => option.trust === "user");\n' +
+    '\t\t\t\t\tif (user.length === 0) return [];\n' +
+    '\t\t\t\t\treturn [{\n' +
+    '\t\t\t\t\t\tid: "' + AGENT_PRESET_MARKER + '",\n' +
+    '\t\t\t\t\t\tlabel: (0, react_jsx_runtime.jsxs)("span", {\n' +
+    '\t\t\t\t\t\t\tclassName: AgentPresetSeat_module_css_default.item,\n' +
+    '\t\t\t\t\t\t\tchildren: [(0, react_jsx_runtime.jsx)("span", {\n' +
+    '\t\t\t\t\t\t\t\tclassName: AgentPresetSeat_module_css_default.itemName,\n' +
+    '\t\t\t\t\t\t\t\tchildren: t("menu.thirdPartyMode")\n' +
+    '\t\t\t\t\t\t\t}), (0, react_jsx_runtime.jsx)("span", {\n' +
+    '\t\t\t\t\t\t\t\tclassName: AgentPresetSeat_module_css_default.itemDesc,\n' +
+    '\t\t\t\t\t\t\t\tchildren: t("menu.thirdPartyModeHint")\n' +
+    '\t\t\t\t\t\t\t})]\n' +
+    '\t\t\t\t\t\t}),\n' +
+    '\t\t\t\t\t\tsubmenu: user.map((option) => {' + seatBody +
+    '\n\t\t\t\t\t\t})\n' +
+    '\t\t\t\t\t}];\n' +
+    '\t\t\t\t}())],\n\t\t\t\tselectedId: state.current,';
+  // 设置行（PresetMenu，纯文本 label）：同样收进 submenu，组内不再带「· 自定义」后缀
+  const rowNew =
+    'items: [...options.filter((option) => option.trust !== "user").map((option) => {' + rowBody +
+    '\n\t\t\t\t}), ...(function () {\n' +
+    '\t\t\t\t\tconst user = options.filter((option) => option.trust === "user");\n' +
+    '\t\t\t\t\tif (user.length === 0) return [];\n' +
+    '\t\t\t\t\treturn [{\n' +
+    '\t\t\t\t\t\tid: "' + AGENT_PRESET_MARKER + '",\n' +
+    '\t\t\t\t\t\tlabel: t("menu.thirdPartyMode"),\n' +
+    '\t\t\t\t\t\tsubmenu: user.map((option) => {\n' +
+    '\t\t\t\t\t\t\tconst name = presetDisplayText(option, t).name;\n' +
+    '\t\t\t\t\t\t\treturn { id: option.id, label: name };\n' +
+    '\t\t\t\t\t\t})\n' +
+    '\t\t\t\t\t}];\n' +
+    '\t\t\t\t}())],\n\t\t\t\tselectedId,';
+  const zhDictAdd = '\n\t\t\t"menu.thirdPartyMode": "第三方模式",\n\t\t\t"menu.thirdPartyModeHint": "自定义与 EAC 内置的 Agent 预设",';
+  const enDictAdd = '\n\t\t\t"menu.thirdPartyMode": "Third-party modes",\n\t\t\t"menu.thirdPartyModeHint": "Custom and EAC-bundled agent presets",';
+  // 先做 items 替换（用旧索引的 slice），再注入词典（词典锚点在 items 之前，不受 items 替换影响）
+  src = src
+    .replace(src.slice(seatStart, seatTail + AGENT_PRESET_SEAT_TAIL.length), seatNew)
+    .replace(src.slice(rowStart, rowTail + AGENT_PRESET_ROW_TAIL.length), rowNew)
+    .replace(AGENT_PRESET_ZH_ANCHOR, AGENT_PRESET_ZH_ANCHOR + zhDictAdd)
+    .replace(AGENT_PRESET_EN_ANCHOR, AGENT_PRESET_EN_ANCHOR + enDictAdd);
+  fs.writeFileSync(target, src);
+  console.log('[patch-deps] 已补丁 agent-preset：第三方模式收进二级菜单');
+  return true;
+}
+
+// Menu 二级菜单滚动补丁：primitives 的 submenu 容器没有高度上限，preset 较多时
+// 子菜单超出视口且不可滚动（scrollable 类在菜单含 submenu 项时会被整体禁用）。
+// 给 submenu 容器注入内联 max-height + overflow-y。锚点用行级定位（submenu 行
+// 后第一个 role: "menu", 行），缩进从目标行提取，兼容上游编译产物缩进变化。
+// 幂等 marker: dsh-desktop:menu-submenu-scroll。
+const MENU_SUBMENU_MARKER = 'dsh-desktop:menu-submenu-scroll';
+const MENU_SUBMENU_FILE = path.join(root, 'node_modules', '@deepseek-ai', 'dsh-client-ui-primitives', 'lib', 'index.js');
+const MENU_SUBMENU_ANCHOR = 'Menu_module_css_default.submenu';
+
+function patchMenuSubmenuScroll(file) {
+  const target = file || MENU_SUBMENU_FILE;
+  if (!fs.existsSync(target)) {
+    console.log('[patch-deps] dsh-client-ui-primitives 不存在，跳过');
+    return false;
+  }
+  let src = fs.readFileSync(target, 'utf8');
+  if (src.includes(MENU_SUBMENU_MARKER)) {
+    console.log('[patch-deps] Menu 二级菜单滚动补丁已应用，跳过');
+    return true;
+  }
+  const submenuIdx = src.indexOf(MENU_SUBMENU_ANCHOR);
+  const roleIdx = submenuIdx >= 0 ? src.indexOf('role: "menu",', submenuIdx) : -1;
+  const lineStart = roleIdx >= 0 ? src.lastIndexOf('\n', roleIdx) + 1 : -1;
+  const roleLineEnd = roleIdx >= 0 ? src.indexOf('\n', roleIdx) : -1;
+  if (lineStart < 0 || roleLineEnd < 0) {
+    console.log('[patch-deps] Menu submenu 未匹配到目标代码（版本可能已更新），跳过');
+    return false;
+  }
+  const indent = src.slice(lineStart, roleIdx);
+  src = src.slice(0, roleLineEnd) + '\n' + indent + 'style: { maxHeight: "min(50vh, 24rem)", overflowY: "auto" }, /*' + MENU_SUBMENU_MARKER + '*/' + src.slice(roleLineEnd);
+  fs.writeFileSync(target, src);
+  console.log('[patch-deps] 已补丁 primitives：二级菜单超高可滚动');
+  return true;
+}
+
 function main() {
   patchPickerWorker();
   patchSettingsNavScroll();
+  patchAgentPresetMenu();
+  patchMenuSubmenuScroll();
 }
 
-main();
+// 单测 require 本模块时不应改写真实 node_modules；仅命令行直接执行时跑 main()。
+if (require.main === module) {
+  main();
+}
+
+module.exports = { patchAgentPresetMenu, patchMenuSubmenuScroll };

--- a/dsh-desktop/test/agent-preset-menu-patch.test.mjs
+++ b/dsh-desktop/test/agent-preset-menu-patch.test.mjs
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const require = createRequire(import.meta.url);
+const { patchAgentPresetMenu } = require('../scripts/patch-deps.js');
+
+// 模拟未补丁的 dsh-client-ui-agent-preset/lib/client.js：只保留补丁锚点结构
+// （items 构建 + selectedId 行 + 词典键），缩进与真实编译产物一致（tab）。
+const FAKE_UNPATCHED = [
+  'const en = {',
+  '\t\t\tpresetCordisName: "Creator mode",',
+  '};',
+  'const zh = {',
+  '\t\t\tpresetCordisName: "创造模式",',
+  '};',
+  'function AgentPresetSeat() {',
+  '  return {',
+  '\t\t\t\titems: state.options.map((option) => {',
+  '\t\t\t\t\tconst text = presetDisplayText(option, t);',
+  '\t\t\t\t\treturn { id: option.id, label: text.name };',
+  '\t\t\t\t}),',
+  '\t\t\t\tselectedId: state.current,',
+  '  };',
+  '}',
+  'function PresetMenu() {',
+  '  return {',
+  '\t\t\t\titems: options.map((option) => {',
+  '\t\t\t\t\tconst name = presetDisplayText(option, t).name;',
+  '\t\t\t\t\treturn { id: option.id, label: option.trust === "user" ? `${name} · ${t("userTrust")}` : name };',
+  '\t\t\t\t}),',
+  '\t\t\t\tselectedId,',
+  '  };',
+  '}',
+].join('\n');
+
+function withFakeFile(content = FAKE_UNPATCHED) {
+  const dir = mkdtempSync(join(tmpdir(), 'preset-patch-'));
+  const file = join(dir, 'client.js');
+  writeFileSync(file, content);
+  return { dir, file };
+}
+
+test('patchAgentPresetMenu 把 user trust 的 preset 收进「第三方模式」submenu', () => {
+  const { dir, file } = withFakeFile();
+  try {
+    assert.equal(patchAgentPresetMenu(file), true);
+    const src = readFileSync(file, 'utf8');
+    assert.match(src, /dsh-desktop:third-party/, '幂等 marker 已写入');
+    assert.match(src, /option\.trust !== "user"/, '主列表过滤掉自定义预设');
+    assert.equal(src.match(/submenu:/g)?.length, 2, 'seat 与设置行各一个 submenu');
+    assert.match(src, /"menu\.thirdPartyMode": "第三方模式"/, '中文词典注入');
+    assert.match(src, /"menu\.thirdPartyMode": "Third-party modes"/, '英文词典注入');
+    assert.match(src, /t\("menu\.thirdPartyMode"\)/, '菜单项引用新词典 key');
+    // 设置行的第三方子项不再带「· 自定义」后缀（submenu 项直接 label: name）
+    assert.match(src, /submenu: user\.map\(\(option\) => \{\s*\n\s*const name = presetDisplayText\(option, t\)\.name;\s*\n\s*return \{ id: option\.id, label: name \};/, 'submenu 项用纯 name');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('patchAgentPresetMenu 幂等：二次应用跳过且内容不变', () => {
+  const { dir, file } = withFakeFile();
+  try {
+    assert.equal(patchAgentPresetMenu(file), true);
+    const once = readFileSync(file, 'utf8');
+    assert.equal(patchAgentPresetMenu(file), true, '已应用后仍返回成功（跳过）');
+    assert.equal(readFileSync(file, 'utf8'), once, '内容不被二次修改');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('patchAgentPresetMenu 锚点失配时跳过且不改文件', () => {
+  const { dir, file } = withFakeFile('// 上游大改版，没有 items 锚点\n');
+  try {
+    assert.equal(patchAgentPresetMenu(file), false);
+    assert.equal(readFileSync(file, 'utf8'), '// 上游大改版，没有 items 锚点\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/dsh-desktop/test/menu-submenu-scroll-patch.test.mjs
+++ b/dsh-desktop/test/menu-submenu-scroll-patch.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const require = createRequire(import.meta.url);
+const { patchMenuSubmenuScroll } = require('../scripts/patch-deps.js');
+
+// 模拟未补丁的 dsh-client-ui-primitives/lib/index.js：只保留 Menu submenu 容器
+// 的锚点结构（submenu 类名行 + 紧随其后的 role 行，缩进与真实编译产物一致）。
+const FAKE_UNPATCHED = [
+  'function Menu() {',
+  '  return {',
+  '\t\t\t\tclassName: clsx(Menu_module_css_default.submenu, compact && Menu_module_css_default.compactList),',
+  '\t\t\t\trole: "menu",',
+  '\t\t\t\tchildren: entry.submenu.map((sub) => ...)',
+  '  };',
+  '}',
+].join('\n');
+
+function withFakeFile(content = FAKE_UNPATCHED) {
+  const dir = mkdtempSync(join(tmpdir(), 'submenu-scroll-'));
+  const file = join(dir, 'index.js');
+  writeFileSync(file, content);
+  return { dir, file };
+}
+
+test('patchMenuSubmenuScroll 给 submenu 容器注入 max-height + overflow-y', () => {
+  const { dir, file } = withFakeFile();
+  try {
+    assert.equal(patchMenuSubmenuScroll(file), true);
+    const src = readFileSync(file, 'utf8');
+    assert.match(src, /dsh-desktop:menu-submenu-scroll/, '幂等 marker 已写入');
+    assert.match(src, /style: \{ maxHeight: "min\(50vh, 24rem\)", overflowY: "auto" \},/, '内联滚动样式注入');
+    // 注入行的缩进应与 role 行一致
+    const roleLine = src.split('\n').find((l) => l.includes('role: "menu",'));
+    const styleLine = src.split('\n').find((l) => l.includes('maxHeight'));
+    assert.equal(styleLine.split('style')[0], roleLine.split('role')[0], '缩进与 role 行一致');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('patchMenuSubmenuScroll 幂等：二次应用跳过且内容不变', () => {
+  const { dir, file } = withFakeFile();
+  try {
+    assert.equal(patchMenuSubmenuScroll(file), true);
+    const once = readFileSync(file, 'utf8');
+    assert.equal(patchMenuSubmenuScroll(file), true, '已应用后仍返回成功（跳过）');
+    assert.equal(readFileSync(file, 'utf8'), once, '内容不被二次修改');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('patchMenuSubmenuScroll 锚点失配时跳过且不改文件', () => {
+  const { dir, file } = withFakeFile('// 上游大改版，没有 submenu 锚点\n');
+  try {
+    assert.equal(patchMenuSubmenuScroll(file), false);
+    assert.equal(readFileSync(file, 'utf8'), '// 上游大改版，没有 submenu 锚点\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概述

本次改动包含两部分：

1. **模式选择下拉二级化**：composer 上方与设置页的模式选择器，把自定义及 EAC 内置的 Agent 预设（trust 为 user 的项）收进「第三方模式」二级菜单，官方内置模式（标准 / PTC / 极简 / 创造）保留在主列表平铺展示。
2. **恢复中止超时结算保险**：`dsh-subprocess-local` 在进程中止后的强制结算改为走 `settle()`（补齐输出收集器封存、标准流销毁等清理），修复此前移除强制结算后 `done` 永远无法结算、导致工具调用与插件卸载流程挂死的问题（issue #162 场景回归）。

## 改动明细

| 文件 | 内容 |
|---|---|
| scripts/patch-deps.js | 新增 `patchAgentPresetMenu()`：把 user 预设折叠进「第三方模式」二级菜单（选择座位与设置行两处均生效），同时注入中英文词典；新增 `patchMenuSubmenuScroll()`：为二级菜单容器注入最大高度与纵向滚动，修复菜单含二级菜单项时整列表失去滚动能力、子菜单超出视口的回归；`main()` 增加 `require.main` 守卫，避免单测引入时改写真实依赖包 |
| main.js | 新增 `applyAgentPresetFix()`：应用启动时对 profile 共享目录、内置依赖、用户更新后的 overlay 三处运行时副本幂等重放上述两个补丁——官方 dsh 更新会整体替换 overlay 目录，若不重放，二级菜单功能会静默丢失 |
| node_modules 下 dsh-subprocess-local | 将 `settle` 提升到外层作用域，中止超时后若仍未结算则调用 `settle(null, null)`——即使进程树无法被杀死，`done` 也能在宽限期内完成结算，且走完整清理路径（收集器封存、标准流销毁、事件解绑） |
| electron-builder.yml | 打包清单补充 scripts/patch-deps.js（main.js 启动时引用，防止打包产物启动即闪退） |
| 测试文件 | 新增 agent-preset-menu-patch 与 menu-submenu-scroll-patch 两组单测（各 3 项） |

## 测试

- 新增单测 6 项，全量 `npm test` 共 **616 项全部通过，0 失败**
- 补丁幂等性验证通过（二次运行直接跳过），`node --check` 语法校验通过
- 运行态验证：Web 界面实际加载的依赖包中已包含补丁标记

## 补充说明

- 补丁锚点若因上游包版本更新而失配，会自动跳过并打印告警，不影响其他功能；重新安装依赖（postinstall）时自动重放
- 已知取舍：二级菜单子项不显示选中勾选（界面基础组件对子项无选中态渲染）
- 顺带移除了 dsh-tool-bash 中的折叠标签包装（该 HTML 原本就以纯文本形式渲染在终端卡片中，从未真正生效过，属良性清理）
