### PR TITLE
本 PR 修复插件从内置资源同步到用户 profile 过程中可能出现的文件缺失问题，并增强 Tauri 打包阶段的资源完整性校验，降低插…

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Linux 打包由社区开发者 [@Luoye-hb](https://github.com/Luoye-hb) 贡献�
 
 ## 开发者文档
 
+完整的当前分支开发参考见 [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)，包括 Tauri 三层架构、L2 模块边界、开发/测试/打包命令、运行时数据目录、桥接契约和排障清单。
+
 ### 从源码构建（Tauri 壳，v5.0 默认）
 
 ```powershell

--- a/dsh-desktop/assets/plugins/dsh-soul-md/vendor/dsh-settings-expose.js
+++ b/dsh-desktop/assets/plugins/dsh-soul-md/vendor/dsh-settings-expose.js
@@ -18,7 +18,7 @@ import { dirname, join, sep } from "node:path";
  * Ensure `nsName` is present in dsh-host-apiproxy's WEB_SETTINGS_NAMESPACES.
  * No-op when already exposed or when the file cannot be located/patched.
  * @param {import("cordis").Context} ctx
- * @param {string} nsName - settings namespace short name (e.g. "tdai-memory").
+ * @param {string} nsName - settings namespace short name (e.g. "soul-md").
  * @param {{info?: Function, warn?: Function}} logger - dsh logger.
  */
 export function ensureSettingsNamespaceExposed(ctx, nsName, logger) {

--- a/dsh-desktop/assets/plugins/picturereader/src/settings-expose.js
+++ b/dsh-desktop/assets/plugins/picturereader/src/settings-expose.js
@@ -18,7 +18,7 @@ import { dirname, join, sep } from "node:path";
  * Ensure `nsName` is present in dsh-host-apiproxy's WEB_SETTINGS_NAMESPACES.
  * No-op when already exposed or when the file cannot be located/patched.
  * @param {import("cordis").Context} ctx
- * @param {string} nsName - settings namespace short name (e.g. "tdai-memory").
+ * @param {string} nsName - settings namespace short name (e.g. "image-reader").
  * @param {{info?: Function, warn?: Function}} logger - dsh logger.
  */
 export function ensureSettingsNamespaceExposed(ctx, nsName, logger) {

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -353,12 +353,26 @@ export function pluginStampOf(src: string): string | null {
   }
 }
 
+// A source stamp alone is not enough: an interrupted copy or an antivirus
+// cleanup can remove files from the profile while leaving the stamp behind.
+// Verify the destination against the same copy manifest before skipping.
+function pluginCopyIsComplete(src: string, dest: string): boolean {
+  try {
+    return pluginCopyEntries(src).every((rel) => {
+      const target = path.join(dest, rel);
+      return fs.existsSync(target) && fs.statSync(target).isFile();
+    });
+  } catch {
+    return false;
+  }
+}
+
 export function copyPluginPackage(profileDirP: string, src: string, name: string): void {
   const destRoot = path.join(profileDirP, 'node_modules', ...name.split('/'));
   const stampFile = path.join(destRoot, COPY_STAMP);
   const want = pluginStampOf(src);
   try {
-    if (want && fs.existsSync(stampFile) && fs.readFileSync(stampFile, 'utf8') === want) {
+    if (want && fs.existsSync(stampFile) && fs.readFileSync(stampFile, 'utf8') === want && pluginCopyIsComplete(src, destRoot)) {
       return; // 内容未变：跳过全量重拷
     }
   } catch { /* 比对失败按需重拷 */ }

--- a/dsh-desktop/scripts/e2e-full.js
+++ b/dsh-desktop/scripts/e2e-full.js
@@ -36,10 +36,9 @@ function arg(name, def) {
 const EXE = arg('exe');
 const DEBUG_PORT = Number(arg('port', '9341'));
 const MOCK_PORT = Number(arg('mockport', '9342'));
-// 插件选择（2026-08-19 实测）：dsh-task-status 已从 npm registry 下架（404）；
-// dsh-tool-vision 已被客户端内置接管（市场拒装 builtin:true）。默认用
-// dsh-tdai-memory（0.2.10 在架、非内置、走完整 pnpm 市场链路）。
-const INSTALL_TARGET = arg('plugin', 'dsh-tdai-memory');
+// 插件选择：使用市场快照中非内置、以 npm 包名安装的插件，确保包名可直接
+// 用于 profile bundles 与 node_modules 落盘断言。可通过 --plugin 覆盖。
+const INSTALL_TARGET = arg('plugin', 'dsh-spend');
 const SKIP_MARKET = arg('skip-market') === '1';
 const SKIP_CHAT = arg('skip-chat') === '1';
 if (!EXE || !fs.existsSync(EXE)) {

--- a/dsh-desktop/test/companion-copy-integrity.test.mjs
+++ b/dsh-desktop/test/companion-copy-integrity.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { copyPluginPackage } from '../lib/desktop/companion-sync.js';
+
+test('copyPluginPackage repairs a missing file even when the source stamp remains', () => {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-plugin-copy-'));
+  try {
+    const src = join(root, 'source');
+    const profile = join(root, 'profile');
+    mkdirSync(join(src, 'lib'), { recursive: true });
+    writeFileSync(join(src, 'package.json'), JSON.stringify({ name: 'example-plugin', version: '1.0.0' }));
+    writeFileSync(join(src, 'lib', 'index.js'), 'module.exports = {}\n');
+
+    copyPluginPackage(profile, src, 'example-plugin');
+    const copied = join(profile, 'node_modules', 'example-plugin', 'lib', 'index.js');
+    assert.equal(existsSync(copied), true);
+    unlinkSync(copied);
+
+    copyPluginPackage(profile, src, 'example-plugin');
+    assert.equal(existsSync(copied), true, 'missing plugin files must be restored');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/dsh-desktop/test/companion-plugins-registry.test.mjs
+++ b/dsh-desktop/test/companion-plugins-registry.test.mjs
@@ -43,9 +43,9 @@ const EXCEPTIONS = new Set([
 
 test('every vendored plugin dir is registered in COMPANION_PLUGINS', () => {
   const pluginsDir = join(root, 'assets', 'plugins');
-  const dirs = readdirSync(pluginsDir)
-    .filter((d) => existsSync(join(pluginsDir, d, 'package.json')))
-    .sort();
+  const dirs = readdirSync(pluginsDir).sort();
+  const withoutManifest = dirs.filter((d) => !existsSync(join(pluginsDir, d, 'package.json')));
+  assert.deepEqual(withoutManifest, [], '插件目录缺少 package.json，可能是已退役插件或不完整安装的残留');
   const slice = companionSlice();
   const missing = [];
   for (const d of dirs) {
@@ -70,6 +70,7 @@ test('every registration row with dir points at a real vendored package', () => 
 
 test('regression: settings-groups stays registered, retired marketplace never returns', () => {
   const slice = companionSlice();
+  assert.doesNotMatch(slice, /dsh-tdai-memory|tdai-memory/, '已退役的 tdai-memory 不得重新进入内置插件清单');
   assert.match(slice, /id:\s*'settings-groups'/, '侧边栏普通/高级分组（Bug #58）—— V4.6.1 起负责常规页页内折叠');
   const retiredStart = main.indexOf('const RETIRED_BUILTIN_PLUGINS');
   assert.ok(retiredStart >= 0, 'RETIRED_BUILTIN_PLUGINS must exist in lib/desktop/companion-sync.ts');

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -9,7 +9,7 @@
 //
 // 用法：node stage-resources.mjs [--skip-npm]（--skip-npm 复用上次 npm ci 产物）
 
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, rmSync, readFileSync, statSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -40,6 +40,54 @@ const SCRIPTS = [
   'onboarding.js', 'make-release-hashes.js',
 ];
 
+function requireFile(file, label) {
+  if (!existsSync(file) || !statSync(file).isFile()) {
+    throw new Error(`[stage] 缺少${label || '文件'}: ${path.relative(root, file)}`);
+  }
+}
+
+function copyRequired(src, dest, label) {
+  requireFile(src, label);
+  mkdirSync(path.dirname(dest), { recursive: true });
+  cpSync(src, dest);
+}
+
+function pluginEntrypoints(pkg) {
+  const result = [];
+  const add = (value) => {
+    if (typeof value === 'string' && value.trim()) result.push(value.replace(/^\.\//, ''));
+  };
+  add(pkg.main);
+  add(pkg.module);
+  if (typeof pkg.exports === 'string') add(pkg.exports);
+  else if (pkg.exports && typeof pkg.exports === 'object') {
+    const walk = (value) => {
+      if (typeof value === 'string') add(value);
+      else if (value && typeof value === 'object') Object.values(value).forEach(walk);
+    };
+    walk(pkg.exports);
+  }
+  return [...new Set(result)].filter((entry) => !entry.includes('*') && !/\.d\.(?:ts|mts|cts)$/i.test(entry));
+}
+
+function validatePluginTree(dir, label) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+    const pluginDir = path.join(dir, entry.name);
+    const manifest = path.join(pluginDir, 'package.json');
+    if (!existsSync(manifest)) {
+      throw new Error(`[stage] ${label}插件目录没有 package.json: ${path.relative(root, pluginDir)}`);
+    }
+    let pkg;
+    try { pkg = JSON.parse(readFileSync(manifest, 'utf8')); }
+    catch (err) { throw new Error(`[stage] ${label}插件 manifest 无法解析: ${path.relative(root, manifest)} (${err.message})`); }
+    const points = pluginEntrypoints(pkg);
+    if (points.length === 0) throw new Error(`[stage] ${label}插件没有可校验入口: ${path.relative(root, manifest)}`);
+    for (const rel of points) requireFile(path.join(pluginDir, rel), `${label}插件入口`);
+  }
+}
+
 console.log('[stage] 清理旧装配目录');
 rmSync(staged, { recursive: true, force: true });
 mkdirSync(path.join(staged, 'sidecar'), { recursive: true });
@@ -56,25 +104,27 @@ for (const f of ['server.js', 'bridge.js', 'rescue-integration.js']) {
 console.log('[stage] dsh-desktop 根模块 + lib/desktop + scripts + package.json');
 for (const f of ROOT_FILES) {
   const src = path.join(dd, f);
-  if (existsSync(src)) cpSync(src, path.join(staged, 'dsh-desktop', f));
+  copyRequired(src, path.join(staged, 'dsh-desktop', f), '根模块');
 }
 mkdirSync(path.join(staged, 'dsh-desktop', 'lib', 'desktop'), { recursive: true });
 for (const f of LIB_DESKTOP) {
-  cpSync(path.join(dd, 'lib', 'desktop', f), path.join(staged, 'dsh-desktop', 'lib', 'desktop', f));
+  copyRequired(path.join(dd, 'lib', 'desktop', f), path.join(staged, 'dsh-desktop', 'lib', 'desktop', f), '桌面库');
 }
 mkdirSync(path.join(staged, 'dsh-desktop', 'scripts'), { recursive: true });
 for (const f of SCRIPTS) {
-  cpSync(path.join(dd, 'scripts', f), path.join(staged, 'dsh-desktop', 'scripts', f));
+  copyRequired(path.join(dd, 'scripts', f), path.join(staged, 'dsh-desktop', 'scripts', f), '脚本');
 }
 // package.json + lock 原样拷贝（npm ci 要求两者一致；--omit=dev 只装生产树）。
 // .npmrc（legacy-peer-deps）必须随行：内核包互相声明 peer，staged 目录里的
 // npm ci 若不带该配置会因 lock 缺 peer 闭包直接 EUSAGE 拒装（全新打包必踩）。
-cpSync(path.join(dd, 'package.json'), path.join(staged, 'dsh-desktop', 'package.json'));
-cpSync(path.join(dd, 'package-lock.json'), path.join(staged, 'dsh-desktop', 'package-lock.json'));
-cpSync(path.join(dd, '.npmrc'), path.join(staged, 'dsh-desktop', '.npmrc'));
+copyRequired(path.join(dd, 'package.json'), path.join(staged, 'dsh-desktop', 'package.json'), 'package.json');
+copyRequired(path.join(dd, 'package-lock.json'), path.join(staged, 'dsh-desktop', 'package-lock.json'), 'package-lock.json');
+copyRequired(path.join(dd, '.npmrc'), path.join(staged, 'dsh-desktop', '.npmrc'), '.npmrc');
 
 console.log('[stage] assets（114MB：38 插件 + 10 皮肤 + 图标）');
 cpSync(path.join(dd, 'assets'), path.join(staged, 'dsh-desktop', 'assets'), { recursive: true });
+validatePluginTree(path.join(dd, 'assets', 'plugins'), '源');
+validatePluginTree(path.join(staged, 'dsh-desktop', 'assets', 'plugins'), 'staging');
 
 console.log('[stage] vendor node/npm 运行时');
 mkdirSync(path.join(staged, 'dsh-desktop', 'vendor'), { recursive: true });


### PR DESCRIPTION
## 摘要

本 PR 修复插件从内置资源同步到用户 profile 过程中可能出现的文件缺失问题，并增强 Tauri 打包阶段的资源完整性校验，降低插件树因缺少入口文件或依赖文件而启动崩溃的风险。

同时清理已弃用的 `dsh-tdai-memory` 本地插件残留引用，避免 E2E 测试和后续构建流程重新使用该插件。

## 问题

- 插件目标目录即使已经缺少文件，只要 `.eac-copy-stamp.json` 仍存在，启动时就会被误判为完整，跳过重新复制。
- 插件文件缺失可能导致 `ERR_MODULE_NOT_FOUND`、插件加载失败或整个插件树启动失败。
- Tauri staging 脚本对部分根模块和脚本使用静默跳过逻辑，源文件缺失时不会立即报错，最终可能生成不完整的安装包。
- 插件目录缺少 `package.json` 或入口文件时，原有流程无法在打包前发现。
- E2E 脚本默认使用已经弃用的 `dsh-tdai-memory`，存在重新拉取废弃插件的风险。

## 修复

- 在 stamp 命中时，按照插件复制清单逐文件检查目标文件是否存在且为普通文件；发现缺失时自动执行完整复制。
- 新增插件文件完整性回归测试，覆盖“保留 stamp 但删除目标文件”的场景。
- 将 Tauri staging 中的根模块、桌面模块、脚本、`package.json`、lock 文件和 `.npmrc` 改为强制校验，缺失时直接终止构建。
- 校验所有内置插件的 `package.json` 以及 `main`、`module`、`exports` 声明的运行时入口。
- 增加插件注册表测试，禁止无 `package.json` 的残留目录进入构建树。
- 增加测试，防止已退役的 `tdai-memory` 重新进入活动内置插件清单。
- 将 E2E 默认市场插件改为 `dsh-spend`。（仅开发者手动测试完整启动会触发）
- 保留 `RETIRED_BUILTIN_PLUGINS` 中的 tdai 条目，用于清理老用户 profile 中遗留的 patch 行、依赖和插件目录。

## 验证

执行了以下验证：

```powershell
npm run build
npm run typecheck
npm test
node --check tauri-shell/stage-resources.mjs
node --check dsh-desktop/scripts/e2e-full.js
git diff --check