### PR TITLE
fix: avoid required escalation fields at full access

### DIFF
--- a/dsh-desktop/scripts/patch-deps.js
+++ b/dsh-desktop/scripts/patch-deps.js
@@ -75,9 +75,44 @@ function patchSettingsNavScroll() {
   console.log('[patch-deps] 已补丁 settings-general：设置弹窗左栏可滚动，底部条目不再被裁掉');
 }
 
+// 函数工具桥接兼容补丁：部分外部工具适配器忽略 JSON Schema 的 required 数组，
+// 把所有 properties 错当成必填。全权限默认策略下不存在可升级的更宽模式，仍
+// 暴露 sandbox_permissions/justification 会让适配器强制提交一条必然失败的同级
+// 升级请求。仅在默认 danger-full-access 时不暴露这对可选字段；执行层的严格
+// 升级校验不变。会话切换到较窄策略后需重载工具 schema 才会再次暴露升级字段。
+const OPTIONAL_ESCALATION_MARKER = 'dsh-desktop-optional-escalation';
+const OPTIONAL_ESCALATION_TARGETS = [
+  path.join(root, 'node_modules', '@deepseek-ai', 'dsh-tool-pwsh', 'lib', 'index.js'),
+  path.join(root, 'node_modules', '@deepseek-ai', 'dsh-tool-fs', 'lib', 'index.js'),
+];
+const OPTIONAL_ESCALATION_OLD = 'defaultMode === void 0 ? [] : ESCALATION_TARGETS';
+const OPTIONAL_ESCALATION_NEW = 'defaultMode === void 0 || defaultMode === "danger-full-access" ? [] : ESCALATION_TARGETS /* dsh-desktop-optional-escalation */';
+
+function patchOptionalEscalationFields() {
+  for (const file of OPTIONAL_ESCALATION_TARGETS) {
+    if (!fs.existsSync(file)) {
+      console.log('[patch-deps] 可选升级字段目标不存在，跳过：' + file);
+      continue;
+    }
+    let src = fs.readFileSync(file, 'utf8');
+    if (src.includes(OPTIONAL_ESCALATION_MARKER)) {
+      console.log('[patch-deps] 可选升级字段兼容补丁已应用，跳过：' + path.basename(path.dirname(path.dirname(file))));
+      continue;
+    }
+    if (!src.includes(OPTIONAL_ESCALATION_OLD)) {
+      console.log('[patch-deps] 未匹配可选升级字段目标（上游版本可能已修复/更新），跳过：' + file);
+      continue;
+    }
+    src = src.replace(OPTIONAL_ESCALATION_OLD, OPTIONAL_ESCALATION_NEW);
+    fs.writeFileSync(file, src);
+    console.log('[patch-deps] 已补丁可选升级字段：' + path.basename(path.dirname(path.dirname(file))));
+  }
+}
+
 function main() {
   patchPickerWorker();
   patchSettingsNavScroll();
+  patchOptionalEscalationFields();
 }
 
 main();


### PR DESCRIPTION
## Summary
- hide optional sandbox escalation fields when the desktop starts in danger-full-access
- avoid external tool bridges treating those optional fields as required and issuing a non-widening escalation
- retain existing strict escalation checks for confined defaults

## Verification
- node --check scripts/patch-deps.js
- git diff --check
- temporary fixture: applies patches to dsh-tool-pwsh and dsh-tool-fs and verifies idempotence