### PR TITLE
chore: remove Electron leftovers and tdai-memory references

### DIFF
--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -445,7 +445,6 @@ export function healProfileModules(): void {
 // 使 dsh web 以 code=1 退出。启动时统一清理这些精确的历史内置条目。
 // （契约测试锚定字面量 `const RETIRED_BUILTIN_PLUGINS = [`，勿加内联注解。）
 export const RETIRED_BUILTIN_PLUGINS = [
-  { id: 'tdai-memory', name: 'dsh-tdai-memory' },
   { id: 'auto-compact', name: 'dsh-auto-compact' },
   { id: 'plugin-marketplace', name: '@deepseek-ai/dsh-plugin-marketplace' },
   { id: 'dsh-market-plugin', name: '@sanqi-normal/dsh-webui-market-plugin' },
@@ -511,7 +510,7 @@ export function syncCompanionPlugins(): void {
     const home = ctx.getDshHome() || path.join(os.homedir(), '.dsh');
     // 桌面专属 profile 必须先存在（未知 profile 不会被 dsh 自动初始化）。
     ensureDesktopProfileInit();
-    // 清理已退役内置插件（tdai-memory 等）在 profile 的残留，避免
+    // 清理已退役内置插件在 profile 的残留，避免
     // 「行在包被清」拖垮插件树或退役插件继续加载。
     retireRemovedBuiltinPlugins(desktopProfileDir());
     // V4 运行时补丁（幂等，随启动 / 服务重启 / agent 更新后重放）：

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -19,14 +19,14 @@ const dd = path.join(root, 'dsh-desktop');
 const staged = path.join(root, 'tauri-shell', 'staged-resources');
 const skipNpm = process.argv.includes('--skip-npm');
 
-// electron-builder.yml 的 files 清单（人工同步：新增根模块要加进来）。
+// 人工同步：新增根模块要加进来（Electron 时代的 main.js / preload.js 已废弃，不再打包）。
 const ROOT_FILES = [
-  'main.js', 'updater.js', 'client-updater.js', 'logger.js', 'plugin-updater.js',
+  'updater.js', 'client-updater.js', 'logger.js', 'plugin-updater.js',
   'balance.js', 'session-watcher.js', 'session-encoding-heal.js', 'profile-module-heal.js',
   'patch-row-heal.js', 'builtin-collision.js', 'plugin-manager-state.js', 'plugin-guard.js',
   'rescue-agent.js', 'preset-sync.js', 'compact-preset-migrate.js', 'error-detail.js',
   'bundle-integrity.js', 'stable-port.js', 'stream-write-guard.js', 'koffi-preflight.js',
-  'renderer-recovery.js', 'watchdog.js', 'shortcut-maintenance.js', 'preload.js',
+  'renderer-recovery.js', 'watchdog.js', 'shortcut-maintenance.js',
   'wsl-backend.js',
 ];
 const LIB_DESKTOP = [


### PR DESCRIPTION
## 变更说明

### 1. 移除 Electron 时代遗留文件引用
- 	auri-shell/stage-resources.mjs: 从 ROOT_FILES 中移除 main.js 和 preload.js
- 这两个文件是 Electron 壳的产物，在 Tauri v5 架构中已不再使用

### 2. 清理退役插件列表
- dsh-desktop/lib/desktop/companion-sync.ts: 从 RETIRED_BUILTIN_PLUGINS 中移除 	dai-memory
- 更新相关注释，移除已过时的 tdai-memory 引用

### 测试
- 所有现有测试通过（包括 companion-copy-integrity.test.mjs）
- pluginCopyIsComplete 函数已在上游实现，戳记匹配时会验证目标文件完整性