### PR TITLE
feat(preset): 移植第三方模式折叠（布局优化）补丁到 TS 版 patch-deps

### DIFF
--- a/.agents/skills/deepseek-harness-eac-dev/references/change-rules.psd1
+++ b/.agents/skills/deepseek-harness-eac-dev/references/change-rules.psd1
@@ -7,7 +7,7 @@
             Pattern = '^tauri-shell/src/.*\.rs$|^tauri-shell/Cargo\.(toml|lock)$'
             Reference = 'references/tauri-shell.md'
             Level = 'runtime'
-            Tests = @('test/bridge-preload-parity.test.mjs')
+            Tests = @('test/bridge-preload-parity.test.ts')
             Smoke = @('cd tauri-shell; cargo run -- --bridge-test', 'node gui-smoke.js')
         },
         @{
@@ -16,7 +16,7 @@
             Pattern = '^tauri-shell/sidecar/|bridge\.(ts|js)$|preload\.js$'
             Reference = 'references/sidecar-and-bridge.md'
             Level = 'runtime'
-            Tests = @('test/bridge-preload-parity.test.mjs')
+            Tests = @('test/bridge-preload-parity.test.ts')
             Smoke = @('cd tauri-shell; cargo run -- --bridge-test')
         },
         @{
@@ -26,14 +26,14 @@
             Reference = 'references/updates-and-packaging.md'
             Level = 'package'
             Tests = @(
-                'test/client-update-platform.test.mjs',
-                'test/client-updater-apply.test.mjs',
-                'test/client-updater-asset.test.mjs',
-                'test/client-updater-hash.test.mjs',
-                'test/client-updater-node-arg.test.mjs',
-                'test/client-updater-nospace.test.mjs',
-                'test/client-updater-proxy.test.mjs',
-                'test/client-updater-resume.test.mjs'
+                'test/client-update-platform.test.ts',
+                'test/client-updater-apply.test.ts',
+                'test/client-updater-asset.test.ts',
+                'test/client-updater-hash.test.ts',
+                'test/client-updater-node-arg.test.ts',
+                'test/client-updater-nospace.test.ts',
+                'test/client-updater-proxy.test.ts',
+                'test/client-updater-resume.test.ts'
             )
             Smoke = @('node update-smoke.js')
         },
@@ -44,9 +44,9 @@
             Reference = 'references/updates-and-packaging.md'
             Level = 'full'
             Tests = @(
-                'test/updater-backup.test.mjs',
-                'test/updater-version.test.mjs',
-                'test/update-mirror-chain.test.mjs'
+                'test/updater-backup.test.ts',
+                'test/updater-version.test.ts',
+                'test/update-mirror-chain.test.ts'
             )
             Smoke = @()
         },
@@ -57,9 +57,9 @@
             Reference = 'references/dependency-patches.md'
             Level = 'package'
             Tests = @(
-                'test/bundle-integrity.test.mjs',
-                'test/bundled-files.test.mjs',
-                'test/verify-dist-fresh.test.mjs'
+                'test/bundle-integrity.test.ts',
+                'test/bundled-files.test.ts',
+                'test/verify-dist-fresh.test.ts'
             )
             Smoke = @(
                 'node tauri-shell/stage-resources.mjs',
@@ -72,7 +72,7 @@
             Pattern = '^dsh-desktop/scripts/.*\.(js|cjs|mjs|ps1)$'
             Reference = 'references/updates-and-packaging.md'
             Level = 'full'
-            Tests = @('test/bundled-files.test.mjs')
+            Tests = @('test/bundled-files.test.ts')
             Smoke = @()
         },
         @{
@@ -82,10 +82,10 @@
             Reference = 'references/dsh-plugins.md'
             Level = 'full'
             Tests = @(
-                'test/skin-chrome-zindex.test.mjs',
-                'test/skin-switch-css.test.mjs',
-                'test/skin-switch-profile.test.mjs',
-                'test/widget-theme.test.mjs'
+                'test/skin-chrome-zindex.test.ts',
+                'test/skin-switch-css.test.ts',
+                'test/skin-switch-profile.test.ts',
+                'test/widget-theme.test.ts'
             )
             Smoke = @('node gui-smoke.js')
         },
@@ -113,7 +113,7 @@
             Pattern = 'plugin-updater\.(js|ts)$'
             Reference = 'references/dsh-plugins.md'
             Level = 'full'
-            Tests = @('test/plugin-updater.test.mjs')
+            Tests = @('test/plugin-updater.test.ts')
             Smoke = @()
         },
         @{
@@ -123,12 +123,12 @@
             Reference = 'references/dsh-plugins.md'
             Level = 'full'
             Tests = @(
-                'test/companion-copy-integrity.test.mjs',
-                'test/companion-plugins-registry.test.mjs',
-                'test/better-sidebar-bundle.test.mjs',
-                'test/patch-row-heal.test.mjs',
-                'test/retired-market-migration.test.mjs',
-                'test/dsh-compact-integration.test.mjs'
+                'test/companion-copy-integrity.test.ts',
+                'test/companion-plugins-registry.test.ts',
+                'test/better-sidebar-bundle.test.ts',
+                'test/patch-row-heal.test.ts',
+                'test/retired-market-migration.test.ts',
+                'test/dsh-compact-integration.test.ts'
             )
             Smoke = @()
         },
@@ -139,10 +139,10 @@
             Reference = 'references/dsh-plugins.md'
             Level = 'full'
             Tests = @(
-                'test/plugin-manager-state.test.mjs',
-                'test/plugin-manager-toggle.test.mjs',
-                'test/onboarding-selection.test.mjs',
-                'test/image-paste-core.test.mjs'
+                'test/plugin-manager-state.test.ts',
+                'test/plugin-manager-toggle.test.ts',
+                'test/onboarding-selection.test.ts',
+                'test/image-paste-core.test.ts'
             )
             Smoke = @()
         },
@@ -153,10 +153,10 @@
             Reference = 'references/dsh-plugins.md'
             Level = 'full'
             Tests = @(
-                'test/companion-plugins-registry.test.mjs',
-                'test/companion-copy-integrity.test.mjs',
-                'test/plugin-slot-registration.test.mjs',
-                'test/onboarding-selection.test.mjs'
+                'test/companion-plugins-registry.test.ts',
+                'test/companion-copy-integrity.test.ts',
+                'test/plugin-slot-registration.test.ts',
+                'test/onboarding-selection.test.ts'
             )
             Smoke = @('node tauri-shell/stage-resources.mjs')
         },
@@ -167,12 +167,12 @@
             Reference = 'references/dsh-plugins.md'
             Level = 'full'
             Tests = @(
-                'test/dsh-compact-engine.test.mjs',
-                'test/dsh-compact-host.test.mjs',
-                'test/dsh-compact-integration.test.mjs',
-                'test/dsh-compact-migration.test.mjs',
-                'test/dsh-compact-output-overflow.test.mjs',
-                'test/dsh-compact-policy.test.mjs'
+                'test/dsh-compact-engine.test.ts',
+                'test/dsh-compact-host.test.ts',
+                'test/dsh-compact-integration.test.ts',
+                'test/dsh-compact-migration.test.ts',
+                'test/dsh-compact-output-overflow.test.ts',
+                'test/dsh-compact-policy.test.ts'
             )
             Smoke = @()
         },
@@ -183,10 +183,10 @@
             Reference = 'references/presets-and-profile.md'
             Level = 'full'
             Tests = @(
-                'test/preset-sync.test.mjs',
-                'test/patch-row-heal.test.mjs',
-                'test/resolve-profile.test.mjs',
-                'test/profile-module-heal.test.mjs'
+                'test/preset-sync.test.ts',
+                'test/patch-row-heal.test.ts',
+                'test/resolve-profile.test.ts',
+                'test/profile-module-heal.test.ts'
             )
             Smoke = @('node boot-smoke.js')
         },
@@ -196,7 +196,7 @@
             Pattern = 'shortcuts\.(ts|js)$|shortcut-maintenance'
             Reference = 'references/presets-and-profile.md'
             Level = 'full'
-            Tests = @('test/shortcut-maintenance.test.mjs')
+            Tests = @('test/shortcut-maintenance.test.ts')
             Smoke = @()
         },
         @{
@@ -206,9 +206,9 @@
             Reference = 'references/product-services.md'
             Level = 'full'
             Tests = @(
-                'test/balance-prices-core.test.mjs',
-                'test/pricing-window.test.mjs',
-                'test/widget-theme.test.mjs'
+                'test/balance-prices-core.test.ts',
+                'test/pricing-window.test.ts',
+                'test/widget-theme.test.ts'
             )
             Smoke = @()
         },
@@ -228,9 +228,9 @@
             Reference = 'references/product-services.md'
             Level = 'full'
             Tests = @(
-                'test/bundle-integrity.test.mjs',
-                'test/bundled-files.test.mjs',
-                'test/image-paste-core.test.mjs'
+                'test/bundle-integrity.test.ts',
+                'test/bundled-files.test.ts',
+                'test/image-paste-core.test.ts'
             )
             Smoke = @()
         },
@@ -241,12 +241,12 @@
             Reference = 'references/product-services.md'
             Level = 'full'
             Tests = @(
-                'test/stable-port.test.mjs',
-                'test/stream-write-after-end.test.mjs',
-                'test/koffi-preflight.test.mjs',
-                'test/error-detail.test.mjs',
-                'test/builtin-collision.test.mjs',
-                'test/bundle-integrity.test.mjs'
+                'test/stable-port.test.ts',
+                'test/stream-write-after-end.test.ts',
+                'test/koffi-preflight.test.ts',
+                'test/error-detail.test.ts',
+                'test/builtin-collision.test.ts',
+                'test/bundle-integrity.test.ts'
             )
             Smoke = @()
         },
@@ -266,17 +266,17 @@
             Reference = 'references/reliability-and-security.md'
             Level = 'full'
             Tests = @(
-                'test/boot-attribution.test.mjs',
-                'test/diagnostics-zip.test.mjs',
-                'test/logger-redact.test.mjs',
-                'test/logger-rotate.test.mjs',
-                'test/plugin-guard.test.mjs',
-                'test/recovery-integration.test.mjs',
-                'test/renderer-recovery.test.mjs',
-                'test/rescue-agent.test.mjs',
-                'test/rescue-auto-repair.test.mjs',
-                'test/rescue-integration.test.mjs',
-                'test/watchdog-behavior.test.mjs'
+                'test/boot-attribution.test.ts',
+                'test/diagnostics-zip.test.ts',
+                'test/logger-redact.test.ts',
+                'test/logger-rotate.test.ts',
+                'test/plugin-guard.test.ts',
+                'test/recovery-integration.test.ts',
+                'test/renderer-recovery.test.ts',
+                'test/rescue-agent.test.ts',
+                'test/rescue-auto-repair.test.ts',
+                'test/rescue-integration.test.ts',
+                'test/watchdog-behavior.test.ts'
             )
             Smoke = @()
         },
@@ -287,12 +287,12 @@
             Reference = 'references/updates-and-packaging.md'
             Level = 'package'
             Tests = @(
-                'test/bundle-integrity.test.mjs',
-                'test/bundled-files.test.mjs',
-                'test/installer-nsh-lengths.test.mjs',
-                'test/installer-nsh-pipe.test.mjs',
-                'test/installer-takeover.test.mjs',
-                'test/verify-dist-fresh.test.mjs'
+                'test/bundle-integrity.test.ts',
+                'test/bundled-files.test.ts',
+                'test/installer-nsh-lengths.test.ts',
+                'test/installer-nsh-pipe.test.ts',
+                'test/installer-takeover.test.ts',
+                'test/verify-dist-fresh.test.ts'
             )
             Smoke = @('node update-smoke.js', 'node upgrade-test-441.js')
         },
@@ -303,10 +303,10 @@
             Reference = 'references/sidecar-and-bridge.md'
             Level = 'runtime'
             Tests = @(
-                'test/bridge-preload-parity.test.mjs',
-                'test/bundled-files.test.mjs',
-                'test/context-menu.test.mjs',
-                'test/desktop-extras.test.mjs'
+                'test/bridge-preload-parity.test.ts',
+                'test/bundled-files.test.ts',
+                'test/context-menu.test.ts',
+                'test/desktop-extras.test.ts'
             )
             Smoke = @()
         },

--- a/dsh-desktop/scripts/patch-deps.ts
+++ b/dsh-desktop/scripts/patch-deps.ts
@@ -112,10 +112,248 @@ function patchOptionalEscalationFields(): void {
   }
 }
 
+// 模式选择菜单二级化补丁：agent preset 选择器把 user trust（自定义 / EAC 内置）
+// 的 preset 收进「第三方模式」二级菜单（Menu 原生 submenu），官方内置（system
+// trust）保留主列表。幂等 marker: dsh-desktop:third-party（preset id 规则不允许
+// 冒号，不会与真实 preset id 冲突）。目标代码是编译产物，锚点失配告警跳过。
+const AGENT_PRESET_MARKER = 'dsh-desktop:third-party';
+const AGENT_PRESET_FILE = path.join(root, 'node_modules', '@deepseek-ai', 'dsh-client-ui-agent-preset', 'lib', 'client.js');
+const AGENT_PRESET_SEAT_START = 'items: state.options.map((option) => {';
+const AGENT_PRESET_SEAT_TAIL = '}),\n\t\t\t\tselectedId: state.current,';
+const AGENT_PRESET_ROW_START = 'items: options.map((option) => {';
+const AGENT_PRESET_ROW_TAIL = '}),\n\t\t\t\tselectedId,';
+const AGENT_PRESET_ZH_ANCHOR = 'presetCordisName: "创造模式",';
+const AGENT_PRESET_EN_ANCHOR = 'presetCordisName: "Creator mode",';
+
+function patchAgentPresetMenu(file?: string): boolean {
+  const target = file || AGENT_PRESET_FILE;
+  if (!fs.existsSync(target)) {
+    console.log('[patch-deps] dsh-client-ui-agent-preset 不存在，跳过');
+    return false;
+  }
+  let src = fs.readFileSync(target, 'utf8');
+  if (src.includes(AGENT_PRESET_MARKER)) {
+    console.log('[patch-deps] agent-preset 模式菜单补丁已应用，跳过');
+    return true;
+  }
+  const seatStart = src.indexOf(AGENT_PRESET_SEAT_START);
+  const seatTail = seatStart >= 0 ? src.indexOf(AGENT_PRESET_SEAT_TAIL, seatStart) : -1;
+  const rowStart = src.indexOf(AGENT_PRESET_ROW_START);
+  const rowTail = rowStart >= 0 ? src.indexOf(AGENT_PRESET_ROW_TAIL, rowStart) : -1;
+  if (seatStart < 0 || seatTail < 0 || rowStart < 0 || rowTail < 0 || !src.includes(AGENT_PRESET_ZH_ANCHOR) || !src.includes(AGENT_PRESET_EN_ANCHOR)) {
+    console.log('[patch-deps] agent-preset 未匹配到目标代码（版本可能已更新），跳过');
+    return false;
+  }
+  const seatBody = src.slice(seatStart + AGENT_PRESET_SEAT_START.length, seatTail);
+  const rowBody = src.slice(rowStart + AGENT_PRESET_ROW_START.length, rowTail);
+  // composer 座位：官方保留主列表，第三方收进「第三方模式」submenu。
+  // submenu 子项复用两行渲染体，但 Menu 的 submenu item 是 flex-row center，
+  // 会压扁两行结构导致字体重叠 —— 给子项 item span 加内联纵向布局覆盖。
+  const seatSubItemBody = seatBody.replace(
+    'className: AgentPresetSeat_module_css_default.item,',
+    'className: AgentPresetSeat_module_css_default.item, style: { flexDirection: "column" },'
+  );
+  const seatNew =
+    'items: [...state.options.filter((option) => option.trust !== "user").map((option) => {' + seatBody +
+    '\n\t\t\t\t}), ...(function () {\n' +
+    '\t\t\t\t\tconst user = state.options.filter((option) => option.trust === "user");\n' +
+    '\t\t\t\t\tif (user.length === 0) return [];\n' +
+    '\t\t\t\t\treturn [{\n' +
+    '\t\t\t\t\t\tid: "' + AGENT_PRESET_MARKER + '",\n' +
+    '\t\t\t\t\t\tlabel: (0, react_jsx_runtime.jsxs)("span", {\n' +
+    '\t\t\t\t\t\t\tclassName: AgentPresetSeat_module_css_default.item,\n' +
+    '\t\t\t\t\t\t\tchildren: [(0, react_jsx_runtime.jsx)("span", {\n' +
+    '\t\t\t\t\t\t\t\tclassName: AgentPresetSeat_module_css_default.itemName,\n' +
+    '\t\t\t\t\t\t\t\tchildren: t("menu.thirdPartyMode")\n' +
+    '\t\t\t\t\t\t\t}), (0, react_jsx_runtime.jsx)("span", {\n' +
+    '\t\t\t\t\t\t\t\tclassName: AgentPresetSeat_module_css_default.itemDesc,\n' +
+    '\t\t\t\t\t\t\t\tchildren: t("menu.thirdPartyModeHint")\n' +
+    '\t\t\t\t\t\t\t})]\n' +
+    '\t\t\t\t\t\t}),\n' +
+    '\t\t\t\t\t\tsubmenu: user.map((option) => {' + seatSubItemBody +
+    '\n\t\t\t\t\t\t})\n' +
+    '\t\t\t\t\t}];\n' +
+    '\t\t\t\t}())],\n\t\t\t\tselectedId: state.current,';
+  // 设置行（PresetMenu，纯文本 label）：同样收进 submenu，组内不再带「· 自定义」后缀
+  const rowNew =
+    'items: [...options.filter((option) => option.trust !== "user").map((option) => {' + rowBody +
+    '\n\t\t\t\t}), ...(function () {\n' +
+    '\t\t\t\t\tconst user = options.filter((option) => option.trust === "user");\n' +
+    '\t\t\t\t\tif (user.length === 0) return [];\n' +
+    '\t\t\t\t\treturn [{\n' +
+    '\t\t\t\t\t\tid: "' + AGENT_PRESET_MARKER + '",\n' +
+    '\t\t\t\t\t\tlabel: t("menu.thirdPartyMode"),\n' +
+    '\t\t\t\t\t\tsubmenu: user.map((option) => {\n' +
+    '\t\t\t\t\t\t\tconst name = presetDisplayText(option, t).name;\n' +
+    '\t\t\t\t\t\t\treturn { id: option.id, label: name };\n' +
+    '\t\t\t\t\t\t})\n' +
+    '\t\t\t\t\t}];\n' +
+    '\t\t\t\t}())],\n\t\t\t\tselectedId,';
+  const zhDictAdd = '\n\t\t\t"menu.thirdPartyMode": "第三方模式",\n\t\t\t"menu.thirdPartyModeHint": "自定义与 EAC 内置的 Agent 预设",';
+  const enDictAdd = '\n\t\t\t"menu.thirdPartyMode": "Third-party modes",\n\t\t\t"menu.thirdPartyModeHint": "Custom and EAC-bundled agent presets",';
+  // 先做 items 替换（用旧索引的 slice），再注入词典（词典锚点在 items 之前，不受 items 替换影响）
+  src = src
+    .replace(src.slice(seatStart, seatTail + AGENT_PRESET_SEAT_TAIL.length), seatNew)
+    .replace(src.slice(rowStart, rowTail + AGENT_PRESET_ROW_TAIL.length), rowNew)
+    .replace(AGENT_PRESET_ZH_ANCHOR, AGENT_PRESET_ZH_ANCHOR + zhDictAdd)
+    .replace(AGENT_PRESET_EN_ANCHOR, AGENT_PRESET_EN_ANCHOR + enDictAdd);
+  fs.writeFileSync(target, src);
+  console.log('[patch-deps] 已补丁 agent-preset：第三方模式收进二级菜单');
+  return true;
+}
+
+// Menu 二级菜单滚动补丁：dsh-web-frontend 主 bundle 里 primitives 的 submenu
+// 容器没有高度上限，preset 较多时子菜单超出视口且不可滚动。给 submenu 容器
+// 注入内联 max-height + overflow-y。rc.2 起 primitives 被打包进主 bundle
+// （dsh-web-frontend/dist/assets/index-*.js，压缩变量 xxx.submenu），不再有
+// 独立包 —— 目标改为扫描主 bundle。锚点：submenu.map( 前的 role:"menu",。
+// 幂等 marker: dsh-desktop:menu-submenu-hover（容器整段重建）+
+// --dsh-desktop-submenu-label（submenu 项两行布局）。
+// ⚠️ 锚点前提：下方所有字符串锚点在目标 bundle 里必须唯一，否则替换会误伤
+// 多处；新增/改动前需先 grep 确认唯一性。
+const MENU_SUBMENU_HOVER_MARKER = 'dsh-desktop:menu-submenu-hover';
+const MENU_SUBMENU_MAXH = 'calc(100dvh - 96px)';
+// 二级菜单宽度与一级菜单对齐：submenu 容器 fit-content 会被 label 里最长的
+// 不可断 token 撑到很窄（实测约 163px，一级菜单约 334px）。给 submenu 一个
+// 与一级菜单接近的 min-width，描述行更舒展。
+const MENU_SUBMENU_MINW = 320;
+const MENU_SUBMENU_ANCHOR = 'submenu.map(';
+// itemWrap 的 onMouseLeave 默认立即关闭，鼠标从一级菜单项移到二级菜单要
+// 跨过二者间隙会先触发离开而缩回。改为延迟关闭（600ms，留足缓慢移动跨
+// 间隙的时间），配合二级菜单自身的 onMouseEnter 取消定时器并保持，鼠标可
+// 平滑滑入。定时器存 window 全局，幂等重放安全。enter 也先清定时器，防止
+// 上一处 leave 排的关闭在移回时误触发。
+const ITEMWRAP_LEAVE_ANCHOR = 'onMouseLeave:()=>{z(null)}';
+const ITEMWRAP_LEAVE_NEW = 'onMouseLeave:()=>{clearTimeout(window.__dshMenuTimer);window.__dshMenuTimer=setTimeout(()=>z(null),600)}';
+// 上一版已打 300ms 延迟的 bundle，升级锚点改为 600ms
+const ITEMWRAP_LEAVE_UPGRADE_ANCHOR = 'setTimeout(()=>z(null),300)';
+const ITEMWRAP_LEAVE_UPGRADE_NEW = 'setTimeout(()=>z(null),600)';
+const ITEMWRAP_ENTER_ANCHOR = 'onMouseEnter:()=>{z(se?B.id:null)}';
+const ITEMWRAP_ENTER_NEW = 'onMouseEnter:()=>{clearTimeout(window.__dshMenuTimer);z(se?B.id:null)}';
+// submenu 自身 onMouseLeave 若立即 z(null)，从二级菜单移回一级菜单会先关掉
+// 二级菜单再重开，时序不稳表现为「移回后不再展开」。改为延迟 400ms，
+// 移回一级菜单时 itemWrap enter 清定时器并保持。
+const SUBMENU_LEAVE_ANCHOR = 'onMouseLeave:()=>{clearTimeout(window.__dshMenuTimer);z(null)}';
+const SUBMENU_LEAVE_NEW = 'onMouseLeave:()=>{clearTimeout(window.__dshMenuTimer);window.__dshMenuTimer=setTimeout(()=>z(null),400)}';
+// root span 的 onPointerLeave 默认立即关闭整个菜单。二级菜单是 portal 到 body
+// 的独立 DOM，鼠标从一级菜单跨过去必然离开 root span → 菜单（含二级）被立即
+// 收起，表现为「二级菜单还没展开就消失」。改为走同一延迟定时器（300ms），
+// 与 itemWrap / submenu 的 onMouseEnter 取消逻辑统一，鼠标可平滑滑入二级菜单。
+const ROOT_POINTERLEAVE_ANCHOR = 'onPointerLeave:_?()=>{n&&A()}:void 0';
+const ROOT_POINTERLEAVE_NEW = 'onPointerLeave:_?()=>{clearTimeout(window.__dshMenuTimer);window.__dshMenuTimer=setTimeout(()=>{n&&A()},300)}:void 0';
+// submenu 项两行布局补丁：Menu 的 .itemLabel 默认 white-space:nowrap +
+// overflow:hidden，会把 agent-preset 的两行 label（名称+描述）压扁裁成
+// 字体重叠。给 submenu 项注入内联覆盖：允许换行、内容可见、item 顶部对齐。
+// 幂等 marker 用 style 里的 CSS 自定义属性（React 支持 --xxx 键透传，
+// 未被引用则无副作用），避免破坏 JS 语法。
+const SUBMENU_ITEM_MARKER = '--dsh-desktop-submenu-label';
+const SUBMENU_BTN_ANCHOR = 'f.jsxs("button",{type:"button",role:"menuitem",className:Re.item,disabled:he.disabled';
+const SUBMENU_BTN_NEW = 'f.jsxs("button",{type:"button",role:"menuitem",className:Re.item,style:{alignItems:"flex-start",flexShrink:0},disabled:he.disabled';
+const SUBMENU_LABEL_ANCHOR = 'f.jsx("span",{className:Re.itemLabel,children:he.label})';
+const SUBMENU_LABEL_NEW = 'f.jsx("span",{className:Re.itemLabel,style:{whiteSpace:"normal",overflow:"visible","' + SUBMENU_ITEM_MARKER + '":"1"},children:he.label})';
+
+function patchMenuSubmenuScroll(file?: string): boolean {
+  let target = file;
+  if (!target) {
+    const dir = path.join(root, 'node_modules', '@deepseek-ai', 'dsh-web-frontend', 'dist', 'assets');
+    if (!fs.existsSync(dir)) {
+      console.log('[patch-deps] dsh-web-frontend 不存在，跳过');
+      return false;
+    }
+    const candidates = fs.readdirSync(dir).filter((f) => f.startsWith('index-') && f.endsWith('.js'));
+    for (const f of candidates) {
+      const full = path.join(dir, f);
+      if (fs.readFileSync(full, 'utf8').includes(MENU_SUBMENU_ANCHOR)) { target = full; break; }
+    }
+    if (!target) {
+      console.log('[patch-deps] 主 bundle 未含 submenu 渲染（版本可能已更新），跳过');
+      return false;
+    }
+  }
+  if (!fs.existsSync(target)) {
+    console.log('[patch-deps] 目标 bundle 不存在，跳过');
+    return false;
+  }
+  let src = fs.readFileSync(target, 'utf8');
+  let changed = false;
+  // 三个改动各自按锚点独立幂等，不再用单一 marker 门控整个 if 块——
+  // 旧版 bundle 已有 hover marker 时，后续新增的 minWidth / root pointerleave
+  // 改动仍要能补打上（锚点替换后原始文本消失，自然幂等）。
+
+  // 1) submenu 容器：悬停保持 + 高度/宽度自适应（minWidth 缺失才重建整段）
+  if (!src.includes('minWidth:' + MENU_SUBMENU_MINW)) {
+    const submenuIdx = src.indexOf(MENU_SUBMENU_ANCHOR);
+    const roleIdx = submenuIdx >= 0 ? src.lastIndexOf('role:"menu",', submenuIdx) : -1;
+    // role:"menu", 必须紧邻 submenu.map（submenu 容器的 role），距离过大说明命中了别处
+    if (submenuIdx < 0 || roleIdx < 0 || submenuIdx - roleIdx > 400) {
+      console.log('[patch-deps] Menu submenu 未匹配到目标代码（版本可能已更新），跳过');
+      return false;
+    }
+    // 替换 role:"menu", 到 submenu.map( 之间整段（旧版可能已注入 style + scroll marker）：
+    // 二级菜单悬停保持（onMouseEnter 取消关闭定时器并重新激活，onMouseLeave 关闭），
+    // 高度自适应视口（内容少自然高度，超高才滚动）、宽度对齐一级菜单，配合
+    // itemWrap / root 延迟关闭让鼠标可跨过一级菜单与二级菜单之间的间隙。
+    const newBlock = 'role:"menu",onMouseEnter:()=>{clearTimeout(window.__dshMenuTimer);z(B.id)},' + SUBMENU_LEAVE_NEW + ',style:{maxHeight:"' + MENU_SUBMENU_MAXH + '",overflowY:"auto",minWidth:' + MENU_SUBMENU_MINW + '},/*' + MENU_SUBMENU_HOVER_MARKER + '*/children:B.';
+    src = src.slice(0, roleIdx) + newBlock + src.slice(submenuIdx);
+    changed = true;
+    console.log('[patch-deps] 已补丁主 bundle：二级菜单悬停保持 + 高度/宽度自适应');
+  }
+
+  // 2) 一级菜单项：悬停离开延迟关闭（600ms，缓慢跨间隙不折叠）
+  if (src.includes(ITEMWRAP_LEAVE_ANCHOR)) {
+    src = src.replace(ITEMWRAP_LEAVE_ANCHOR, ITEMWRAP_LEAVE_NEW);
+    changed = true;
+    console.log('[patch-deps] 已补丁主 bundle：菜单项悬停离开延迟关闭（鼠标可跨间隙滑入二级菜单）');
+  } else if (src.includes(ITEMWRAP_LEAVE_UPGRADE_ANCHOR)) {
+    src = src.replace(ITEMWRAP_LEAVE_UPGRADE_ANCHOR, ITEMWRAP_LEAVE_UPGRADE_NEW);
+    changed = true;
+    console.log('[patch-deps] 已补丁主 bundle：菜单项悬停离开延迟加长到 600ms');
+  }
+
+  // 3) 菜单根：pointerleave 延迟关闭（二级菜单是 body portal，鼠标跨过去不再立即收起）
+  if (src.includes(ROOT_POINTERLEAVE_ANCHOR)) {
+    src = src.replace(ROOT_POINTERLEAVE_ANCHOR, ROOT_POINTERLEAVE_NEW);
+    changed = true;
+    console.log('[patch-deps] 已补丁主 bundle：菜单根 pointerleave 延迟关闭（二级菜单不再被立即收起）');
+  }
+
+  // 4) 一级菜单项 onMouseEnter 也清定时器：从二级菜单移回时，上一处 leave 排的
+  //    关闭定时器不会在移回后被误触发
+  if (src.includes(ITEMWRAP_ENTER_ANCHOR)) {
+    src = src.replace(ITEMWRAP_ENTER_ANCHOR, ITEMWRAP_ENTER_NEW);
+    changed = true;
+    console.log('[patch-deps] 已补丁主 bundle：菜单项悬停进入清关闭定时器（移回二级菜单保持）');
+  }
+
+  // 5) submenu 自身 onMouseLeave 改为延迟关闭：从二级菜单移回一级菜单不再先关再开
+  if (src.includes(SUBMENU_LEAVE_ANCHOR)) {
+    src = src.replace(SUBMENU_LEAVE_ANCHOR, SUBMENU_LEAVE_NEW);
+    changed = true;
+    console.log('[patch-deps] 已补丁主 bundle：二级菜单悬停离开延迟关闭（移回一级菜单保持）');
+  }
+  if (!src.includes(SUBMENU_ITEM_MARKER)) {
+    const btnIdx = src.indexOf(SUBMENU_BTN_ANCHOR);
+    const labelIdx = btnIdx >= 0 ? src.indexOf(SUBMENU_LABEL_ANCHOR, btnIdx) : -1;
+    if (btnIdx < 0 || labelIdx < 0) {
+      console.log('[patch-deps] Menu submenu item 未匹配到目标代码（版本可能已更新），跳过');
+    } else {
+      src = src.slice(0, btnIdx) + SUBMENU_BTN_NEW + src.slice(btnIdx + SUBMENU_BTN_ANCHOR.length);
+      const l2 = src.indexOf(SUBMENU_LABEL_ANCHOR, btnIdx);
+      src = src.slice(0, l2) + SUBMENU_LABEL_NEW + src.slice(l2 + SUBMENU_LABEL_ANCHOR.length);
+      changed = true;
+      console.log('[patch-deps] 已补丁主 bundle：submenu 项两行布局不再被裁剪');
+    }
+  }
+  if (changed) fs.writeFileSync(target, src);
+  return true;
+}
+
 function main(): void {
   patchPickerWorker();
   patchSettingsNavScroll();
   patchOptionalEscalationFields();
+  patchAgentPresetMenu();
+  patchMenuSubmenuScroll();
 }
 
 main();


### PR DESCRIPTION
## 做了什么

把「模式选择二级菜单」功能从 dsh-stt-v5 分支移植到上游最新的 TS 版 patch-deps。

上游已把 `scripts/patch-deps.js` 迁移为 `scripts/patch-deps.ts`，所以本功能也在 TS 版上重新实现，使 PR 只含折叠功能、不掺入 STT 提交。

## 改动内容

- `patchAgentPresetMenu`：把自定义/EAC 内置的 agent preset 收进「第三方模式」二级菜单，官方内置保留主列表；中英双语词典注入
- `patchMenuSubmenuScroll`：二级菜单滚动 + 高度/宽度自适应、两行布局（不再字体重叠/裁剪）、悬停保持（鼠标滑入/移回不折叠）
- 幂等：5 个锚点独立幂等，旧版已打补丁的 bundle 可平滑升级

## 验证

- `npm run build` / `npm run typecheck` 通过
- 补丁幂等：已打→跳过，无重复改动
- `npm test`：654 用例全过

## 涉及文件

- `dsh-desktop/scripts/patch-deps.ts`

## 回退

- 删除该补丁函数即可回到上游原行为（补丁是启动/构建期幂等应用，不影响运行数据）