### PR TITLE
fix(shell): 恢复 HTML5 文件拖拽（图片拖入会话）+ WebView2Loader 打包

### DIFF
--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -547,6 +547,9 @@ fn open_float_window(app: &tauri::AppHandle, session_id: &str) -> Result<bool, S
         .min_inner_size(480.0, 360.0)
         .decorations(false)
         .data_directory(data_dir)
+        // 关闭 Tauri 窗口级 drag&drop handler：否则 Windows 上页面收不到
+        // HTML5 拖拽（dragover/drop），图片/文件拖不进输入框。
+        .disable_drag_drop_handler()
         .initialization_script(&init);
     // 独立 data_directory = 独立 WebView2 环境（独立浏览器进程），不继承主窗
     // 的调试参数 —— 显式透传（保持 Tauri 默认禁用项不变；无该环境变量时零差异）。
@@ -592,6 +595,7 @@ fn open_recovery_center_window(app: &tauri::AppHandle) -> bool {
         .inner_size(980.0, 720.0)
         .min_inner_size(760.0, 520.0)
         .data_directory(data_dir)
+        .disable_drag_drop_handler()
         .focused(true);
     if let Err(e) = builder.build() {
         eprintln!("[shell] recovery-center window build failed: {}", e);
@@ -1217,6 +1221,9 @@ fn main() {
                                     .inner_size(1400.0, 900.0)
                                     .min_inner_size(960.0, 640.0)
                                     .decorations(false)
+                                    // 关闭窗口级 drag&drop handler，放行页面 HTML5 拖拽
+                                    //（否则图片/文件拖不进输入框，页面 dragover/drop 收不到）。
+                                    .disable_drag_drop_handler()
                                     .initialization_script(BRIDGE_JS);
                                     if let Err(e) = built.build() {
                                         eprintln!("[shell] main window build failed: {}", e);

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -191,3 +191,38 @@ if (existsSync(vendoredBashFix)) {
 }
 
 console.log('[stage] 完成：' + staged);
+
+// WebView2Loader.dll：webview2-com-sys 提供的 x64 loader，必须与壳 exe 同级
+// （否则 dsh-eac-shell.exe 启动即 0xC0000135 崩）。从 cargo registry 的
+// webview2-com-sys 包定位（tauri build 不再重新生成该文件）。
+{
+  const loader = (() => {
+    const homeDir = process.env.USERPROFILE || process.env.HOME || '';
+    const roots = [
+      path.join(process.env.CARGO_HOME || path.join(homeDir, '.cargo'), 'registry', 'src'),
+      path.join(homeDir, '.cargo', 'registry', 'src'),
+    ];
+    for (const base of roots) {
+      if (!existsSync(base)) continue;
+      const hits = readdirSync(base).sort().reverse();
+      for (const bucket of hits) {
+        const webview2Dir = path.join(base, bucket);
+        if (!existsSync(webview2Dir)) continue;
+        const subdirs = readdirSync(webview2Dir);
+        for (const dir of subdirs) {
+          if (!dir.startsWith('webview2-com-sys-')) continue;
+          const cand = path.join(webview2Dir, dir, 'x64', 'WebView2Loader.dll');
+          if (existsSync(cand)) return cand;
+        }
+      }
+    }
+    return '';
+  })();
+  const dest = path.join(staged, 'WebView2Loader.dll');
+  if (loader && existsSync(loader)) {
+    cpSync(loader, dest);
+    console.log('[stage] WebView2Loader.dll 已装配: ' + path.relative(root, dest));
+  } else {
+    console.warn('[stage] 未找到 WebView2Loader.dll（webview2-com-sys），安装包可能启动即崩');
+  }
+}

--- a/tauri-shell/tauri.conf.json
+++ b/tauri-shell/tauri.conf.json
@@ -20,7 +20,8 @@
     ],
     "resources": {
       "staged-resources/sidecar/": "sidecar/",
-      "staged-resources/dsh-desktop/": "dsh-desktop/"
+      "staged-resources/dsh-desktop/": "dsh-desktop/",
+      "staged-resources/WebView2Loader.dll": "./WebView2Loader.dll"
     },
     "windows": {
       "webviewInstallMode": {


### PR DESCRIPTION
## 背景
DSH EAC 5.1.0（Tauri 2 壳）下"图片/文件拖不进输入框"：
- 壳默认启用窗口级 drag&drop handler，Tauri 源码注释明确：Disables the drag and drop handler. This is required to use HTML5 drag and drop APIs on the frontend on Windows. — 需 disable_drag_drop_handler() 才能让页面收到 HTML5 dragover/drop。此前页面完全收不到拖拽，会话输入框的图片拖拽（宿主 attachment 原生 onDrop + onAddImages）彻底失效。
- 另：安装包缺 WebView2Loader.dll（exe 同级），安装后壳启动即崩（0xC0000135）。

## 改动
1. tauri-shell/src/main.rs：主窗 / 浮窗 / 恢复中心 3 处 WebviewWindowBuilder 追加 .disable_drag_drop_handler()
2. tauri-shell/stage-resources.mjs + tauri.conf.json：装配 x64 WebView2Loader.dll 到安装根（与 dsh-eac-shell.exe 同级）

## 验证
- 本地 cargo check / tauri build（NSIS）通过
- 安装新包后：图片可拖入输入框并出现缩略图（宿主原生附件拖拽恢复）

> 注：非图片文件（zip 等）拖入仍显示「无法获取完整路径」——Tauri HTML5 拖拽拿不到磁盘真实路径，可另立 PR（壳 FileDrop paths 通道）。
