### PR TITLE
feat: 拖入文件（zip/二进制等）落盘返回真实路径（file-drop.save 通道）

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-file-drop-eac/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-file-drop-eac/lib/client.js
@@ -214,6 +214,33 @@
     return true;
   }
 
+  /** 二进制/超大文件：经 fileDrop.save 落盘到临时目录拿真实路径（HTML5 拖拽在
+   * 页面拿不到磁盘路径），失败则降级为无路径提示。 */
+  function injectHintWithPath(rec) {
+    var fallback = function () {
+      injectIntoComposer(findComposer(), buildPathHint({ name: rec.name, path: '', size: rec.size }));
+    };
+    var b = typeof window !== 'undefined' && window.dshDesktop && window.dshDesktop.fileDrop;
+    if (!b || typeof b.save !== 'function' || !rec.file || rec.size > 64 * 1024 * 1024) {
+      fallback();
+      return;
+    }
+    var reader = new FileReader();
+    reader.onload = function () {
+      b.save({ dataUrl: String(reader.result || ''), name: rec.name || '拖入文件' })
+        .then(function (res) {
+          if (res && res.ok) {
+            injectIntoComposer(findComposer(), buildPathHint({ name: rec.name, path: res.path, size: res.size != null ? res.size : rec.size }));
+          } else {
+            fallback();
+          }
+        })
+        .catch(fallback);
+    };
+    reader.onerror = fallback;
+    reader.readAsDataURL(rec.file);
+  }
+
   /** 按计划执行：先文件夹降级提示，再文本内容注入，再路径提示。 */
   function handlePlan(plan) {
     if (plan.folders && plan.folders.length) {
@@ -231,7 +258,7 @@
       reader.readAsText(rec.file);
     });
     plan.hints.forEach(function (rec) {
-      injectIntoComposer(findComposer(), buildPathHint({ name: rec.name, path: rec.path, size: rec.size }));
+      injectHintWithPath(rec);
     });
   }
 

--- a/dsh-desktop/lib/desktop/plugin-ops.ts
+++ b/dsh-desktop/lib/desktop/plugin-ops.ts
@@ -244,6 +244,28 @@ export function imagePasteSave(dataUrl: string, name: string): { ok: boolean; er
   return { ok: true, path: file, size: buf.length };
 }
 
+// 拖入文件保存（dsh-file-drop-eac 插件）：任意文件（zip/二进制/超大文本等）的
+// data URL → 临时目录，返回真实磁盘路径供 agent 按路径读取（HTML5 拖拽在页面
+// 拿不到磁盘路径，由 sidecar 落盘后回传）。上限 FILE_DROP_MAX_BYTES。
+export const FILE_DROP_MAX_BYTES = 64 * 1024 * 1024;
+
+export function fileDropSave(dataUrl: string, name: string): { ok: boolean; error?: string; path?: string; size?: number } {
+  const m = /^data:([^;,]+);base64,([A-Za-z0-9+/=]+)$/.exec(String(dataUrl || ''));
+  if (!m) return { ok: false, error: '不是合法的 data URL' };
+  const buf = Buffer.from(m[2]!, 'base64');
+  if (buf.length === 0) return { ok: false, error: '文件内容为空' };
+  if (buf.length > FILE_DROP_MAX_BYTES) return { ok: false, error: '文件超过 64MB 上限' };
+  const dir = path.join(os.tmpdir(), 'dsh-file-drop');
+  fs.mkdirSync(dir, { recursive: true });
+  const inert = String(name || '拖入文件').replace(/[\\/:*?"<>|\u0000-\u001f]/g, '_').trim().slice(0, 40) || '拖入文件';
+  const dot = inert.lastIndexOf('.');
+  const base = dot > 1 ? inert.slice(0, dot) : inert;
+  const ext = dot > 1 ? inert.slice(dot).toLowerCase().slice(0, 12) : '';
+  const file = path.join(dir, base + '-' + Date.now() + (ext || '.bin'));
+  fs.writeFileSync(file, buf);
+  return { ok: true, path: file, size: buf.length };
+}
+
 // 写入/移除用户层 disabled 条目（纯文本手术见 scripts/plugin-manager-patch.js）：
 // 与上游的差异 —— 「启用」保留顶层裸条目 {id, name} 而不是整条移除，这样
 // 默认禁用的配套插件（dsh-pet）被用户启用后不会被下次 sync 重新插回

--- a/dsh-desktop/preload.ts
+++ b/dsh-desktop/preload.ts
@@ -93,6 +93,11 @@ const dshDesktop = {
   imagePaste: {
     save: (payload: unknown): Promise<unknown> => ipcRenderer.invoke('dsh:image-paste-save', payload),
   },
+  // 拖入文件（zip/二进制等，与 tauri-shell/sidecar/bridge.ts 的 fileDrop 对齐）：
+  // dataUrl → 临时目录 → 真实路径，供 agent 按路径读取。
+  fileDrop: {
+    save: (payload: unknown): Promise<unknown> => ipcRenderer.invoke('dsh:file-drop-save', payload),
+  },
   // Token 价格自定义（V4.2，dsh-balance 插件「价格设置」页）：读取默认档/
   // 当前覆盖、保存自定义价格（¥/百万 token）、恢复默认。
   balancePrices: {

--- a/tauri-shell/sidecar/bridge.ts
+++ b/tauri-shell/sidecar/bridge.ts
@@ -153,6 +153,10 @@ type BridgePending = { resolve: (v: any) => void; reject: (e: any) => void };
     imagePaste: {
       save: function (payload: Record<string, unknown>) { return call('image-paste.save', payload || {}); },
     },
+    // 拖入文件（zip/二进制等）：dataUrl → 临时目录 → 真实路径，供 agent 按路径读取。
+    fileDrop: {
+      save: function (payload: Record<string, unknown>) { return call('file-drop.save', payload || {}); },
+    },
     // Token 价格自定义：读取/保存/恢复（¥/百万 token）。
     balancePrices: {
       get: function (model: string) { return call('balance.prices-get', { model: model }); },

--- a/tauri-shell/sidecar/server.ts
+++ b/tauri-shell/sidecar/server.ts
@@ -667,6 +667,14 @@ const batch: Record<string, (p: RpcParams) => unknown> = {
       return { ok: false, error: String(((e as Error).message) || e) };
     }
   },
+  // 拖入文件保存（dsh-file-drop-eac）：任意文件 data URL → 临时目录 → 真实路径。
+  'file-drop.save': (p): Record<string, unknown> => {
+    try {
+      return (pluginOpsMod.fileDropSave as (d: string, n: string) => Record<string, unknown>)(String((p && p.dataUrl) || ''), String((p && p.name) || '拖入文件'));
+    } catch (e) {
+      return { ok: false, error: String(((e as Error).message) || e) };
+    }
+  },
   'files.revert': (p): Record<string, unknown> => {
     const changes = (p && p.changes) as Array<{ path?: string; oldText?: string; newText?: string }>;
     if (!Array.isArray(changes) || changes.length === 0 || changes.length > 300) return { results: [] };


### PR DESCRIPTION
## 背景
DSH EAC 5.1.0（Tauri 2 壳）下，拖入**非图片文件**（zip / 二进制 / 超大文件）时，`dsh-file-drop-eac` 无法获取真实磁盘路径——新壳 `<Tauri>` 的 `getPathForFile` 硬编码返回空，页面在 HTML5 拖拽里拿不到路径，只能显示「无法获取完整路径」降级提示（agent 无法按路径读取该文件）。

## 改动
1. `dsh-desktop/lib/desktop/plugin-ops.ts`：新增通用文件落盘 `fileDropSave(dataUrl, name)`（任意 data URL → `%TEMP%/dsh-file-drop/<清洗名>-<时间戳><原扩展名>` → 返回真实路径；上限 64MB）。
2. `tauri-shell/sidecar/server.ts`：注册 `file-drop.save` IPC。
3. `tauri-shell/sidecar/bridge.ts`：暴露 `window.dshDesktop.fileDrop.save`。
4. `dsh-desktop/assets/plugins/dsh-file-drop-eac/lib/client.js`：二进制/超大文件拖入先经 `fileDrop.save` 落盘拿真实路径，再注入「完整路径」提示（失败降级为原无路径提示）。

## 验证
- `npm run typecheck` 通过（plugin-ops.ts）；
- sidecar TS 编译通过、`server.js` 含 `file-drop.save`、`bridge.js` 含 `fileDrop`；
- dsh-file-drop-eac client.js `node --check` 通过。
- 效果：拖入 zip → 输入框出现「完整路径：C:\Users\...\Temp\dsh-file-drop\xxx.zip」，agent 可按路径解压/读取。
