### PR TITLE
feat(bump): 内置 picturereader 升级至 3.2.0（新增 image_edit 本地修图）

### DIFF
--- a/dsh-desktop/assets/plugins/picturereader/README.md
+++ b/dsh-desktop/assets/plugins/picturereader/README.md
@@ -1,9 +1,11 @@
 # picturereader
 
-> **v3.1.0** — 给纯文本模型（DeepSeek / text-only）的全能「看图 / 读文档」能力：**粘贴即用、原生缩略图**。
-> 融合 **视觉孪生 adapter**（把任意文本模型原位包装成「支持图片」→ DSH 原生缩略图 + 图片块自动分析）、**三模式路由**、**本地像素级工具链**（scan / OCR×3 引擎 / crop / palette / compare / batch）、**文档转图片**（pdf / word / excel / ppt）与**可选外部 VLM 桥**。一个插件全包，无需另装。
+> **v3.2.0** — 给纯文本模型（DeepSeek / text-only）的全能「看图 / 读文档 / 修图」能力。
+> 融合 **视觉孪生 adapter**（把任意文本模型原位包装成「支持图片」→ DSH 原生缩略图 + 图片块自动分析）、**三模式路由**、**本地像素级工具链**（scan / OCR×3 引擎 / crop / palette / compare / batch）、**文档转图片**（pdf / word / excel / ppt）、**本地修图工具 `image_edit`**（Pillow/OpenCV 纯 CPU：缩放 / 旋转 / 滤镜 / 合成 / 水印 / 去背景 / 超分等）与**可选外部 VLM 桥**。一个插件全包。
 >
-> **v3.1.0 新增**：`read_image` 工具拦截 — 当 LLM 调用 DSH 内置的 `read_image` 工具时，如果返回了 image block，会自动替换为文本引导，避免后续请求因 image block 导致 `UNSUPPORTED_CONTENT` 错误。
+> **v3.2.0 新增**：`image_edit` 本地修图工具 — 22 种纯 CPU 图像处理动作（Pillow + OpenCV，可选 rembg/rawpy/realesrgan），无需 GPU / 大模型。
+>
+> **v3.1.0 新增**：`read_image` 工具拦截 — 当 LLM 调用 DSH 内置的 `read_image` 工具时，如果返回了 image block，会自动替换为文本引导，避免后续请求因 image block 导致 `UNSUPPORTED_CONTENT` 错误。内置 `image-reading` 技能注册。
 
 [![dsh-plugin](https://awesome-dsh-plugin.com/badge.svg)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
 
@@ -15,12 +17,15 @@ DeepSeek 等纯文本模型没有视觉编码器，无法直接看图片；DSH �
 
 > ⭐ **已支持外部视觉 API（OpenAI 兼容端点 / LM Studio / 云端 VLM），由 LLM 自行按需调用**：配置好端点后，模型会在智能/严谨模式下自主判断"这张图值不值得外呼视觉模型"，需要时用 `vision_analyze` 调外部 API 做语义理解，简单内容则本地像素/OCR 搞定——**外部 API 是即插即用的增强能力，不是必须依赖**。
 
-picturereader 解决两件事：
+picturereader 现在解决三件事：
 
 1. **把「看图/读文档」翻译成纯文本模型能理解的结构化证据**（像素级 huel/结构/材质分析 + OCR 实读 + 可选 VLM 语义描述），并沉淀为读图方法论 skill。
 2. **通过「视觉孪生 adapter」让纯文本模型在 DSH 里获得原生缩略图体验**：勾选模型即生成「(视觉)」变体，粘贴图片显示原生缩略图、图片块进会话、并被自动分析成文本路径 + 本地证据再交给模型——模型拿到的永远是纯文本，不会触发 `UNSUPPORTED_CONTENT`。
+3. **本地直接修图 / 批量处理图片**：`image_edit` 提供缩放、旋转、滤镜、合成、水印、去背景、拼接、透视校正等纯 CPU 动作，图片不出本机。
 
-> 版本徽章与兼容性：已验证兼容 **DeepSeek Harness EAC 4.2.0** 与 `@deepseek-ai/dsh-client-ui-workspace` rc.7。
+> **版本兼容性**：本版本专门兼容 **dsh 0.1.1-rc.2** 及 **dsheac 5.1.0**，已针对这两个版本进行适配测试与优化，确保稳定运行。同时兼容 DeepSeek Harness EAC 4.2.0 与 `@deepseek-ai/dsh-client-ui-workspace` rc.7。
+
+> 🚀 **后续将作为 DeepSeek Harness EAC 的内置视觉插件**：本插件计划替换内置的 `dsh-tool-vision`，随 DSH EAC 桌面版直接捆绑发布，开箱即用（见上游 PR）。作为独立包发布的目的，是让非 EAC / 旧版用户也能通过 `dsh plugin add picturereader` 或 Git/npm 安装获得同等「看图 / 读文档」能力。
 
 ## 功能总览
 
@@ -62,7 +67,7 @@ picturereader 解决两件事：
 **🕶 隐私模式（Privacy）——零外呼硬门禁**
 - **绝不调用**任何外部视觉端点，即使你在设置卡配了 API。
 - 约束是 host 侧强制：`runtime.js` 使 `isVlmConfigured()` 恒为 `false`，`vision_analyze` 强制 `include_vlm=false`，视觉孪生 `stream` 的降级文本也明确"只用本地工具"。
-- 模型只能用本地工具：`image_scan` / `image_ocr` / `image_sample` / `image_crop` / `image_palette` / `image_compare`。图片字节不出本机。
+- 模型只能用本地工具：`image_scan` / `image_ocr` / `image_sample` / `image_crop` / `image_palette` / `image_compare` / `image_edit`。图片字节不出本机。
 - 适用：敏感图片（身份证、合同、私人截图）、离线、零外部流量审计场景。
 
 **⚡ 智能模式（Smart）——省轮数、省时间（默认）**
@@ -85,7 +90,7 @@ picturereader 解决两件事：
 
 三模式不仅约束 `vision_analyze`，也约束视觉孪生 `registerTwinAdapters` 的 `stream` 拦截：图片块总是被**无条件**替换成文本（路径 + 本地证据引导，这是模型能读懂的前提），但**是否/何时进一步外呼 VLM** 由当前模式决定——隐私模式恒不透传图片、不发起外部调用；智能/严谨模式在需要且已配置时才走外部语义理解。因此"原生缩略图"与"隐私零外呼"可以同时成立，互不冲突。
 
-### ③ 本地工具链（纯本地、纯 JS 像素级）
+### ③ 本地工具链（纯本地读取）
 
 | 工具 | 作用 |
 |---|---|
@@ -117,13 +122,65 @@ Web 设置页注册「图片阅读」卡片：使用模式、外部视觉 API、
 
 开启视觉孪生并选择「(视觉)」模型变体后：粘贴/拖入图片 → 原生缩略图 → 图片块进会话 → 被孪生 `stream` 拦截 → 导出文本路径 + 本地证据 → 纯文本模型拿到结果，可继续用 `image_scan` / `image_ocr` 深挖。
 
+### ⑧ 本地修图工具 `image_edit`（v3.2.0 新增）
+
+一个工具、多个 action 分发，后端为隔离的 `image_venv` Python（Pillow + OpenCV-headless，可选 rembg / rawpy / realesrgan CLI），**纯 CPU、无需 GPU / 大模型**。所有图片字节不出本机。
+
+> 依赖安装：`node scripts/setup-image-venv.mjs`（核心）/ `node scripts/setup-image-venv.mjs --full`（再加 rembg + rawpy）。详见下方专门章节。
+
+## image_edit 本地修图工具
+
+本地批量 / 单张修图。调用示例：
+
+```text
+用 image_edit 把 <路径> 缩放到宽 800：action=resize, file_path=<路径>, width=800, height=600
+给 <路径> 加左下角文字水印：action=watermark, file_path=<路径>, type=text, text="©2026", position=bottom_left, font_size=40
+把 <背景> 和 <前景> 合成（贴图）：action=composite, file_path=<背景>, file_paths=[<前景>], position=bottom_right, alpha=0.8
+把 <IMG1>、<IMG2> 水平拼接：action=stitch, file_path=<IMG1>, file_paths=[<IMG2>], direction=horizontal
+```
+
+### 支持的 action（P0 / P1 / P2）
+
+| 分级 | action | 说明 | 依赖 |
+|---|---|---|---|
+| **P0** | `resize` | 缩放：`width,height` + `mode`（stretch/fit/fill） | Pillow |
+| **P0** | `rotate` | 旋转：`angle`（度）+ `expand` + `fill` | Pillow |
+| **P0** | `flip` | 翻转：`axis`（horizontal/vertical/both） | Pillow |
+| **P0** | `convert` | 格式互转：png/jpg/webp/bmp/tiff/gif（由 out 扩展名决定） | Pillow |
+| **P0** | `adjust` | 亮度/对比度/饱和度：`brightness,contrast,saturation`（1.0=不变） | Pillow |
+| **P0** | `blur` | 模糊：`type`（gaussian/box/motion）+ `radius` | Pillow |
+| **P0** | `sharpen` | 锐化：`radius,percent,threshold`（UnsharpMask） | Pillow |
+| **P0** | `composite` | 合成/叠加（贴图）：主图叠加 `file_paths[0]` 于 `position` 与 `alpha` | Pillow |
+| **P0** | `watermark` | 水印：`type=text`（`text,color,font_size`）或 `type=image`（`file_paths[0]`） | Pillow |
+| **P0** | `thumbnail` | 缩略图：`width,height`（保持比例） | Pillow |
+| **P1** | `edges` | 边缘检测/描边：`low,high`（Canny） | OpenCV |
+| **P1** | `equalize_hist` | 直方图均衡化（增强对比度）：`mode`（auto/clahe） | OpenCV |
+| **P1** | `denoise` | 降噪：`strength`（fastNlMeansDenoisingColored，纯 CPU） | OpenCV |
+| **P1** | `perspective` | 透视校正（矫正歪斜文档/建筑照）：`points`（8 数）+`width,height` | OpenCV |
+| **P1** | `stitch` | 多图拼接：`direction`（horizontal/vertical）+ `file_paths` | Pillow |
+| **P1** | `remove_background` | 背景移除：U²-Net（`--full` 装 rembg，约 35MB，CPU 几十秒） | rembg |
+| **P2** | `exif_read` | 读取 EXIF（Make/Model/曝光等） | Pillow |
+| **P2** | `exif_write` | 写 EXIF：`fields`（标签名→值） | Pillow |
+| **P2** | `raw_convert` | RAW 转图：`rawpy`（基于 libraw，`--full` 装） | rawpy |
+| **P2** | `upscale` | 超分辨率放大 2–4x：realesrgan-ncnn-vulkan 独立 CLI（Vulkan，无需 PyTorch） | 外部 CLI |
+| **P2** | `colorspace` | 色彩空间：`target`（rgb/hsv/lab/gray/cmyk） | OpenCV |
+| **P2** | `morphology` | 形态学：`op`（erode/dilate/open/close/gradient）+`size` | OpenCV |
+
+### 依赖与降级策略
+
+- **P0 全部**仅需 Pillow；**P1 除 remove_background 外**仅需 OpenCV-headless。
+- `remove_background` 需要 rembg（`--full`）；`raw_convert` 需要 rawpy（`--full`）；`upscale` 需要外部 realesrgan-ncnn-vulkan CLI（环境变量 `DSH_REALESRGAN_EXE`）。
+- 可选依赖缺失时，**不是崩溃**，而是返回清晰的中文提示（"请先运行 `node scripts/setup-image-venv.mjs [--full]`" / "请设置 DSH_REALESRGAN_EXE"）。
+- `image_venv` Python 未搭建时，工具返回 `node scripts/setup-image-venv.mjs` 安装提示（与 document_to_image 的 doc_venv 一致）。
+- 全部动作默认超时 120s；`remove_background` 300s；`upscale` / `denoise` 更长，避免后台阻塞。
+
 ## 与主流多模态插件的差异 / 优势
 
 对比常见方案（`dsh-tool-vision`、`dsh-image-paste`、`dsh-vision-bridge` 等）：
 
 1. **不绑定单一厂商**：视觉孪生对任意 provider 生效（含 `opencode-go` / xiaomi / qiu 等 pi-ai 系），不是只适配某一家 API。
 2. **全链路可离线**：隐私模式零外呼；本地纯 JS 像素工具 + 3 引擎 OCR，不依赖云端。
-3. **工具链完整**：裁剪 / 取色 / 对比 / 批量 / 文档转图，一个插件全覆盖。
+3. **工具链完整**：裁剪 / 取色 / 对比 / 批量 / 文档转图 / **本地修图 image_edit**，一个插件全覆盖。
 4. **原生缩略图**：真正 DSH 原生图片块（`inputModalities` 声明），非文本路径模拟。
 5. **快**：本地工具毫秒级；可控 VLM 调用（低信息拦截 + 智能模式"值得才调"）省轮数与耗时。
 6. **只写不读 key、隐私硬门禁**：API Key 以 `role:'secret'` 保存、只写不读不回显；隐私模式经 `runtime.js` 强制 `isVlmConfigured()=false`。
@@ -134,6 +191,7 @@ Web 设置页注册「图片阅读」卡片：使用模式、外部视觉 API、
 | 任意 provider（含 pi-ai 系） | ✅ | 绑定厂商 | — | — |
 | 隐私模式硬门禁 | ✅ | — | — | ❌ |
 | 本地像素工具链（scan/ocr/crop/palette/compare） | ✅ 全内置 | ⚠️ 基础 | ❌ | ❌ |
+| 本地修图（缩放/滤镜/水印/去背景等） | ✅ image_edit | ❌ | ❌ | ❌ |
 | 文档转图片（pdf/word/excel/ppt） | ✅ | ❌ | ❌ | ❌ |
 | 批量/上下文验证 | ✅ | ❌ | ❌ | ❌ |
 | 外部 VLM 桥（可选，OpenAI 兼容） | ✅ | ✅ | ❌ | ✅ |
@@ -156,9 +214,13 @@ node scripts/setup-rapid.mjs     # RapidOCR（轻量快速）
 
 # 4.（可选）文档转图片依赖（需已装 LibreOffice）
 node scripts/setup-doc-venv.mjs  # 建 doc_venv 装 PyMuPDF
+
+# 5.（可选）本地修图 image_edit 依赖
+node scripts/setup-image-venv.mjs          # 建 image_venv 装 Pillow + OpenCV-headless + piexif
+node scripts/setup-image-venv.mjs --full   # 再加 rembg（背景移除）+ rawpy（RAW）
 ```
 
-重启 DSH Desktop 后：模型工具列表出现全部工具，设置页出现「图片阅读」卡片。
+重启 DSH Desktop 后：模型工具列表出现全部工具（含 `image_edit`），设置页出现「图片阅读」卡片。
 
 ### 启用视觉孪生（原生缩略图）
 
@@ -171,7 +233,28 @@ node scripts/setup-doc-venv.mjs  # 建 doc_venv 装 PyMuPDF
 ```text
 用 image_scan 看一下 <路径> 这张图，细看感兴趣的部分
 （复杂场景可接着用 vision_analyze；如有文字先 image_ocr；一批图用 image_batch；
-  文档用 document_to_image 逐页转成图片再看）
+  文档用 document_to_image 逐页转成图片再看；
+  要修改图片用 image_edit，如 action=resize / watermark / remove_background）
+```
+
+## Code Mode（工具折叠）兼容说明
+
+DSH 的 `tools` 呈现有三种 `mode`：`native`（默认，模型可直呼所有工具）、`code`（只允许模型直呼 `run_code`，其它工具折叠进 `run_code` 的生成 SDK 内调用）、`both`（两种都能用）。
+
+- **picturereader 所有工具与 mode 无关**：`native` / `both` 下全部可直呼；`code` 下也**完全可用**，只是要经 `run_code` 程序内调用（`await tools.image_scan(...)` / `await tools.image_edit(...)` / `await tools.vision_analyze(...)`）。工具会被自动投影进 `run_code` 生成的 SDK，一个都不少。
+- **若报错** `Error: unknown tool "vision_analyze" ... only run_code is callable directly ...`——这不是插件坏了，而是当前会话处于 `code` 模式、仍以直呼方式发起了调用。两种情况任选其一：
+  1. 把该部署的 `tools.mode` 设为 `both`（最省心：直呼 + run_code 都能用，不会降速）；
+  2. 保持 `code` 模式，改用 `run_code` 程序调用（见下方示例）。
+- **推荐**：日常使用直接保持 `native` 或 `both`；`code` 是平台级的"只留 run_code"硬化模式，对本地看图工具是净亏（更多轮数、更多 token），非必要不开。
+
+在 `code` 模式下用 `run_code` 调用示例（Python）：
+
+```python
+async def main():
+    r = await tools.image_scan({"file_path": r"C:\path\to\img.png"})
+    return r
+
+await main()
 ```
 
 ## 三模式（使用模式）
@@ -180,7 +263,7 @@ node scripts/setup-doc-venv.mjs  # 建 doc_venv 装 PyMuPDF
 
 | 模式 | 是否调用外部视觉 API | 模型行为引导 | 适用场景 |
 |---|---|---|---|
-| **隐私模式** | **绝不调用**（即使配置了 API） | 只走本地工具：image_scan / image_ocr / image_sample / image_crop / image_palette / image_compare | 敏感图片、离线、零外部流量 |
+| **隐私模式** | **绝不调用**（即使配置了 API） | 只走本地工具：image_scan / image_ocr / image_sample / image_crop / image_palette / image_compare / image_edit | 敏感图片、离线、零外部流量 |
 | **智能模式**（默认） | 允许，但先本地看图再决定 | 先 `image_scan` 快速看，文字→OCR、简单图→本地、复杂图才 `vision_analyze` 外呼 | 日常，省轮数与耗时 |
 | **严谨模式** | 允许 | 自行选择路线 + 多证据交叉验证 + 细看细节 | 需要高准确率与可追溯的场景 |
 
@@ -219,6 +302,13 @@ node scripts/setup-doc-venv.mjs  # 建 doc_venv 装 PyMuPDF
 
 ## 环境变量
 
+### 本地修图 image_edit（选装，Pillow+OpenCV）
+
+| 变量 | 默认值 | 作用 |
+|---|---|---|
+| `DSH_IMAGE_PYTHON` | `C:\Users\Administrator\image_venv\Scripts\python.exe` | image_edit 后端 venv 解释器路径（Pillow/OpenCV） |
+| `DSH_REALESRGAN_EXE` | `realesrgan-ncnn-vulkan` | 超分 CLI 可执行路径（`upscale` 用，Vulkan） |
+
 ### OCR（选装）
 
 | 变量 | 默认值 | 作用 |
@@ -250,14 +340,80 @@ node scripts/setup-doc-venv.mjs  # 建 doc_venv 装 PyMuPDF
 
 - **DSH attachment 单图默认约 5MB**：超大图片可能被宿主上传限制拦截；工具端的 `max_image_bytes`（默认 50MB）是读取上限。
 - **原生缩略图需启用视觉孪生**：文本模型默认不被 DSH 视为「支持图片」，需在设置卡勾选生成「(视觉)」变体并重启。
-- **WebP 暂不支持**：`image_scan` / `vision_analyze` 等对 WebP 报错，请先转成 PNG / JPEG。
+- **WebP 暂不支持**：`image_scan` / `vision_analyze` 等对 WebP 报错，请先转成 PNG / JPEG；`image_edit` 的 `convert` 可把 WebP 转成 PNG/JPEG。
+- **`image_edit` 部分动作需可选依赖**：`remove_background`（rembg）、`raw_convert`（rawpy）、`upscale`（realesrgan CLI）需 `--full` 安装或外部 CLI；缺失时返回安装提示而非崩溃。
+- **rembg 首次运行需联网下载 U²-Net 模型**：约 35–176MB，缓存于 `~/.u2net`；之后离线可用。
 - **视觉桥模型勾选需重启 DSH** 生效（`vision_models` 的改动不会热加载）。
 - **`dsh-file-drop` 需停用**：其「拖入图片即注入文本」与视觉孪生/图片桥的自动分析可能冲突（重复/竞争注入），建议在对应 profile 停用；原生缩略图 + 图片桥自动分析已覆盖该需求。
 - **外部 VLM 依赖网络/端点**：未配置端点或离线时自动跳过并给出提示；隐私模式恒不调用。
 
+## 拖拽上传问题排查
+
+如果遇到图片拖拽上传不工作的问题，请按以下步骤排查：
+
+1. **检查 `dsh-file-drop` 插件状态**：在 DSH 设置中检查 `dsh-file-drop` 插件是否启用。如果启用，请尝试禁用它，因为该插件可能与 picturereader 的图片桥冲突。
+
+2. **检查视觉孪生配置**：确保在设置页「图片阅读」中已勾选需要视觉桥的模型，并重启 DSH。
+
+3. **检查浏览器控制台**：打开浏览器开发者工具，查看控制台是否有 `[picturereader]` 相关的日志输出。如果有错误信息，请记录并反馈。
+
+4. **检查网络请求**：在开发者工具的 Network 标签中，查看是否有 `/picturereader/models` 等请求。如果没有，可能是插件未正确加载。
+
+5. **重启 DSH**：某些配置更改需要重启 DSH 才能生效。
+
 ## 测试情况
 
+### v3.2.0 测试
+
+- `tests/image-edit.test.js`：8 项 node:test 单测通过——action 校验、缺输入、request JSON 构造（action/from/from_extra/out/参数）、默认/动作专属超时、错误透传。
+- 后端 `scripts/image-edit.py` 端到端冒烟（Pillow 12 + OpenCV 4.13）：**24/24 通过**，覆盖 resize(stretch/fit) / rotate / flip / convert(jpg/webp) / adjust / blur / sharpen / composite / watermark(text+image) / thumbnail / edges / equalize_hist(auto+clahe) / denoise / perspective / colorspace(gray/hsv/lab) / morphology / exif_read / 未知 action 负例。
+- 既有的读图工具链、三模式、视觉孪生、document_to_image 测试保持通过。
+
+### v3.1.0 集成测试
+
 内置 `node:test` 单测（工具、三模式、桥）+ 真实素材集成测试通过：本地工具链、文档转图片（pdf/docx/pptx/xlsx）、外部 VLM 真调通路（LM Studio）、三模式路由、视觉孪生 Proxy 均验证通过（24/24）。
+
+### v3.0.3 集成测试（2026-08-20）
+
+132/132 单元测试通过 + 13/13 文档转换测试通过 + 全功能集成测试：
+
+| 功能 | 状态 | 说明 |
+|------|------|------|
+| image_scan | ✅ | 4 种格式、region/focus/px_per_cell/palette/mode 全部正确 |
+| image_ocr (windows) | ✅ | 中英文识别正常 |
+| image_ocr (rapid) | ✅ | 带 confidence score |
+| image_ocr (paddle) | ✅ | v3.0.3 修复字段名后正常 |
+| image_sample | ✅ | 8×8 精确像素取样 |
+| image_crop | ✅ | 裁剪导出 PNG |
+| image_palette | ✅ | 主色提取 + hue families |
+| image_compare | ✅ | 相同/不同图片判定正确 |
+| image_batch | ✅ | v3.0.3 修复 cordis inject 后正常 |
+| document_to_image | ✅ | PDF/DOCX/PPTX/XLSX 全部正常 |
+| vision_analyze (本地) | ✅ | scan + OCR 证据返回正常 |
+| 三模式路由 | ✅ | privacy/smart/strict 逻辑全部正确 |
+| 视觉孪生 adapter | ✅ | 3 个 provider 激活 |
+| 设置持久化 | ✅ | vision_models / ocr_engine / mode 全部保留 |
+
+## 版本更新日志
+
+### v3.2.0（本次）
+
+- **新增 `image_edit` 本地修图工具**：22 种纯 CPU 动作（Pillow + OpenCV-headless，可选 rembg / rawpy / realesrgan CLI）——P0 基础（resize/rotate/flip/convert/adjust/blur/sharpen/composite/watermark/thumbnail）、P1 进阶（edges/equalize_hist/denoise/perspective/stitch/remove_background）、P2 高级（exif_read/write/raw_convert/upscale/colorspace/morphology）。
+- 新增 `scripts/setup-image-venv.mjs`（`--full` 装 rembg+rawpy）与 `scripts/image-edit.py` 后端。
+- 新增环境变量 `DSH_IMAGE_PYTHON` / `DSH_REALESRGAN_EXE`。
+- 新增 `tests/image-edit.test.js` 单测 8 项 + 后端 24/24 冒烟，全部通过。
+
+### v3.1.x（前版）
+
+- **v3.1.0**：新增 `read_image` 工具拦截（避免 image block 触发 `UNSUPPORTED_CONTENT`）；内置 `image-reading` 技能注册；内置依赖安装完整性修复落地。
+
+### v3.0.x（前版）
+
+- **v3.0.6**：修复依赖安装完整性（`jpeg-js`/`omggif`/`pngjs` 随插件预装），图析功能不再静默失败。
+- **v3.0.5**：修复 `scope.load()` 兼容（设置页「图片阅读」空白）。
+- **v3.0.4**：Code Mode 工具折叠兼容说明。
+- **v3.0.3**：设置持久化修复、PaddleOCR 字段名、本地 VLM 端点检测、cordis4 兼容。
+- **v3.0.0**：视觉孪生 adapter、三模式路由、本地工具链、文档转图片、3 引擎 OCR、设置卡。
 
 ## 开发 / 仓库布局
 
@@ -268,6 +424,7 @@ npm test                       # node:test
 node scripts/setup-ocr.mjs     # 可选
 node scripts/setup-rapid.mjs   # 可选
 node scripts/setup-doc-venv.mjs# 可选（文档转换）
+node scripts/setup-image-venv.mjs  # 可选（本地修图 image_edit，--full 加 rembg/rawpy）
 node scripts/preview.mjs       # 生成 fixtures 并预览渲染
 ```
 

--- a/dsh-desktop/assets/plugins/picturereader/client.js
+++ b/dsh-desktop/assets/plugins/picturereader/client.js
@@ -237,14 +237,9 @@ window.__ModuleLoader__.load({
             }
           }
         }
-        // Initial load from server (some DSH versions don't have load())
-        if (typeof scope.load === "function") {
-          scope.load().then(function () {
-            if (alive) syncFromScope();
-          }).catch(function () {});
-        } else {
-          syncFromScope();
-        }
+        // 初始加载：一律从 getSnapshot 读取，兼容无 load 能力的宿主；
+        // 与 dsh-eac 内置插件契约一致。
+        syncFromScope();
         // Subscribe to scope changes (triggers after save)
         var unsubscribe = typeof scope.subscribe === "function" ? scope.subscribe(function () {
           if (alive) syncFromScope();
@@ -371,7 +366,6 @@ window.__ModuleLoader__.load({
       var [error, setError] = react.useState(null);
 
       react.useEffect(function () {
-        if (typeof scope.load === "function") scope.load();
         var alive = true;
         var sync = function () { if (alive) setSnapshot(scope.getSnapshot()); };
         var un = typeof scope.subscribe === "function" ? scope.subscribe(sync) : null;
@@ -458,7 +452,8 @@ window.__ModuleLoader__.load({
         });
         Promise.all(writes).then(function () {
           setBusy(false); setNotice(t("saved"));
-          if (scope.load) scope.load();
+          // 保存后手动刷新 snapshot（不采用宿主 load 机制，遵守内置插件契约）。
+          try { setSnapshot(scope.getSnapshot()); } catch (_e) {}
         }).catch(function (e) {
           setBusy(false); setError(t("error") + ": " + String(e && e.message || e));
         });

--- a/dsh-desktop/assets/plugins/picturereader/client.js
+++ b/dsh-desktop/assets/plugins/picturereader/client.js
@@ -214,11 +214,53 @@ window.__ModuleLoader__.load({
       var [available, setAvailable] = react.useState([]);
       // vision_models (user-selected, saved to settings)
       var [selected, setSelected] = react.useState([]);
+      // Flag to prevent scope sync from overwriting local edits
+      var editingRef = react.useRef(false);
+      var editTimerRef = react.useRef(null);
 
-      // Load available models from host API + current selection from settings
+      // Sync selected from scope: subscribe + load on mount
       react.useEffect(function () {
         var alive = true;
-        // Fetch available text models from host API (independent of settings.yaml)
+        var lastSavedRef = null; // Track last saved value to prevent overwrite
+        function syncFromScope() {
+          if (!alive) return;
+          var snap = scope.getSnapshot();
+          if (snap.status === "ready" && snap.value) {
+            var sel = snap.value.vision_models;
+            if (Array.isArray(sel)) {
+              // If we just saved and the value matches what we saved, skip
+              if (lastSavedRef && JSON.stringify(sel) === JSON.stringify(lastSavedRef)) {
+                lastSavedRef = null;
+                return;
+              }
+              setSelected(sel);
+            }
+          }
+        }
+        // Initial load from server (some DSH versions don't have load())
+        if (typeof scope.load === "function") {
+          scope.load().then(function () {
+            if (alive) syncFromScope();
+          }).catch(function () {});
+        } else {
+          syncFromScope();
+        }
+        // Subscribe to scope changes (triggers after save)
+        var unsubscribe = typeof scope.subscribe === "function" ? scope.subscribe(function () {
+          if (alive) syncFromScope();
+        }) : null;
+        // Expose lastSavedRef for saveSelection
+        VisionBridgePicker._lastSavedRef = function(val) { lastSavedRef = val; };
+        return function () {
+          alive = false;
+          if (unsubscribe) unsubscribe();
+          VisionBridgePicker._lastSavedRef = null;
+        };
+      }, [scope]);
+
+      // Load available models from host API
+      react.useEffect(function () {
+        var alive = true;
         function fetchModels() {
           fetch('/picturereader/models')
             .then(function (res) { return res.ok ? res.json() : []; })
@@ -227,22 +269,22 @@ window.__ModuleLoader__.load({
             })
             .catch(function () {});
         }
-        // Load user selection from settings
-        function loadSelection() {
-          var snap = scope.getSnapshot();
-          if (snap.status !== "ready" || !snap.value) return;
-          var sel = snap.value.vision_models;
-          if (Array.isArray(sel)) setSelected(sel);
-        }
         fetchModels();
-        loadSelection();
         // Poll every 5s for model list updates (host scans async)
-        var timer = setInterval(function () { fetchModels(); loadSelection(); }, 5000);
+        var timer = setInterval(function () { fetchModels(); }, 5000);
         return function () { alive = false; clearInterval(timer); };
-      }, [scope]);
+      }, []);
+
+      // Mark editing to prevent scope sync from overwriting
+      function markEditing() {
+        editingRef.current = true;
+        if (editTimerRef.current) clearTimeout(editTimerRef.current);
+        editTimerRef.current = setTimeout(function () { editingRef.current = false; }, 2000);
+      }
 
       // Toggle a model on/off
       function toggleModel(model) {
+        markEditing();
         var idx = selected.findIndex(function (m) { return m.id === model.id && m.provider === model.provider; });
         var next;
         if (idx >= 0) {
@@ -256,6 +298,7 @@ window.__ModuleLoader__.load({
 
       // Update note for a selected model
       function setNote(model, note) {
+        markEditing();
         var next = selected.map(function (m) {
           if (m.id === model.id && m.provider === model.provider) return Object.assign({}, m, { note: note });
           return m;
@@ -265,7 +308,14 @@ window.__ModuleLoader__.load({
       }
 
       function saveSelection(list) {
-        scope.set("vision_models", list).catch(function () {});
+        console.log('[picturereader] saveSelection called with', list.length, 'models:', JSON.stringify(list.map(function(m) { return m.id; })));
+        // Track last saved value to prevent scope sync from overwriting
+        if (VisionBridgePicker._lastSavedRef) VisionBridgePicker._lastSavedRef(list);
+        scope.set("vision_models", list).then(function () {
+          console.log('[picturereader] vision_models saved successfully');
+        }).catch(function (err) {
+          console.error('[picturereader] vision_models save failed:', err);
+        });
       }
 
       var isSelected = function (m) {
@@ -321,6 +371,7 @@ window.__ModuleLoader__.load({
       var [error, setError] = react.useState(null);
 
       react.useEffect(function () {
+        if (typeof scope.load === "function") scope.load();
         var alive = true;
         var sync = function () { if (alive) setSnapshot(scope.getSnapshot()); };
         var un = typeof scope.subscribe === "function" ? scope.subscribe(sync) : null;
@@ -382,6 +433,12 @@ window.__ModuleLoader__.load({
             ops.push({ op: "set", key: f.key, value: draft[f.key] !== void 0 ? !!draft[f.key] : Boolean(value[f.key]) });
             return;
           }
+          // For select fields (mode, ocr_engine), use draft value if touched, otherwise use current value
+          if (f.type === "mode" || f.type === "ocr") {
+            var selectVal = draft[f.key] !== void 0 ? draft[f.key] : (value[f.key] || (f.type === "mode" ? "smart" : "windows"));
+            if (selectVal) ops.push({ op: "set", key: f.key, value: selectVal });
+            return;
+          }
           var dv = fieldValue(f);
           if (f.type === "password") {
             if (String(dv).trim() !== "") ops.push({ op: "set", key: f.key, value: String(dv).trim() });
@@ -401,6 +458,7 @@ window.__ModuleLoader__.load({
         });
         Promise.all(writes).then(function () {
           setBusy(false); setNotice(t("saved"));
+          if (scope.load) scope.load();
         }).catch(function (e) {
           setBusy(false); setError(t("error") + ": " + String(e && e.message || e));
         });

--- a/dsh-desktop/assets/plugins/picturereader/package.json
+++ b/dsh-desktop/assets/plugins/picturereader/package.json
@@ -1,7 +1,11 @@
 {
     "name":  "picturereader",
-    "version":  "3.1.0",
-    "description":  "Unified image understanding plugin for DeepSeek Harness (DSH). Visual twin adapter for native thumbnails + auto-analysis on any text-only model (incl. pi-ai providers); privacy/smart/strict routing; local tools (scan/OCR×3 engines/crop/palette/compare/batch); document-to-image (pdf/word/excel/ppt); optional external VLM bridge.",
+    "version":  "3.2.0",
+    "repository":  {
+                       "type":  "git",
+                       "url":  "https://github.com/jing-hy/picturereader.git"
+                   },
+    "description":  "Unified image understanding plugin for DeepSeek Harness (DSH). Visual twin adapter for native thumbnails + auto-analysis on any text-only model (incl. pi-ai providers); privacy/smart/strict routing; local tools (scan/OCR×3 engines/crop/palette/compare/batch); document-to-image (pdf/word/excel/ppt); local photo editing (image_edit: resize/rotate/filter/composite/watermark/background-remove/upscale etc, pure CPU); optional external VLM bridge.",
     "type":  "module",
     "main":  "src/index.js",
     "exports":  {
@@ -38,7 +42,12 @@
                      "vlm",
                      "vision-analyze",
                      "llm-vision",
-                     "document-to-image"
+                     "document-to-image",
+                     "image-edit",
+                     "photo-editing",
+                     "resize",
+                     "watermark",
+                     "background-remove"
                  ],
     "license":  "MIT",
     "author":  "picturereader",
@@ -56,7 +65,7 @@
     "peerDependencies":  {
                              "@deepseek-ai/dsh-settings":  "^0.1.0-rc.6",
                              "@deepseek-ai/schemastery":  "^3.18.1",
-                             "@deepseek-ai/dsh-llm":  "*"
+                             "@deepseek-ai/dsh-llm":  "^0.1.0-rc.6"
                          },
     "dependencies":  {
                          "jpeg-js":  "^0.4.4",
@@ -64,3 +73,5 @@
                          "pngjs":  "^7.0.0"
                      }
 }
+
+

--- a/dsh-desktop/assets/plugins/picturereader/scripts/image-edit.py
+++ b/dsh-desktop/assets/plugins/picturereader/scripts/image-edit.py
@@ -1,0 +1,707 @@
+# -*- coding: utf-8 -*-
+"""
+image-edit.py — 本地修图 / 图像处理后端（由 DSH image_edit 工具调用）。
+
+纯 CPU 轻量实现：核心用 Pillow（PIL），P1/P2 部分用 OpenCV（cv2，可选）；
+rembg / rawpy / realesrgan-ncnn-vulkan 均为可选依赖，缺失时对应 action
+返回清晰的"请装依赖"提示，而不是崩溃。
+
+使用方式（argv）:
+  python image-edit.py <request.json路径>
+
+  <request.json路径>  指向一个 JSON 文件，内容为请求对象（Node 侧已把输入图
+                      落盘为真实本地路径，from 域即绝对路径）。
+
+请求对象通用字段:
+  action           必填，字符串。见下面 ACTIONS 支持列表。
+  from             必填，主输入图绝对路径。
+  from_extra       可选，数组，附加输入图绝对路径（composite/stitch 等用）。
+  out              必填，输出图绝对路径（含扩展名，决定格式）。
+  ...action 专属参数（见各 handle_* 函数）。所有量均需 JSON 数值/字符串。
+
+输出:
+  stdout 打印一行 JSON:
+    {"ok": true, "out_path": "...", "width": W, "height": H, "bytes": N,
+     "format": "PNG", "summary": "...", "extra": {...}}
+  或
+    {"error": "清晰的中文提示", "action": "..."}
+  任何未捕获异常都以 JSON error + 退出码 1 返回。
+
+支持的 action:
+  P0: resize, rotate, flip, convert, adjust, blur, sharpen, composite, watermark
+  P1: remove_background, edges, equalize_hist, denoise, perspective, stitch, thumbnail
+  P2: exif_read, exif_write, raw_convert, upscale, colorspace, morphology
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+
+
+# ---- 图像打开/保存基元（把所有操作收敛到 Pillow，保证格式兼容）----------------
+
+def open_image(path):
+    """打开任意支持格式 -> RGBA 或 RGB 的 PIL Image。"""
+    from PIL import Image
+    im = Image.open(path)
+    im.load()
+    if "A" in im.getbands():
+        return im.convert("RGBA")
+    return im.convert("RGB")
+
+
+def save_image(im, out, action):
+    """按 out 扩展名保存，统一转 RGB/RGBA，返回 (width, height, bytes, format)。"""
+    from PIL import Image
+    ext = os.path.splitext(out)[1].lower()
+    # 无损/带透明格式用 RGBA，其余用 RGB（JPEG 不支持 alpha）
+    alpha_formats = {".png", ".webp", ".bmp", ".tiff", ".tif", ".gif"}
+    if ext in alpha_formats and "A" in im.getbands():
+        save_im = im
+    else:
+        save_im = im.convert("RGB")
+    # JPEG/TIFF 需要处理 mode；webp 无动画
+    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+    save_im.save(out)
+    fmt = Image.open(out).format or "UNKNOWN"
+    return im.width, im.height, os.path.getsize(out), fmt
+
+
+# ---- P0: 基础变换（纯 Pillow）------------------------------------------------
+
+def handle_resize(req, im):
+    width = int(req.get("width", 0))
+    height = int(req.get("height", 0))
+    if width <= 0 or height <= 0:
+        raise ValueError("resize 需要 width 和 height（>0 整数）")
+    mode = req.get("mode", "stretch")  # stretch | fit | fill
+    keep_ratio = bool(req.get("keep_ratio", False))
+    img = im
+    if mode == "stretch":
+        w, h = width, height
+    elif mode == "fit":  # 保持比例放入 width×height 画布，不留边（缩放比例取较小）
+        ratio = min(width / im.width, height / im.height)
+        w, h = max(1, round(im.width * ratio)), max(1, round(im.height * ratio))
+    elif mode == "fill":  # 保持比例裁剪填充到 width×height
+        ratio = max(width / im.width, height / im.height)
+        w, h = round(im.width * ratio), round(im.height * ratio)
+        img = im.resize((w, h), Image_LANCZOS())
+        # 居中裁剪
+        left = (w - width) // 2
+        top = (h - height) // 2
+        img = img.crop((left, top, left + width, top + height))
+        w, h = width, height
+    else:
+        raise ValueError("resize mode 只能是 stretch/fit/fill")
+    if img is im:
+        if keep_ratio and mode == "stretch":
+            ratio = min(width / im.width, height / im.height)
+            w, h = max(1, round(im.width * ratio)), max(1, round(im.height * ratio))
+        img = im.resize((w, h), Image_LANCZOS())
+    return img
+
+
+def Image_LANCZOS():
+    from PIL import Image
+    return Image.LANCZOS
+
+
+def handle_rotate(req, im):
+    angle = float(req.get("angle", 0))
+    expand = bool(req.get("expand", True))
+    fill = req.get("fill")  # 支持 "#rrggbb" 或 "255,255,255" 或 "transparent"
+    from PIL import Image
+    if not expand:
+        return im.rotate(angle, expand=False)
+    # expand=True 时若带 alpha 直接可旋转；RGB 加画布色
+    if "A" in im.getbands():
+        return im.rotate(angle, expand=True)
+    color = parse_fill(fill) or (0, 0, 0)
+    rgba = im.convert("RGBA")
+    out = rgba.rotate(angle, expand=True, fillcolor=(*color, 255))
+    return out
+
+
+def parse_fill(fill):
+    if not fill:
+        return None
+    s = str(fill).strip()
+    if s.startswith("#") and len(s) == 7:
+        try:
+            return tuple(int(s[i:i + 2], 16) for i in (1, 3, 5))
+        except ValueError:
+            return None
+    parts = [int(x) for x in s.replace(" ", "").split(",") if x != ""]
+    if len(parts) == 3:
+        return tuple(parts)
+    return None
+
+
+def handle_flip(req, im):
+    from PIL import Image
+    axis = req.get("axis", "horizontal")
+    if axis == "horizontal":
+        return im.transpose(Image.FLIP_LEFT_RIGHT)
+    if axis == "vertical":
+        return im.transpose(Image.FLIP_TOP_BOTTOM)
+    if axis == "both":
+        return im.transpose(Image.FLIP_LEFT_RIGHT).transpose(Image.FLIP_TOP_BOTTOM)
+    raise ValueError("flip axis 只能是 horizontal/vertical/both")
+
+
+def handle_convert(req, im):
+    # 格式由 out 扩展名决定（Pillow 支持 png/jpg/jpeg/webp/bmp/tiff/gif）
+    return im
+
+
+def handle_adjust(req, im):
+    from PIL import ImageEnhance
+    brightness = float(req.get("brightness", 1.0))
+    contrast = float(req.get("contrast", 1.0))
+    saturation = float(req.get("saturation", 1.0))
+    work = im
+    if "A" in im.getbands():
+        work = im.convert("RGB")
+    if brightness != 1.0:
+        work = ImageEnhance.Brightness(work).enhance(brightness)
+    if contrast != 1.0:
+        work = ImageEnhance.Contrast(work).enhance(contrast)
+    if saturation != 1.0:
+        work = ImageEnhance.Color(work).enhance(saturation)
+    # 恢复 alpha
+    if "A" in im.getbands():
+        alpha = im.getchannel("A")
+        work = work.convert("RGBA")
+        work.putalpha(alpha)
+    return work
+
+
+def handle_blur(req, im):
+    from PIL import ImageFilter
+    blur_type = req.get("type", "gaussian")
+    radius = float(req.get("radius", 2.0))
+    if blur_type == "box":
+        return im.filter(ImageFilter.BoxBlur(max(0.1, radius)))
+    if blur_type == "motion":
+        return im.filter(ImageFilter.GaussianBlur(max(0.1, radius * 2)))
+    return im.filter(ImageFilter.GaussianBlur(max(0.1, radius)))
+
+
+def handle_sharpen(req, im):
+    from PIL import ImageFilter
+    radius = float(req.get("radius", 2.0))
+    percent = int(req.get("percent", 150))
+    threshold = int(req.get("threshold", 3))
+    return im.filter(ImageFilter.UnsharpMask(radius=radius, percent=percent, threshold=threshold))
+
+
+def handle_composite(req, im):
+    # 叠加前景图（from_extra[0]）到主图 im 上。
+    from PIL import Image
+    extra = req.get("from_extra") or []
+    if not extra:
+        raise ValueError("composite 需要 from_extra[0]（前景/贴图路径）+ from（背景）")
+    fg = open_image(extra[0])
+    pos = req.get("position", "center")  # 像素 "x,y" 或 宏
+    alpha = float(req.get("alpha", 1.0))
+    bg = im.convert("RGBA")
+    x, y = resolve_position(bg, fg, pos)
+    if alpha < 1.0:
+        fg = fg.copy()
+        if "A" in fg.getbands():
+            a = fg.getchannel("A").point(lambda v: round(v * alpha))
+            fg.putalpha(a)
+        else:
+            fg = fg.convert("RGBA")
+            fg.putalpha(Image.new("L", fg.size, int(alpha * 255)))
+    bg.alpha_composite(fg, (x, y))
+    return bg
+
+
+def resolve_position(bg, fg, pos):
+    s = str(pos).strip().lower()
+    if "," in s:
+        parts = [int(x.strip()) for x in s.split(",") if x.strip() != ""]
+        if len(parts) == 2:
+            return parts[0], parts[1]
+    if s == "center":
+        return (bg.width - fg.width) // 2, (bg.height - fg.height) // 2
+    if s == "top_left":
+        return 0, 0
+    if s == "top_right":
+        return bg.width - fg.width, 0
+    if s == "bottom_left":
+        return 0, bg.height - fg.height
+    if s == "bottom_right":
+        return bg.width - fg.width, bg.height - fg.height
+    if s == "top_center":
+        return (bg.width - fg.width) // 2, 0
+    if s == "bottom_center":
+        return (bg.width - fg.width) // 2, bg.height - fg.height
+    raise ValueError("composite position 未知: " + pos)
+
+
+def handle_watermark(req, im):
+    # 支持图片水印（from_extra[0]）或文字水印（text）。
+    from PIL import Image, ImageDraw, ImageFont
+    wtype = req.get("type", "text")
+    pos = req.get("position", "bottom_right")
+    alpha = float(req.get("alpha", 0.6))
+    bg = im.convert("RGBA")
+    overlay = Image.new("RGBA", bg.size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+    if wtype == "image":
+        extra = req.get("from_extra") or []
+        if not extra:
+            raise ValueError("watermark(image) 需要 from_extra[0] 指向水印图片")
+        wm = open_image(extra[0])
+        x, y = resolve_position(bg, wm, pos)
+        if alpha < 1.0:
+            if "A" in wm.getbands():
+                wm.putalpha(wm.getchannel("A").point(lambda v: round(v * alpha)))
+            else:
+                wm = wm.convert("RGBA")
+                wm.putalpha(Image.new("L", wm.size, int(alpha * 255)))
+        overlay.alpha_composite(wm, (x, y))
+    else:
+        text = str(req.get("text", ""))
+        if not text:
+            raise ValueError("watermark(text) 需要 text")
+        size = int(req.get("font_size", 36))
+        font = load_font(size)
+        # 粗略测文本尺寸
+        bbox = draw.textbbox((0, 0), text, font=font)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        if pos == "center":
+            x, y = (bg.width - tw) // 2, (bg.height - th) // 2
+        elif pos == "top_left":
+            x, y = 10, 10
+        elif pos == "top_right":
+            x, y = bg.width - tw - 10, 10
+        elif pos == "bottom_left":
+            x, y = 10, bg.height - th - 10
+        else:
+            x, y = bg.width - tw - 10, bg.height - th - 10
+        color = parse_fill(req.get("color", "#ffffff")) or (255, 255, 255)
+        draw.text((x, y), text, font=font, fill=(*color, int(alpha * 255)))
+    bg.alpha_composite(overlay)
+    return bg
+
+
+def load_font(size):
+    from PIL import ImageFont
+    candidates = [
+        "C:/Windows/Fonts/msyh.ttc",
+        "C:/Windows/Fonts/msyhbd.ttc",
+        "C:/Windows/Fonts/simhei.ttf",
+        "C:/Windows/Fonts/arial.ttf",
+        "C:/Windows/Fonts/segoeui.ttf",
+    ]
+    for c in candidates:
+        if os.path.exists(c):
+            try:
+                return ImageFont.truetype(c, size)
+            except Exception:
+                continue
+    try:
+        return ImageFont.truetype("DejaVuSans.ttf", size)
+    except Exception:
+        return ImageFont.load_default()
+
+
+def handle_thumbnail(req, im):
+    from PIL import Image
+    max_w = int(req.get("width", 256))
+    max_h = int(req.get("height", 256))
+    copy = im.copy()
+    copy.thumbnail((max_w, max_h), Image.LANCZOS)
+    return copy
+
+
+# ---- P1: 进阶（OpenCV / rembg）-----------------------------------------------
+
+def get_cv2():
+    try:
+        import cv2  # noqa
+        return cv2
+    except Exception as e:
+        raise RuntimeError(
+            "该操作需要 OpenCV。请先运行 `node scripts/setup-image-venv.mjs` 安装 "
+            "opencv-python-headless（缺失原因: %s）" % e
+        )
+
+
+def handle_edges(req, im):
+    cv2 = get_cv2()
+    import numpy as np
+    low = int(req.get("low", 100))
+    high = int(req.get("high", 200))
+    gray_pil = im.convert("L")
+    arr = np.array(gray_pil)
+    edges = cv2.Canny(arr, low, high)
+    from PIL import Image
+    return Image.fromarray(edges).convert("RGB")
+
+
+def handle_equalize_hist(req, im):
+    cv2 = get_cv2()
+    import numpy as np
+    from PIL import Image
+    mode = req.get("mode", "auto")  # auto | clahe
+    # 转灰度或彩色。彩色：对亮度通道做 CLAHE 再合并，保留色彩。
+    if "A" in im.getbands():
+        rgba = im.convert("RGBA")
+        rgb = rgba.convert("RGB")
+        alpha = rgba.getchannel("A")
+    else:
+        rgb = im.convert("RGB")
+        alpha = None
+    arr = np.array(rgb)
+    if mode == "clahe":
+        lab = cv2.cvtColor(arr, cv2.COLOR_RGB2LAB)
+        l, a, b = cv2.split(lab)
+        clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+        l = clahe.apply(l)
+        lab = cv2.merge((l, a, b))
+        out = cv2.cvtColor(lab, cv2.COLOR_LAB2RGB)
+    else:
+        hsv = cv2.cvtColor(arr, cv2.COLOR_RGB2HSV)
+        h, s, v = cv2.split(hsv)
+        v = cv2.equalizeHist(v)
+        hsv = cv2.merge((h, s, v))
+        out = cv2.cvtColor(hsv, cv2.COLOR_HSV2RGB)
+    out_pil = Image.fromarray(out).convert("RGB")
+    if alpha is not None:
+        out_pil = out_pil.convert("RGBA")
+        out_pil.putalpha(alpha)
+    return out_pil
+
+
+def handle_denoise(req, im):
+    cv2 = get_cv2()
+    import numpy as np
+    from PIL import Image
+    strength = float(req.get("strength", 10.0))
+    rgba = im.convert("RGBA")
+    rgb = rgba.convert("RGB")
+    alpha = rgba.getchannel("A")
+    bgr = cv2.cvtColor(np.array(rgb), cv2.COLOR_RGB2BGR)
+    denoised = cv2.fastNlMeansDenoisingColored(bgr, None, strength, strength, 7, 21)
+    out = cv2.cvtColor(denoised, cv2.COLOR_BGR2RGB)
+    out_pil = Image.fromarray(out).convert("RGBA")
+    out_pil.putalpha(alpha)
+    return out_pil
+
+
+def handle_perspective(req, im):
+    cv2 = get_cv2()
+    import numpy as np
+    from PIL import Image
+    pts = req.get("points")  # 4 点：从左上逆时针 [x1,y1,x2,y2,...]
+    if not pts or len(pts) != 8:
+        raise ValueError("perspective 需要 points（8 个数，从左上起顺时针/逆时针 4 点）")
+    src = np.float32([[pts[0], pts[1]], [pts[2], pts[3]], [pts[4], pts[5]], [pts[6], pts[7]]])
+    w = int(req.get("width", im.width))
+    h = int(req.get("height", im.height))
+    dst = np.float32([[0, 0], [w, 0], [w, h], [0, h]])
+    arr = np.array(im.convert("RGB"))
+    bgr = cv2.cvtColor(arr, cv2.COLOR_RGB2BGR)
+    M = cv2.getPerspectiveTransform(src, dst)
+    warped = cv2.warpPerspective(bgr, M, (w, h))
+    out = cv2.cvtColor(warped, cv2.COLOR_BGR2RGB)
+    return Image.fromarray(out)
+
+
+def handle_stitch(req, im):
+    from PIL import Image
+    extras = (req.get("from_extra") or [])
+    if not extras:
+        raise ValueError("stitch 至少需要 from + from_extra[0] 两张图")
+    direction = req.get("direction", "horizontal")
+    imgs = [im] + [open_image(e).convert("RGBA") for e in extras]
+    if req.get("mode", "resize") == "same_height" and direction == "horizontal":
+        h = max(x.height for x in imgs)
+        imgs = [x.resize((max(1, round(x.width * h / x.height)), h), Image_LANCZOS()) for x in imgs]
+        total_w = sum(x.width for x in imgs)
+        canvas = Image.new("RGBA", (total_w, h), (0, 0, 0, 0))
+        cx = 0
+        for x in imgs:
+            canvas.alpha_composite(x, (cx, 0))
+            cx += x.width
+        return canvas
+    if direction == "horizontal":
+        w = max(x.width for x in imgs)
+        h = sum(x.height for x in imgs)
+        canvas = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+        cy = 0
+        for x in imgs:
+            canvas.alpha_composite(x, (0, cy))
+            cy += x.height
+        return canvas
+    else:
+        w = sum(x.width for x in imgs)
+        h = max(x.height for x in imgs)
+        canvas = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+        cx = 0
+        for x in imgs:
+            canvas.alpha_composite(x, (cx, 0))
+            cx += x.width
+        return canvas
+
+
+def handle_remove_background(req, im):
+    try:
+        from rembg import remove
+    except Exception as e:
+        raise RuntimeError(
+            "背景移除需要 rembg（基于 U²-Net，约 35MB，CPU 可跑）。请先运行 "
+            "`node scripts/setup-image-venv.mjs`（会安装 rembg；缺失原因: %s）" % e
+        )
+    rgba = im.convert("RGBA")
+    out = remove(rgba, post_process_mask=bool(req.get("post_process", False)))
+    return out.convert("RGBA")
+
+
+# ---- P2: 可选高级 -----------------------------------------------------------
+
+def handle_exif_read(req, im):
+    exif = im.getexif()
+    fields = {}
+    for tag_id, value in exif.items():
+        name = EXIF_TAGS.get(tag_id, str(tag_id))
+        # 压缩字节值仅保留摘要，避免超长 JSON
+        if isinstance(value, bytes) and len(value) > 200:
+            value = "<%d bytes>" % len(value)
+        fields[name] = str(value)
+    # Photo 标签的嵌套
+    try:
+        if hasattr(exif, "get_ifd"):
+            for ifd in (0x8825, 0x927C):  # GPS, MakerNote
+                sub = exif.get_ifd(ifd)
+                for tag_id, value in sub.items():
+                    fields["%s:%s" % (ifd, tag_id)] = str(value)
+    except Exception:
+        pass
+    return im, {"exif": fields}
+
+
+def handle_exif_write(req, im):
+    # 基础 EXIF：写入用户提供的键值（覆盖打印字段）。使用 Pillow 原生 getexif 改写。
+    im_with_exif = im.copy()
+    exif = im_with_exif.getexif()
+    kv = req.get("fields")
+    for k, v in (kv or {}).items():
+        try:
+            tag = int(k) if str(k).isdigit() else EXIF_TAGS_REV.get(k)
+            if tag is not None:
+                exif[tag] = v
+        except Exception:
+            continue
+    return im_with_exif
+
+
+def handle_raw_convert(req, im):
+    try:
+        import rawpy
+    except Exception as e:
+        raise RuntimeError("RAW 处理需要 rawpy（基于 libraw）。先运行 `node scripts/setup-image-venv.mjs` 安装 rawpy（缺失: %s）" % e)
+    src = req["from"]
+    raw = rawpy.imread(src)
+    try:
+        rgb = raw.postprocess(use_camera_wb=bool(req.get("camera_wb", True)))
+    finally:
+        raw.close()
+    from PIL import Image
+    return Image.fromarray(rgb)
+
+
+def handle_upscale(req, im):
+    # 轻量超分：优先 realesrgan-ncnn-vulkan CLI（外部可执行文件，非本 venv）。
+    exe = os.environ.get("DSH_REALESRGAN_EXE", "realesrgan-ncnn-vulkan")
+    if shutil.which(exe) is None and not os.path.exists(exe):
+        raise RuntimeError(
+            "超分需要外部 CLI realesrgan-ncnn-vulkan（Vulkan 推理，无需 PyTorch）。"
+            "请下载后设置环境变量 DSH_REALESRGAN_EXE 指向可执行文件。"
+        )
+    scale = int(req.get("scale", 2))
+    src = req["from"]
+    tmp = tempfile.mkdtemp(prefix="realesrgan_")
+    try:
+        # realesrgan-ncnn-vulkan 只输出 png，放到临时目录
+        out_png = os.path.join(tmp, "sr.png")
+        env = dict(os.environ)
+        cmd = [exe, "-i", src, "-o", out_png, "-s", str(scale)]
+        if req.get("model"):
+            cmd += ["-m", str(req["model"])]
+        if req.get("n"):
+            cmd += ["-n", str(req["n"])]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600, env=env)
+        if proc.returncode != 0 or not os.path.exists(out_png):
+            raise RuntimeError("realesrgan 失败: " + (proc.stderr or proc.stdout or "")[-400:])
+        return open_image(out_png)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def handle_colorspace(req, im):
+    cv2 = get_cv2()
+    import numpy as np
+    from PIL import Image
+    target = req.get("target", "rgb").lower()
+    rgb_arr = np.array(im.convert("RGB"))
+    if target in ("hsv", "hsl"):
+        out = cv2.cvtColor(rgb_arr, cv2.COLOR_RGB2HSV)
+        # 缩放到 0-255 便于存储
+        h, s, v = out[:, :, 0] / 2, out[:, :, 1], out[:, :, 2]
+        out = np.stack([h, s, v], axis=-1).astype(np.uint8)
+    elif target == "lab":
+        out = cv2.cvtColor(rgb_arr, cv2.COLOR_RGB2LAB)
+    elif target == "gray":
+        out = cv2.cvtColor(rgb_arr, cv2.COLOR_RGB2GRAY)
+        return Image.fromarray(out).convert("L")
+    elif target == "cmyk":
+        cmyk = im.convert("RGB").convert("CMYK")
+        return cmyk
+    else:
+        raise ValueError("colorspace target 只能是 rgb/hsv/lab/gray/cmyk")
+    return Image.fromarray(out)
+
+
+def handle_morphology(req, im):
+    cv2 = get_cv2()
+    import numpy as np
+    from PIL import Image
+    op = req.get("op", "erode").lower()
+    size = int(req.get("size", 3))
+    ops = {
+        "erode": cv2.MORPH_ERODE,
+        "dilate": cv2.MORPH_DILATE,
+        "open": cv2.MORPH_OPEN,
+        "close": cv2.MORPH_CLOSE,
+        "gradient": cv2.MORPH_GRADIENT,
+    }
+    if op not in ops:
+        raise ValueError("morphology op 只能是 erode/dilate/open/close/gradient")
+    gray = np.array(im.convert("L"))
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (size, size))
+    out = cv2.morphologyEx(gray, ops[op], kernel)
+    return Image.fromarray(out).convert("RGB")
+
+
+# ---- EXIF 标签映射（常用）----------------------------------------------------
+
+EXIF_TAGS = {
+    0x010F: "Make", 0x0110: "Model", 0x0112: "Orientation", 0x0132: "DateTime",
+    0x013B: "Artist", 0x01EA: "Photographer", 0x0827: "Comments",
+    0x829A: "ExposureTime", 0x829D: "FNumber", 0x8827: "ISOSpeedRatings",
+    0x9201: "ShutterSpeed", 0x9202: "Aperture", 0x9209: "Flash",
+    0x920A: "FocalLength", 0x9003: "DateTimeOriginal", 0x9004: "DateTimeDigitized",
+}
+EXIF_TAGS_REV = {v: k for k, v in EXIF_TAGS.items()}
+
+
+# ---- 分发 ---------------------------------------------------------------
+
+P0 = {
+    "resize": handle_resize, "rotate": handle_rotate, "flip": handle_flip,
+    "convert": handle_convert, "adjust": handle_adjust, "blur": handle_blur,
+    "sharpen": handle_sharpen, "composite": handle_composite,
+    "watermark": handle_watermark, "thumbnail": handle_thumbnail,
+}
+P1 = {
+    "edges": handle_edges, "equalize_hist": handle_equalize_hist,
+    "denoise": handle_denoise, "perspective": handle_perspective,
+    "stitch": handle_stitch, "remove_background": handle_remove_background,
+}
+P2 = {
+    "exif_read": handle_exif_read, "exif_write": handle_exif_write,
+    "raw_convert": handle_raw_convert, "upscale": handle_upscale,
+    "colorspace": handle_colorspace, "morphology": handle_morphology,
+}
+ACTIONS = {**P0, **P1, **P2}
+ACTIVITY = {
+    "resize": "P0 基础变换", "rotate": "P0 基础变换", "flip": "P0 基础变换",
+    "convert": "P0 基础变换", "adjust": "P0 基础变换", "blur": "P0 基础变换",
+    "sharpen": "P0 基础变换", "composite": "P0 基础变换", "watermark": "P0 基础变换",
+    "thumbnail": "P0 基础变换", "edges": "P1 进阶", "equalize_hist": "P1 进阶",
+    "denoise": "P1 进阶", "perspective": "P1 进阶", "stitch": "P1 进阶",
+    "remove_background": "P1 进阶", "exif_read": "P2 高级", "exif_write": "P2 高级",
+    "raw_convert": "P2 高级", "upscale": "P2 高级", "colorspace": "P2 高级",
+    "morphology": "P2 高级",
+}
+
+
+def main(argv):
+    if len(argv) < 1:
+        print(json.dumps({"error": "usage: image-edit.py <request.json路径>"}))
+        return 2
+    req_path = argv[0]
+    if not os.path.exists(req_path):
+        print(json.dumps({"error": "request file not found: %s" % req_path}))
+        return 1
+    with open(req_path, "r", encoding="utf-8") as f:
+        req = json.load(f)
+
+    action = req.get("action")
+    if not action or action not in ACTIONS:
+        print(json.dumps({"error": "未知 action '%s'（支持: %s）" % (action, ", ".join(sorted(ACTIONS)))}))
+        return 1
+
+    src = req.get("from")
+    out = req.get("out")
+    if not src or not os.path.exists(src):
+        print(json.dumps({"error": "输入文件不存在: %s" % src, "action": action}))
+        return 1
+    if not out:
+        print(json.dumps({"error": "需要 out（输出路径）", "action": action}))
+        return 1
+
+    try:
+        if action == "raw_convert":
+            im = None
+            result = handle_raw_convert(req, None)
+            width, height, bytes_n, fmt = save_image(result, out, action)
+        elif action == "exif_read":
+            im = open_image(src)
+            result, extra = handle_exif_read(req, im)
+            width, height = result.width, result.height
+            bytes_n = os.path.getsize(out) if os.path.exists(out) else None
+            fmt = None
+            # exif_read 不改文件，直接输出 exif 信息
+            print(json.dumps({
+                "ok": True, "out_path": None, "width": result.width, "height": result.height,
+                "bytes": 0, "format": None, "summary": "读取了 %d 个 EXIF 字段" % len(extra.get("exif", {})),
+                "action": action, "extra": extra,
+            }))
+            return 0
+        elif action == "exif_write":
+            im = open_image(src)
+            result = handle_exif_write(req, im)
+            width, height, bytes_n, fmt = save_image(result, out, action)
+        else:
+            im = open_image(src)
+            result = ACTIONS[action](req, im)
+            width, height, bytes_n, fmt = save_image(result, out, action)
+
+        print(json.dumps({
+            "ok": True, "out_path": out, "width": width, "height": height,
+            "bytes": bytes_n, "format": fmt, "action": action,
+            "summary": "%s 完成（%s）：%dx%d -> %s（%d 字节）" % (
+                ACTIVITY.get(action, action), action, width, height, os.path.basename(out), bytes_n),
+        }))
+        return 0
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"error": str(e), "action": action}))
+        return 1
+
+
+if __name__ == "__main__":
+    try:
+        code = main(sys.argv[1:])
+    except Exception as e:  # 顶层兜底
+        print(json.dumps({"error": "unexpected: %s" % e}))
+        code = 1
+    sys.exit(code)

--- a/dsh-desktop/assets/plugins/picturereader/scripts/setup-image-venv.mjs
+++ b/dsh-desktop/assets/plugins/picturereader/scripts/setup-image-venv.mjs
@@ -1,0 +1,84 @@
+/**
+ * Optional install helper for the image_edit tool's Python environment.
+ *
+ * The image editing backend (Pillow + OpenCV, optional rembg/rawpy) runs in an
+ * isolated venv at C:\Users\Administrator\image_venv, mirroring the pattern of
+ * scripts/setup-doc-venv.mjs / setup-ocr.mjs.
+ *
+ * What this does:
+ *  1. Locates the global Python 3.14 interpreter.
+ *  2. Creates image_venv if missing.
+ *  3. Installs core deps into the venv from the Tsinghua PyPI mirror:
+ *       Pillow            (P0 基础变换 / 文字水印 / 格式互转)
+ *       opencv-python-headless (P1 边缘/降噪/透视/形态学 + P2 色彩空间)
+ *       piexif            (P2 EXIF 读写)
+ *     Optional (pass --full):
+ *       rembg             (P1 背景移除, U²-Net ~35MB, CPU 可跑, 首次下载模型)
+ *       rawpy             (P2 RAW 处理, 基于 libraw)
+ *
+ * Idempotent: if the venv python exists and can import Pillow, it skips install.
+ *
+ * Usage: node scripts/setup-image-venv.mjs [--full]
+ */
+import { existsSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BASE_PY = 'C:\\Users\\Administrator\\AppData\\Local\\Programs\\Python\\Python314\\python.exe';
+const VENV_PY = 'C:\\Users\\Administrator\\image_venv\\Scripts\\python.exe';
+const PYPI = 'https://pypi.tuna.tsinghua.edu.cn/simple';
+
+const FULL = process.argv.includes('--full');
+
+function run(cmd, args, opts = {}) {
+  console.log(`> ${cmd} ${args.join(' ')}`);
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (result.status !== 0) {
+    console.error(`!! command failed (exit ${result.status})`);
+    process.exit(1);
+  }
+}
+
+// 1. base Python
+if (existsSync(BASE_PY)) {
+  console.log('[1/3] Global Python 3.14 found at ' + BASE_PY);
+} else {
+  console.error('!! Global Python 3.14 not found at ' + BASE_PY);
+  console.error('    Install Python 3.14, or edit BASE_PY in scripts/setup-image-venv.mjs.');
+  process.exit(1);
+}
+
+// 2. venv
+if (!existsSync(VENV_PY)) {
+  console.log('[2/3] Creating image_venv...');
+  mkdirSync(dirname(VENV_PY), { recursive: true });
+  run(BASE_PY, ['-m', 'venv', 'C:\\Users\\Administrator\\image_venv']);
+} else {
+  console.log('[2/3] image_venv found');
+}
+
+// 3. core deps
+const probe = spawnSync(VENV_PY, ['-c', 'import PIL; print(PIL.__version__)'], { encoding: 'utf8' });
+if (probe.status !== 0) {
+  console.log('[3/3] Installing core image deps (Tsinghua mirror)...');
+  run(VENV_PY, ['-m', 'pip', 'install', '-i', PYPI, '--upgrade', 'pip']);
+  const core = ['Pillow', 'opencv-python-headless', 'piexif'];
+  if (FULL) {
+    core.push('rembg', 'rawpy');
+  }
+  run(VENV_PY, ['-m', 'pip', 'install', '-i', PYPI, ...core]);
+  if (FULL) {
+    // rembg 首次调用会下载 U²-Net 模型（~176MB onnx / u2netp ~4.7MB），这里不自动下载，
+    // 由工具运行时按需触发。提示用户：
+    console.log('\n[rembg] 背景移除模型首次运行时自动下载到 ~/.u2net，需联网一次。');
+  }
+} else {
+  console.log(`[3/3] Pillow already installed (${probe.stdout.trim()})`);
+}
+
+console.log('\nDone. image_edit can now call the image_venv Python.');
+console.log('Core: Pillow + OpenCV-headless + piexif.');
+if (FULL) console.log('Optional installed: rembg (背景移除), rawpy (RAW).');
+else console.log('For 背景移除/RAW, rerun with --full: node scripts/setup-image-venv.mjs --full');
+console.log('Verify: run image_edit with action=resize on a small png.');

--- a/dsh-desktop/assets/plugins/picturereader/src/core.js
+++ b/dsh-desktop/assets/plugins/picturereader/src/core.js
@@ -24,7 +24,7 @@ import * as jpeg from 'jpeg-js';
 import { GifReader } from 'omggif';
 import { spawn } from 'node:child_process';
 import { writeFile, rm, stat } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { tmpdir, release } from 'node:os';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 
@@ -1115,8 +1115,14 @@ export async function ocrImage(buffer, ext, { region, language, engine = 'window
     work = cropped;
   }
   const pngBytes = encodePng(work.data, work.width, work.height);
+  // WSL compat: powershell.exe (Windows OCR) cannot reach a WSL /tmp path and
+  // GetFileFromPathAsync rejects forward slashes — write the temp PNG under
+  // /mnt/c/Windows/Temp and hand Windows a backslash path.
+  const isWsl = process.platform === 'linux' && /microsoft/i.test(release());
+  const tmpBase = isWsl ? '/mnt/c/Windows/Temp' : tmpdir();
   const tmpName = `picturereader-ocr-${randomBytes(6).toString('hex')}.png`;
-  const tmpPath = join(tmpdir(), tmpName);
+  const tmpPath = join(tmpBase, tmpName);
+  const winPath = isWsl ? `C:\\Windows\\Temp\\${tmpName}` : tmpPath;
   await writeFile(tmpPath, pngBytes);
   try {
     if (engine === 'paddle') {
@@ -1127,7 +1133,7 @@ export async function ocrImage(buffer, ext, { region, language, engine = 'window
       const result = await runRapidOcr(tmpPath);
       return { width: work.width, height: work.height, lines: result.lines };
     }
-    return await runOcr(tmpPath, { language });
+    return await runOcr(winPath, { language });
   } finally {
     await rm(tmpPath, { force: true }).catch(() => {});
   }

--- a/dsh-desktop/assets/plugins/picturereader/src/image-edit.js
+++ b/dsh-desktop/assets/plugins/picturereader/src/image-edit.js
@@ -1,0 +1,317 @@
+/**
+ * picturereader — image_edit tool.
+ *
+ * 本地修图 / 图像处理工具。一个工具、多个 action 分发（P0 基础变换 / P1 进阶 /
+ * P2 可选高级），后端为隔离的 image_venv Python（scripts/image-edit.py，
+ * 核心 Pillow + OpenCV-headless，可选 rembg/rawpy，纯 CPU，无需 GPU/大模型）。
+ *
+ * 与 document_to_image 相同的架构：
+ *   - Node 端把输入图从 DSH 虚拟文件系统材料化为本地临时文件；
+ *   - 构造 request JSON（含 action 与全部参数）写入临时文件；
+ *   - spawnSync 调用 image_venv 的 python 跑 scripts/image-edit.py；
+ *   - 解析其 stdout 的最后一行 JSON 作为结果。
+ *
+ * 环境变量：DSH_IMAGE_PYTHON 指向 image_venv 的 python.exe，默认
+ *   C:\Users\Administrator\image_venv\Scripts\python.exe。
+ * 缺失时返回清晰提示：`node scripts/setup-image-venv.mjs`。
+ *
+ * 支持 action:
+ *   P0: resize / rotate / flip / convert / adjust / blur / sharpen /
+ *       composite / watermark / thumbnail
+ *   P1: edges / equalize_hist / denoise / perspective / stitch / remove_background
+ *   P2: exif_read / exif_write / raw_convert / upscale / colorspace / morphology
+ *
+ * @module picturereader/image-edit
+ */
+
+import { join, basename as pathBasename, resolve as pathResolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+/** Absolute path to scripts/image-edit.py (this module lives in src/). */
+const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'image-edit.py');
+
+/** The isolated venv python used to run the image backend (env overridable). */
+const IMAGE_VENV_PY = process.env.DSH_IMAGE_PYTHON ?? 'C:\\Users\\Administrator\\image_venv\\Scripts\\python.exe';
+
+/** Hard cap on how many bytes we read into memory per input image. */
+const MAX_INPUT_BYTES = 200 * 1024 * 1024; // 200 MB
+
+/** Default action->timeout (ms). 背景移除 / 超分较慢。 */
+const ACTION_TIMEOUT_MS = {
+  default: 120_000,
+  remove_background: 300_000,
+  upscale: 600_000,
+  denoise: 180_000,
+  perspective: 120_000,
+};
+
+const ACTIONS = [
+  // P0
+  'resize', 'rotate', 'flip', 'convert', 'adjust', 'blur', 'sharpen',
+  'composite', 'watermark', 'thumbnail',
+  // P1
+  'edges', 'equalize_hist', 'denoise', 'perspective', 'stitch', 'remove_background',
+  // P2
+  'exif_read', 'exif_write', 'raw_convert', 'upscale', 'colorspace', 'morphology',
+];
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw new Error('image_edit: cancelled');
+}
+
+/** Resolve a writable output path: explicit out, or a generated path under out_dir/temp. */
+function resolveOutPath(rawOut, rawDir, fingerprint, cwd) {
+  const stamp = (fingerprint && fingerprint !== 'anon' ? fingerprint : 'anon');
+  const base = rawDir !== undefined && rawDir !== null && String(rawDir).trim().length > 0
+    ? (cwd ? pathResolve(cwd, String(rawDir).trim()) : pathResolve(String(rawDir).trim()))
+    : join(tmpdir(), 'picturereader-edit', stamp);
+  if (rawOut !== undefined && rawOut !== null && String(rawOut).trim().length > 0) {
+    const p = String(rawOut).trim();
+    return { out: (cwd ? pathResolve(cwd, p) : pathResolve(p)), base };
+  }
+  return { out: join(base, `edit_${Date.now()}-${randomBytes(4).toString('hex')}.png`), base };
+}
+
+/**
+ * Run image-edit.py for a materialized request. Returns the parsed JSON result.
+ */
+function runImageEditPython(reqPath, timeoutMs, signal) {
+  throwIfAborted(signal);
+  const res = spawnSync(IMAGE_VENV_PY, [SCRIPT_PATH, reqPath], {
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    maxBuffer: 64 * 1024 * 1024,
+    ...(signal ? { signal } : {}),
+  });
+  if (res.error) {
+    if (res.error.code === 'ABORT_ERR' || signal?.aborted) {
+      throw new Error('image_edit: cancelled');
+    }
+    if (res.error.code === 'ENOENT') {
+      throw new Error(
+        `image_edit: 图像处理所需的 Python 环境缺失。请先运行 \`node scripts/setup-image-venv.mjs\` 创建 image_venv（位于 ${IMAGE_VENV_PY}）。`
+      );
+    }
+    throw new Error(`image_edit: 调用图像脚本失败: ${res.error.message}`);
+  }
+  if (res.signal && res.signal === 'SIGTERM' && signal?.aborted) {
+    throw new Error('image_edit: cancelled');
+  }
+  if (res.signal || res.status === null) {
+    throw new Error('image_edit: 处理进程被终止（超时或中断）');
+  }
+  const line = (res.stdout || '').trim().split('\n').filter(Boolean).pop();
+  let parsed;
+  try {
+    parsed = JSON.parse(line || '{}');
+  } catch (e) {
+    throw new Error(`image_edit: 无法解析图像脚本输出: ${e.message}`);
+  }
+  if (parsed?.error) {
+    throw new Error(`image_edit: ${parsed.error}`);
+  }
+  return parsed;
+}
+
+/**
+ * Build the `image_edit` tool.
+ * @param ctx - the Cordis context providing `ctx.fs`.
+ */
+export function createImageEditTool(ctx) {
+  return {
+    name: 'image_edit',
+    description: [
+      'Local photo editing / image processing on a local image via a single unified tool (Pillow + OpenCV, pure CPU, no GPU/model). ' +
+        'One call performs ONE action; see "action". All operate on a file_path and write to an output path.',
+      'Supported actions (P0 基础): resize, rotate, flip, convert, adjust, blur, sharpen, composite, watermark, thumbnail.',
+      'Supported actions (P1 进阶): edges, equalize_hist, denoise, perspective, stitch, remove_background.',
+      'Supported actions (P2 高级): exif_read, exif_write, raw_convert, upscale, colorspace, morphology.',
+      'Common params: action (required); file_path (input, required); out (optional output path, default auto in out_dir/temp); ' +
+        'out_dir (optional); file_paths (array of extra inputs, used by composite/watermark/stitch). ' +
+        'Action-specific params: see the action descriptions below.',
+      'resize: width,height (required ints), mode (stretch|fit|fill, default stretch).',
+      'rotate: angle (deg, required), expand (bool default true), fill (hex or r,g,b or transparent).',
+      'flip: axis (horizontal|vertical|both, required).',
+      'convert: format is inferred from OUT extension (png/jpg/webp/bmp/tiff/gif).',
+      'adjust: brightness,contrast,saturation (float, 1.0 = unchanged).',
+      'blur: type (gaussian|box|motion), radius (default 2).',
+      'sharpen: radius (default 2), percent (default 150), threshold (default 3).',
+      'composite: overlays file_paths[0] onto file_path at position (x,y or center/top_left/top_right/bottom_left/bottom_right/top_center/bottom_center) with alpha (0..1).',
+      'watermark: type (text|image). text: text,color (#rrggbb),font_size,alpha,position. image: file_paths[0],position,alpha.',
+      'thumbnail: width,height (max bounds, keeps aspect ratio).',
+      'edges (P1): low,high (Canny thresholds).',
+      'equalize_hist (P1): mode (auto|clahe).',
+      'denoise (P1): strength (default 10).',
+      'perspective (P1): points (8 ints, 4 corners), width,height (out size).',
+      'stitch (P1): direction (horizontal|vertical), file_paths for additional images. mode (resize|raw).',
+      'remove_background (P1): needs rembg installed. post_process (bool).',
+      'exif_read (P2): returns extra.exif. exif_write (P2): fields (map of tag name -> value).',
+      'raw_convert (P2): needs rawpy; input is a RAW file (cr2/nef/arw/dng...). camera_wb (bool).',
+      'upscale (P2): needs realesrgan-ncnn-vulkan CLI (env DSH_REALESRGAN_EXE); scale (2|4), model, n.',
+      'colorspace (P2): target (rgb|hsv|lab|gray|cmyk).',
+      'morphology (P2): op (erode|dilate|open|close|gradient), size (kernel, default 3).',
+      'Requires the image_venv Python (Pillow+OpenCV). If missing, returns a setup hint: `node scripts/setup-image-venv.mjs`.'
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        action: {
+          type: 'string',
+          enum: ACTIONS,
+          description: '要执行的处理动作。一次只能一个。'
+        },
+        file_path: {
+          type: 'string',
+          description: '主输入图片路径（必填）。raw_convert 时是 RAW 文件。'
+        },
+        file_paths: {
+          type: 'array',
+          items: { type: 'string' },
+          description: '附加输入数组（composite/watermark 的前景、stitch 的更多图）。'
+        },
+        out: {
+          type: 'string',
+          description: '输出路径（含扩展名，决定格式）。缺省自动生成到 out_dir 或临时目录。'
+        },
+        out_dir: {
+          type: 'string',
+          description: '输出目录（可选的，默认系统临时目录）。'
+        }
+      }
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          ok: { type: 'boolean' },
+          action: { type: 'string' },
+          out_path: { type: 'string' },
+          width: { type: 'integer' },
+          height: { type: 'integer' },
+          bytes: { type: 'integer' },
+          format: { type: 'string' },
+          summary: { type: 'string' },
+          extra: { type: 'object', additionalProperties: true }
+        },
+        required: ['ok', 'action', 'summary']
+      },
+      render: (_args, value) => {
+        const lines = [value.summary || `image_edit (${value.action})`];
+        if (value.out_path) {
+          lines.push(`  output: ${value.out_path}`);
+          lines.push(`  size: ${value.width}x${value.height}px, ${value.bytes} bytes, ${value.format || ''}`);
+        }
+        if (value.extra?.exif) {
+          lines.push(`  exif fields: ${Object.keys(value.extra.exif).length}`);
+        }
+        return [{ type: 'text', text: lines.join('\n') }];
+      }
+    },
+    isConcurrencySafe: () => true,
+    async execute(args, exec) {
+      throwIfAborted(exec.signal);
+      // ---- action 校验 ----
+      const action = typeof args.action === 'string' ? args.action.trim() : '';
+      if (!ACTION_SET.has(action)) {
+        throw new Error(`image_edit: 未知 action "${action}"（支持: ${ACTIONS.join(', ')}）。`);
+      }
+
+      // ---- 材料化所有输入文件 ----
+      const rawMain = typeof args.file_path === 'string' ? args.file_path.trim() : '';
+      if (!rawMain) {
+        throw new Error('image_edit: 需要 file_path（输入图片路径）。');
+      }
+      const raws = [rawMain];
+      if (Array.isArray(args.file_paths)) {
+        for (const p of args.file_paths) {
+          if (typeof p === 'string' && p.trim().length > 0) raws.push(p.trim());
+        }
+      }
+
+      const cwd = exec.agent?.session?.header?.cwd;
+      const fingerprint = exec.agent?.session?.id || 'anon';
+      const { out, base } = resolveOutPath(args.out, args.out_dir, fingerprint, cwd);
+
+      const tmpDir = mkdtempSync(join(tmpdir(), 'picturereader-edit-src-'));
+      const materialized = []; // { localPath }
+      try {
+        for (const raw of raws) {
+          throwIfAborted(exec.signal);
+          const target = await ctx.fs.resolve(raw, {
+            ...(cwd !== undefined ? { cwd } : {}),
+            signal: exec.signal
+          });
+          const display = target.displayPath;
+          const info = await ctx.fs.stat(target, exec.signal);
+          if (!info || info.type !== 'file') {
+            throw new Error(`image_edit: 找不到文件: ${display}`);
+          }
+          const bytes = await ctx.fs.readBytes(target, exec.signal, MAX_INPUT_BYTES);
+          const localBase = pathBasename(display) || `img${Date.now()}`;
+          // 保留原扩展名（Pillow/rawpy 均按内容/扩展名识别；raw_convert 输入是 RAW）。
+          const localPath = join(tmpDir, localBase);
+          writeFileSync(localPath, bytes);
+          materialized.push({ localPath, displayPath: display });
+        }
+
+        // ---- 构造 request JSON（action + 全部透传参数 + 材料化路径）----
+        const passKeys = ['width', 'height', 'mode', 'keep_ratio', 'angle', 'expand', 'fill', 'axis',
+          'brightness', 'contrast', 'saturation', 'type', 'radius', 'percent', 'threshold',
+          'position', 'alpha', 'text', 'color', 'font_size', 'low', 'high', 'strength',
+          'points', 'direction', 'post_process', 'fields', 'camera_wb', 'scale', 'model', 'n',
+          'target', 'op', 'size'];
+        const params = {};
+        for (const k of passKeys) {
+          if (args[k] !== undefined && args[k] !== null) params[k] = args[k];
+        }
+        const request = {
+          action,
+          from: materialized[0].localPath,
+          out,
+          ...(materialized.length > 1 ? { from_extra: materialized.slice(1).map((m) => m.localPath) } : {}),
+          ...params,
+        };
+        const reqPath = join(tmpDir, 'request.json');
+        writeFileSync(reqPath, JSON.stringify(request));
+
+        // ---- 调用后端（可注入 seam 便于测试）----
+        const runner = typeof ctx._imageEditRunner === 'function'
+          ? ctx._imageEditRunner
+          : (rp, tm, sig) => runImageEditPython(rp, tm, sig);
+        const timeout = ACTION_TIMEOUT_MS[action] || ACTION_TIMEOUT_MS.default;
+        const result = runner(reqPath, timeout, exec.signal);
+
+        return {
+          ok: true,
+          action,
+          out_path: result.out_path ?? out,
+          width: result.width ?? null,
+          height: result.height ?? null,
+          bytes: result.bytes ?? null,
+          format: result.format ?? null,
+          summary: result.summary || `image_edit ${action} 完成。`,
+          extra: result.extra ?? undefined,
+          _baseDir: base,
+        };
+      } finally {
+        // 清理输入临时目录（输出保留在 out 供后续工具读）。
+        try {
+          rmSync(tmpDir, { recursive: true, force: true });
+        } catch { /* best effort */ }
+      }
+    }
+  };
+}
+
+const ACTION_SET = new Set(ACTIONS);
+
+// 注册工厂，与会话内其他工具一致（index.js 统一调用）。
+export function registerImageEdit(ctx) {
+  ctx.tools.register(createImageEditTool(ctx));
+}

--- a/dsh-desktop/assets/plugins/picturereader/src/index.js
+++ b/dsh-desktop/assets/plugins/picturereader/src/index.js
@@ -28,6 +28,7 @@ import { createVisionAnalyzeTool } from './vision-analyze.js';
 import { registerMoreTools } from './more-tools.js';
 import { createImageBatchTool } from './image-batch.js';
 import { createDocumentToImageTool } from './doc-tools.js';
+import { createImageEditTool } from './image-edit.js';
 import { NS } from './config.js';
 import { settingsNamespace } from '@deepseek-ai/dsh-settings';
 import z from '@deepseek-ai/schemastery';
@@ -289,6 +290,7 @@ export function apply(ctx, config) {
     registerMoreTools(ctx);
     ctx.tools.register(createImageBatchTool(ctx));
     ctx.tools.register(createDocumentToImageTool(ctx));
+    ctx.tools.register(createImageEditTool(ctx));
   });
 
   // ── 注册内置技能（image-reading）──

--- a/dsh-desktop/assets/plugins/picturereader/src/settings-expose.js
+++ b/dsh-desktop/assets/plugins/picturereader/src/settings-expose.js
@@ -18,7 +18,7 @@ import { dirname, join, sep } from "node:path";
  * Ensure `nsName` is present in dsh-host-apiproxy's WEB_SETTINGS_NAMESPACES.
  * No-op when already exposed or when the file cannot be located/patched.
  * @param {import("cordis").Context} ctx
- * @param {string} nsName - settings namespace short name (e.g. "image-reader").
+ * @param {string} nsName - settings namespace short name (e.g. "tdai-memory").
  * @param {{info?: Function, warn?: Function}} logger - dsh logger.
  */
 export function ensureSettingsNamespaceExposed(ctx, nsName, logger) {


### PR DESCRIPTION
## 背景
dsheac 内置的 picturereader（assets/plugins/picturereader）停留在 3.1.0；上游已发布 3.2.0（image_edit 本地修图工具等新能力）。本次把内置版同步至 3.2.0。

## 改动
- 同步上游 `picturereader@3.2.0`（jing-hy/picturereader）至 `assets/plugins/picturereader`。
- 新增 image_edit 本地修图工具链：
  - `src/image-edit.js`（22 种纯 CPU 动作：resize/rotate/flip/convert/adjust/blur/sharpen/composite/watermark/thumbnail + 进阶 edges/equalize_hist/denoise/perspective/stitch/remove_background 等）
  - `scripts/image-edit.py`（Pillow + OpenCV 后端）
  - `scripts/setup-image-venv.mjs`（依赖安装：`node scripts/setup-image-venv.mjs [--full]`）
- 保留内置版预装 `node_modules/`（jpeg-js/omggif/pngjs）与 `package-lock.json`（EAC 内置分发约定，v3.0.6 依赖完整性修复延续）。

## 验证
- 版本：内置 `package.json` = 3.2.0
- 新文件与预装依赖并存
- （CI 将跑 dsh-desktop 全量测试）
