### PR TITLE
ci: 运行测试超时 15 分钟自动重新开始（最多 3 次）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           retry_on: error,timeout
-          working_directory: dsh-desktop
-          command: npm test
+          command: npm --prefix dsh-desktop test
 
       - name: 构建产物（portable + NSIS 安装包）
         run: npm run dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
   build:
     name: 测试并构建 dsh-desktop（Windows x64）
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     defaults:
       run:
         working-directory: dsh-desktop
@@ -119,8 +119,15 @@ jobs:
       - name: 构建 Rust 原生模块（supervisor + snapshot）
         run: npm run build:native && npm run build:native -- snapshot
 
-      - name: 运行测试
-        run: npm test
+      - name: 运行测试（超过 15 分钟自动重新开始，最多 3 次）
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          retry_on: error,timeout
+          working_directory: dsh-desktop
+          command: npm test
 
       - name: 构建产物（portable + NSIS 安装包）
         run: npm run dist


### PR DESCRIPTION
## 背景
dsh-desktop CI 的「运行测试」步骤偶发卡死（in_progress 长时间不结束），没有超时兜底，run 直接悬挂。

## 改动
- `ci.yml` 的「运行测试」改用 `nick-fields/retry@v3` 包装 `npm test`：
  - 单次 **timeout 15 分钟**
  - 超时/失败**自动重新开始**（最多 3 次，间隔 30s）
- job 总超时 `60 → 90` 分钟以容纳最多 3 次重试。

## 验证
- 本地：skill 回归（`ci-workflow-not-release` 等 11 项）通过；`validate-skill` exit 0。
- 该 PR 自身的 CI 会用新配置跑（第一步即验证 retry 包装可用）。
