### PR TITLE
fix(plugin): 修复 better-sidebar 客户端模块加载

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client-registry.js
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client-registry.js
@@ -1306,8 +1306,18 @@ window.__ModuleLoader__.load({
 		/** Chunk script endpoint served by the plugin host half (src/bundle-route.ts). */
 		const CHUNK_URL = (name) => `/sidebar/bundle/${name}.js`;
 		/** Resolve the shell-installed module system (set before any plugin activates). */
+		let fallbackModuleSystem;
 		function moduleSystem() {
-			return globalThis.__DSH_MODULES__;
+			const globalModules = globalThis.__DSH_MODULES__;
+			if (globalModules && typeof globalModules.import === "function") return globalModules;
+			// The plugin entry already receives the same resolver from ModuleLoader.
+			// Reuse it when the legacy global is absent (older shells / early loads).
+			if (fallbackModuleSystem === void 0 && typeof require === "function") {
+				fallbackModuleSystem = {
+					import: async (specifier) => require(specifier)
+				};
+			}
+			return fallbackModuleSystem;
 		}
 		function chunkRegistry() {
 			const g = globalThis;

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client.js
@@ -1306,8 +1306,18 @@ window.__ModuleLoader__.load({
 		/** Chunk script endpoint served by the plugin host half (src/bundle-route.ts). */
 		const CHUNK_URL = (name) => `/sidebar/bundle/${name}.js`;
 		/** Resolve the shell-installed module system (set before any plugin activates). */
+		let fallbackModuleSystem;
 		function moduleSystem() {
-			return globalThis.__DSH_MODULES__;
+			const globalModules = globalThis.__DSH_MODULES__;
+			if (globalModules && typeof globalModules.import === "function") return globalModules;
+			// The plugin entry already receives the same resolver from ModuleLoader.
+			// Reuse it when the legacy global is absent (older shells / early loads).
+			if (fallbackModuleSystem === void 0 && typeof require === "function") {
+				fallbackModuleSystem = {
+					import: async (specifier) => require(specifier)
+				};
+			}
+			return fallbackModuleSystem;
 		}
 		function chunkRegistry() {
 			const g = globalThis;

--- a/dsh-desktop/test/better-sidebar-bundle.test.ts
+++ b/dsh-desktop/test/better-sidebar-bundle.test.ts
@@ -83,3 +83,15 @@ test('COMPANION_PLUGINS registers dsh-better-sidebar', () => {
 test('vendored plugin ships without TypeScript sources (installer size)', () => {
   assert.equal(existsSync(join(PLUGIN, 'src')), false, 'src/ must not ship in the installer');
 });
+
+test('lazy client chunks fall back to the plugin resolver when the legacy module global is absent', () => {
+  for (const entry of ['client.js', 'client-registry.js']) {
+    const src = readFileSync(join(PLUGIN, 'lib', entry), 'utf8');
+    assert.match(src, /const globalModules = globalThis\.__DSH_MODULES__/,
+      `${entry} must check the legacy module table first`);
+    assert.match(src, /fallbackModuleSystem = \{\s*import: async \(specifier\) => require\(specifier\)/,
+      `${entry} must reuse the plugin entry resolver as a fallback`);
+    assert.match(src, /client module system unavailable/,
+      `${entry} must retain an actionable error when neither resolver exists`);
+  }
+});


### PR DESCRIPTION
## 目的

修复 `dsh-better-sidebar` 客户端懒加载模块时，在旧版壳或过早加载场景下缺少 `globalThis.__DSH_MODULES__`，导致终端出现 `client module system unavailable` 并阻断侧边栏功能的问题。

## 架构与范围

涉及 L3 DSH 插件客户端 bundle：

- `dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client.js`
- `dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client-registry.js`
- `dsh-desktop/test/better-sidebar-bundle.test.ts`

当全局模块系统存在且可用时继续优先使用；缺失时复用插件入口提供的 `require`，避免影响现有加载路径。

## 风险与兼容

- 保留原有 `globalThis.__DSH_MODULES__` 优先路径。
- 仅增加兼容回退，不修改公开 RPC、配置、用户数据或升级结构。
- 当两种模块解析器都不可用时，继续保留原有可诊断错误。

## 验证

- [x] Skill 推荐的最低验证级别已完成
- [x] `git diff --check` 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] UI 变化已提供截图或录屏
- [x] 未验证项已明确列出

实际执行：

- `node --test test/better-sidebar-bundle.test.ts`：8/8 通过
- `npm test`：760 通过，0 失败，4 跳过
- `tsc -p tsconfig.json`：通过（由 `npm test` 的 `pretest` 执行）
- `git diff --check`：通过

UI 未发生视觉变化，因此无需截图；未验证真实发布安装包中的现场环境，仅验证源码 bundle 和完整测试链路。

## 配置与迁移

无。

## 回退方式

如需回退，撤销本 PR 即可恢复旧版客户端 bundle；不涉及用户数据或配置迁移。