### PR TITLE
fix(ci): 稳定 Linux 快照 GC 测试

### DIFF
--- a/dsh-desktop/native/snapshot/src/engine.rs
+++ b/dsh-desktop/native/snapshot/src/engine.rs
@@ -682,7 +682,9 @@ mod tests {
         let src = c.src.to_str().unwrap();
         write_file(&c.src, "a.txt", "v1");
         let s1 = create(st, src, "1");
-        write_file(&c.src, "a.txt", "v2");
+        // 使用不同长度，避免 Linux runner 的粗粒度 mtime 让哈希缓存误判为未变化；
+        // 本用例只验证删除中间快照后孤儿对象会被 GC 回收。
+        write_file(&c.src, "a.txt", "v2x");
         let s2 = create(st, src, "2");
 
         // head 不可删


### PR DESCRIPTION
## 目的

修复 Linux CI 中 `dsh-snapshot-native` 的 `delete_and_gc` 测试不稳定问题。

测试先后写入两个相同长度的文件内容，Linux runner 的文件系统时间戳精度在快速连续写入时可能不足，快照索引会复用旧哈希，导致测试期望回收 1 个对象但实际回收 0 个对象。

## 架构与范围

仅涉及 Rust 快照模块的单元测试：

- `dsh-desktop/native/snapshot/src/engine.rs`

将第二次测试内容改为不同长度，使快照必然识别为新内容。本修改不改变生产代码、快照格式或 GC 逻辑。

## 风险与兼容

- 不影响运行时行为和用户数据。
- 不修改公开 API、配置、迁移和打包流程。
- 仅消除测试对 Linux 文件系统 mtime 分辨率的隐式依赖。

## 验证

- [x] Skill 推荐的最低验证级别已完成
- [x] `git diff --check` 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] UI 变化已提供截图或录屏（本次无 UI 变化）
- [x] 未验证项已明确列出

实际验证：

- `git diff --check`：通过
- Linux `dsh-snapshot-native` 定向测试：交由本 PR CI 验证
- 本机 Windows 无法执行该 native 定向构建：当前环境缺少 `dlltool.exe` 和 `libnode.dll`，属于本机工具链阻断，不是测试断言失败

## 配置与迁移

无。

## 回退方式

如需回退，恢复 `engine.rs` 中测试内容即可；不涉及生产逻辑和用户数据。