### PR TITLE
feat(feature-pack): 功能包体系 —— .dshpack 打包分发 + 官方内核兼容扫描 + 集成进统一市场

### DIFF
--- a/docs/feature-pack-spec.md
+++ b/docs/feature-pack-spec.md
@@ -1,0 +1,161 @@
+# 功能包规范（.dshpack · Feature Pack）v1
+
+状态：草案 v1（formatVersion = 1）
+事实源：本文件 + `docs/schemas/feature-pack-pack.json`（两者不一致时以 schema 为准并修文档）。
+参考：HMCL 整合包体系（modpack manifest + overrides + 安装事务），仅借鉴概念，不含其代码（HMCL GPLv3 / 本项目 MIT）。
+
+## 1. 是什么
+
+`.dshpack` 是 Deepseek Harness EAC 的「功能包」归档：把一组**官方内核版本要求 + DSH 插件引用 + agent preset + skill** 打成单个 zip，供一键安装 / 卸载 / 更新 / 导出分享，并可声明**内核（@deepseek-ai/dsh）兼容范围**——官方内核升级后自动检出失配的功能包并支持迁移或回滚。
+
+- 分发：GitHub 市场索引（`packs-index.json`）指向 `.dshpack` 下载地址 + SHA-256；
+- 管理 UI：内置插件 `dsh-unified-market` 的设置页「功能包」分区；
+- 执行体：dsheac 主体 L2 的功能包 CLI（`dsh-desktop/scripts/feature-pack-cli.js`），插件层只做交互编排（spawn CLI + 轮询），不重复实现核心逻辑。
+
+## 2. 归档布局
+
+```
+<id>-<version>.dshpack          # zip 归档，UTF-8 文件名
+├── pack.json                   # 清单（必填，见 §3）
+├── icon.png                    # 可选图标（≤512KB，png）
+└── payload/                    # 可选内嵌载荷
+    ├── presets/<preset-id>/    # preset 目录（必须含 preset.yml）
+    └── skills/<skill-id>/      # skill 目录（必须含 SKILL.md）
+```
+
+## 3. pack.json 清单
+
+```jsonc
+{
+  "formatVersion": 1,
+  "id": "com.example.coder-pack",          // ^[a-z0-9][a-z0-9._-]{2,63}$，全局唯一
+  "name": "全能编码功能包",
+  "version": "1.2.0",                       // semver
+  "description": "一句话说明",
+  "author": "someone",
+  "license": "MIT",
+  "icon": "icon.png",                       // 可选，包内相对路径
+  "requires": {                             // 可选，缺省不限
+    "dsh": ">=0.1.1-rc.2 <0.2.0 || ^0.2.1"  // 内核 semver 范围（§5）
+  },
+  "plugins": [                              // 可选；声明式引用，安装时解析
+    { "ref": "builtin:dsh-terminal" },                      // EAC 内置插件（只核验存在）
+    { "ref": "github:user/repo", "version": ">=1.0.0" },    // GitHub 源
+    { "ref": "@deepseek-ai/dsh-fs" }                        // registry/npm 名
+  ],
+  "presets": [{ "id": "anchored-standard" }], // 内嵌于 payload/presets/ 或要求已存在
+  "skills":  [{ "id": "my-skill" }],           // 内嵌于 payload/skills/ 或要求已存在
+  "conflicts": ["dsh-xxx"],                    // 已知冲突插件（profile 已装则阻断；--force 可越过）
+  "overrides": [],                             // v1 预留（未使用；出现非空值判为无效）
+  "changelog": "本次更新…"                     // 可选，更新提示用
+}
+```
+
+### 3.1 插件引用（plugins[].ref）
+
+| 形式 | 语义 | 安装动作 |
+| --- | --- | --- |
+| `builtin:<assets 目录名>` | EAC 内置插件 | 仅校验存在并登记，不复制不写行 |
+| `github:<owner>/<repo>` | GitHub dsh-plugin | `dsh plugin --profile <p> add github:o/r` |
+| 裸 npm / registry 名 | npm 发布插件 | `dsh plugin --profile <p> add <name>` |
+
+- `version` 对 github/npm 为期望范围；与已装版本不符时**升级式重装**（remove + add）。
+- `enabled`（可选布尔，v1 预留）：目前不改变任何行为；插件启停始终走「插件管理」页，包不越权。
+
+## 4. 安装 / 卸载语义
+
+- **解析顺序**：下载/定位 zip → 解压临时目录 → `validateManifest` → `checkCompat`（requires vs 当前内核）→ conflicts 预检 → 保护中心快照 → 逐插件装配（CLI）→ payload 同步（skip-if-exists）→ 写注册表。
+- **内置 preset/skill 同步规则**（沿用既有纪律）：
+  - 目标不存在 → 复制安装；
+  - 目标存在且带 EAC 托管标记（preset：整目录由包管理；skill：`.eac-skill.json` 且版本更新）→ 覆盖更新；
+  - 用户自建同名（无托管标记）→ **永不覆盖**，登记为 `skipped`；
+- **事务**：任一步失败 → 反向拆除已完成步骤（已装的非内置插件逐个 `dsh plugin remove`）、清理临时目录、注册表不留半成品；保护中心快照保留供人工兜底。
+- **Windows 文件锁**：pnpm 撞锁（EPERM/EBUSY）时不硬重试——CLI 以专用退出码结束，宿主把任务原样排队（`feature-packs/.ops/pending.json`），下次服务启动前的无锁窗口自动续跑（与插件市场排队同窗口）。
+- **卸载**：只拆本包登记物（registry 的 owned 列表）；被多个包共用的插件保留（引用计数）；用户自行安装的插件、session、API Key 一律不动。
+
+## 5. 内核兼容（适配官方版本）
+
+- `kernelDshVersion()`：优先读桌面 profile 闭包 `node_modules/@deepseek-ai/dsh/package.json` 的真实版本 → 回退随包内置版本。
+- 启动时兼容扫描：遍历注册表 `state:"active"` 条目 × `matchRange(requires.dsh, kernel)`，失配者置 `incompatible`（幂等写回）；EAC 自更新后的首启自然触发。
+- 失配处理：UI 提示 →「一键迁移」（拉新版包 update）或「一键回滚」（restore 安装时快照，快照来自保护中心）。
+- 预发布宽容：`0.1.1-rc.2` 参与 rc 序比较；范围未声明 prerelease 时按「同 `[major,minor,patch]` 的 rc 视为满足」的宽容策略匹配（EAC 内核常驻 rc 命名，从严会把合法范围全部错杀）。
+
+### 5.1 范围语法（matchSemverRange）
+
+支持：`*`｜空｜`x.y.z` 精确｜`>=` `>` `<=` `<` `=` 前缀比较符｜`^`｜`~`｜`||` 或组｜空格 AND 组｜部分版本（`1.2` ≙ `>=1.2.0 <1.3.0`，`1` ≙ `>=1.0.0 <2.0.0`）。
+不支持即判**不匹配**（保守），并以诊断指明语法位置。
+
+## 6. 注册表
+
+路径：`<DSH_HOME>/feature-packs/registry.json`（新增目录，不改动 DSH_HOME 其余布局；原子写：tmp + rename）。
+
+```jsonc
+{
+  "version": 1,
+  "packs": [{
+    "id": "com.example.coder-pack",
+    "version": "1.2.0",
+    "installedAt": "2026-09-01T00:00:00.000Z",
+    "profile": "web-desktop",
+    "state": "active",                        // active | incompatible | rolled-back
+    "requires": { "dsh": "..." },
+    "source": "local-file | url | market",
+    "plugins": [{ "ref": "...", "pkg": "@scope/name|null", "managed": true }],
+    "presets": [{ "id": "...", "installed": true, "skipped": false }],
+    "skills":  [{ "id": "...", "installed": true, "skipped": false }],
+    "snapshotRef": "snap-123",                // 保护中心快照 id（回滚依据）
+    "opRef": "fp-1700000000000-ab12"          // 最近一次 op（状态文件 key）
+  }]
+}
+```
+
+op 状态文件：`<DSH_HOME>/feature-packs/.ops/<opRef>.json`——`{ opRef, action, stage, pct, message, done, ok, error?, result? }`，宿主（市场插件）轮询消费；任务级排队标记为 `.ops/pending.json`。
+
+## 7. CLI（执行体唯一入口）
+
+```
+node scripts/feature-pack-cli.js inspect  <zip|url>              # 只解析校验，输出 manifest JSON
+node scripts/feature-pack-cli.js list                            # 注册表 + 实时兼容标注
+node scripts/feature-pack-cli.js install  <zip|url> [--force] [--op <opRef>]
+node scripts/feature-pack-cli.js update   <id> <zip|url> [--force] [--op <opRef>]
+node scripts/feature-pack-cli.js uninstall <id> [--op <opRef>]
+node scripts/feature-pack-cli.js export   <id> [-o <out.zip>] 
+node scripts/feature-pack-cli.js scan                             # 启动兼容扫描（写回 state）
+node scripts/feature-pack-cli.js resume                           # 消费 pending 排队（无锁窗口由 sidecar 调）
+```
+
+退出码：`0` 成功｜`1` 一般失败｜`2` 用法错误｜`3` 文件锁待排队（宿主据此挂起）｜`4` 兼容失配｜`5` 冲突阻断。
+所有长操作若给了 `--op` 则把进度写 `.ops/<opRef>.json`。
+
+## 8. 市场索引协议
+
+`packs-index.json`：
+
+```jsonc
+{
+  "updated": "2026-09-01",
+  "source": "live",
+  "packs": [{
+    "id": "com.example.coder-pack",
+    "name": "全能编码功能包",
+    "version": "1.2.0",
+    "author": "someone",
+    "desc": "一句话简介",
+    "url": "https://github.com/o/r/releases/download/v1.2.0/com.example.coder-pack-1.2.0.dshpack",
+    "sha256": "<64 hex>",
+    "requires": { "dsh": "..." },
+    "iconUrl": null,
+    "added": "2026-09-01"
+  }]
+}
+```
+
+获取链：远程 live → 5 分钟内存缓存 → 内置离线快照（`data/packs-snapshot.json`）。
+完整性：下载后必须校验 SHA-256（索引缺失 sha256 时拒绝安装该条目）。
+
+## 9. 边界与红线
+
+- 不修改 `@deepseek-ai/*` 包本体；patch 行一律经 `dsh plugin` CLI 写/删，包不手写 `cordis.patch.yml`。
+- 不改 `DSH_HOME` 既有目录布局，仅新增 `feature-packs/`。
+- 用户数据不可侵犯：session、settings.yaml、用户自建 preset/skill/插件永不因装/卸/更新/回滚丢失（回滚 = 保护中心快照语义，仍以「恢复配置面」为限）。
+- 插件进程（L3）不含核心逻辑：解析/校验/semver/注册表/编排全部在 L2 CLI；L3 仅 spawn 与轮询。

--- a/docs/schemas/feature-pack-pack.json
+++ b/docs/schemas/feature-pack-pack.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/zouyuxuan122/Deepseek-Harness-EAC/blob/main/docs/schemas/feature-pack-pack.json",
+  "title": "EAC 功能包清单（pack.json）",
+  "description": ".dshpack 归档内 pack.json 的契约（事实源：docs/feature-pack-spec.md；两者不一致时以本 schema 为准并修文档）。",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["formatVersion", "id", "name", "version"],
+  "properties": {
+    "formatVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "清单格式版本。当前仅支持 1。"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{2,63}$",
+      "description": "全局唯一 id（小写字母/数字开头，长度 3–64）。"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$",
+      "description": "semver（允许 rc/预发布与 build 元数据）。"
+    },
+    "description": { "type": "string", "maxLength": 500 },
+    "author": { "type": "string", "maxLength": 128 },
+    "license": { "type": "string", "maxLength": 64 },
+    "icon": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._/-]+\\.png$",
+      "description": "包内图标相对路径（必须存在且 ≤ 512 KiB）。"
+    },
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dsh": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "官方内核 @deepseek-ai/dsh 的 semver 兼容范围（语法见 feature-pack-spec.md §5.1）。"
+        }
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ref"],
+        "properties": {
+          "ref": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "builtin:<assets 目录名> | github:owner/repo | npm/registry 包名。"
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "期望的 semver 范围（github/npm 源；与已装版本不符时升级式重装）。"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "v1 预留：目前不改变行为，插件启停始终走插件管理页。"
+          }
+        }
+      }
+    },
+    "presets": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "maxLength": 128
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "maxItems": 32,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "maxLength": 128
+          }
+        }
+      }
+    },
+    "conflicts": {
+      "type": "array",
+      "maxItems": 64,
+      "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+    },
+    "overrides": {
+      "type": "array",
+      "maxItems": 64,
+      "description": "v1 预留：必须为空数组。出现非空值判为无效（防目录穿越路径在安装器另行拒绝）。",
+      "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+    },
+    "changelog": { "type": "string", "maxLength": 2000 }
+  }
+}

--- a/dsh-desktop/.gitignore
+++ b/dsh-desktop/.gitignore
@@ -70,6 +70,8 @@ build/*
 /lib/desktop/shortcuts.js
 /lib/desktop/static-preview.js
 /lib/desktop/companion-sync.js
+/lib/desktop/feature-pack.js
+/scripts/feature-pack-cli.js
 /stable-port.js
 /error-detail.js
 /bundle-integrity.js

--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -36,7 +36,45 @@ allowBuilds 放行；已下载插件更新面板 + 一键全部/逐个更新 + �
 修复；computer-use 批准问答卡 + /computer 幂等批准；400 瞬态自愈与压缩
 误报护栏；移除内置「第三方模型思考强度」插件；手机连接桥（LAN 配对 +
 白名单 RPC，手机端占位）；内置鲸鱼余额挂件与 AgentTeams（均默认关闭）。
-版本号字段保持 5.1.0，不引 5.1.1 —— 与 R13 产物命名规则一致）
+版本号字段保持 5.1.0，不引 5.1.1 —— 与 R13 产物命名规则一致）→
+next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官方内核兼容范围，
+官方版本升级自动检出并一键迁移/回滚 —— 核心在 L2 功能包引擎 + CLI，
+交互集成进 dsh-unified-market 插件；详见下方「功能包体系（Feature Pack）」批次）
+
+## 功能包体系（Feature Pack · 借鉴 HMCL 整合包架构）· next
+
+### 功能包（.dshpack）：插件 + 预设 + 技能打包分发
+
+- **新格式与规范**：`.dshpack`（zip）＝ `pack.json` 清单 + 可选 `payload/`
+  （内嵌 preset/skills）+ `icon.png`；清单声明 `requires.dsh`（官方内核 semver
+  兼容范围）、`plugins[]`（builtin:/github:/npm 声明式引用，安装时解析，不内嵌
+  插件代码，来源可追溯）、`presets[]`、`skills[]`、`conflicts[]`。
+  规范与 JSON Schema：`docs/feature-pack-spec.md`、`docs/schemas/feature-pack-pack.json`。
+- **L2 核心引擎**（`lib/desktop/feature-pack.ts`，壳无关纯 Node）：
+  清单解析/校验、`matchSemverRange`（支持 `^ ~ x 部分版本 || 空格 &&` 与
+  预发布宽容——适配 `0.1.1-rc.x` 内核命名）、注册表
+  （`DSH_HOME/feature-packs/registry.json`，原子写）、内核版本探测、
+  安装/卸载/更新/导出/回滚编排（事务化：保护中心快照 → 装配 → 失败回滚；
+  `dsh plugin` 前后复用 artifact-keep 保护第三方构建产物；preset/skills 沿用
+  skip-if-exists，用户自建同名永不覆盖；卸载只拆本包登记物+引用计数）；
+  启动兼容扫描：官方内核版本变化自动把失配包置 `incompatible`（幂等）。
+- **功能包 CLI**（`scripts/feature-pack-cli.ts`）：
+  `inspect/list/install/update/uninstall/export/rollback/scan/resume`；
+  退出码 0/1/2/3/4/5（3=文件锁待排队、4=兼容失配、5=冲突阻断）；URL 安装 +
+  `--sha256` 校验；撞文件锁自动写入 `feature-packs/.ops/pending.json`，
+  sidecar 在无锁窗口（启动/重启前）经 `resume` 自动续跑。
+- **市场插件集成**（`dsh-unified-market`，SELF_VERSION 0.2.1 → 0.3.0）：
+  - host：`pack.list/inspect/install/uninstall/update/export/rollback/scan/market`
+    方法（spawn CLI + 复用 op 串行/轮询/超时；`pack.market` 索引 live→缓存→
+    内置 `data/packs-snapshot.json` 离线快照三级降级；上传文件 op 结束自动清理）；
+  - client：设置页新增「📦 功能包」tab —— 已安装列表（版本/兼容徽标/更新/导出/
+    卸载）、本地导入 `.dshpack`（文件选择→base64→安装）、功能包市场浏览一键安装、
+    官方内核升级后不兼容包提示条 + 「迁移（选新版）」/「回滚（保护中心快照）」；
+  - CLI 定位经 sidecar 注入的 `DSH_DESKTOP_RESOURCE_ROOT`（proc.ts childEnv）。
+- **打包与验证**：`electron-builder` 清单补 `lib/desktop/feature-pack.js` 与
+  `scripts/feature-pack-cli.js`；`unzipper` 移入 dependencies（CLI 运行时依赖）；
+  新增 `test/feature-pack.test.ts`（14 项：semver 全分支/校验/注册表/装卸往返/
+  用户保护/兼容扫描/导出/CLI）。
 
 ## 5.1.0 修复批次（内部代号 5.1.1）· 2026-08-27
 

--- a/dsh-desktop/assets/plugins/dsh-unified-market/data/packs-snapshot.json
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/data/packs-snapshot.json
@@ -1,0 +1,5 @@
+{
+  "updated": "",
+  "source": "snapshot",
+  "packs": []
+}

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/client.js
@@ -882,6 +882,163 @@ window.__ModuleLoader__.load({ id: 'dsh-unified-market', factory: (require) => {
     )
   }
 
+  // ─────────────────────────────────────────────────────────────────────
+  // 功能包（Feature Pack）面板：交互编排层，核心逻辑在 L2 功能包 CLI。
+  // host pack.* method ↔ CLI；本组件只做 UI 与 op 轮询。
+  // ─────────────────────────────────────────────────────────────────────
+  function FeaturePackPanel() {
+    const [data, setData] = useState({ phase: 'loading', packs: [], kernel: null, error: null })
+    const [market, setMarket] = useState({ packs: [], source: 'none', phase: 'idle' })
+    const [op, setOp] = useState(null)
+    const [msg, setMsg] = useState('')
+    const fileRef = useRef(null)
+    const updateTargetRef = useRef(null)
+
+    const pollStop = useRef(false)
+    useEffect(() => () => { pollStop.current = true }, [])
+
+    const loadPacks = () => {
+      api('pack.list').then((r) => {
+        setData({ phase: 'ready', packs: (r && r.packs) || [], kernel: (r && r.kernel) || null, error: (r && r.error) || null })
+      }).catch((err) => setData({ phase: 'ready', packs: [], kernel: null, error: String((err && err.message) || err) }))
+    }
+    const loadMarket = () => {
+      api('pack.market').then((r) => {
+        setMarket({ packs: (r && r.packs) || [], source: (r && r.source) || 'none', phase: 'ready' })
+      }).catch(() => setMarket({ packs: [], source: 'none', phase: 'ready' }))
+    }
+    useEffect(() => { loadPacks(); loadMarket() }, [])
+
+    const pollOp = (opId) => {
+      const tick = () => {
+        if (pollStop.current) return
+        api('op', { opId }).then((r) => {
+          const o = r && r.op
+          if (!o) { setOp(null); return }
+          if (o.status === 'done') { setOp(o); loadPacks(); return }
+          setOp(o)
+          if (o.status === 'running') setTimeout(tick, 1200)
+        }).catch(() => setTimeout(tick, 1600))
+      }
+      tick()
+    }
+
+    const runOp = (method, params, label) => {
+      if (op && op.status === 'running') { setMsg('已有任务进行中，请先等待完成'); return }
+      setMsg('')
+      api(method, params).then((r) => {
+        if (!r || !r.ok) {
+          setOp({ id: 'err', status: 'failed', output: (r && (r.error || r.output)) || '操作失败', label: label || '' })
+          if (r && r.busy) setMsg('已有任务进行中')
+          return
+        }
+        setOp({ id: r.opId, status: 'running', output: '', label: label || '' })
+        pollOp(r.opId)
+      }).catch((err) => setOp({ id: 'err', status: 'failed', output: String((err && err.message) || err), label: label || '' }))
+    }
+    const killOp = () => { api('kill', {}).catch(() => {}) }
+    const closeOp = () => { setOp(null); loadPacks() }
+
+    const pickFile = (mode, packId) => {
+      updateTargetRef.current = mode === 'update' ? packId : null
+      if (fileRef.current) fileRef.current.value = ''
+      if (fileRef.current) fileRef.current.click()
+    }
+    const onFile = (e) => {
+      const f = e.target.files && e.target.files[0]
+      if (!f) return
+      const reader = new FileReader()
+      reader.onload = () => {
+        const raw = String(reader.result || '')
+        const b64 = raw.slice(raw.indexOf(',') + 1)
+        if (updateTargetRef.current) {
+          runOp('pack.update', { id: updateTargetRef.current, data: b64, label: f.name }, '更新功能包')
+        } else {
+          runOp('pack.install', { data: b64, label: f.name }, '安装功能包')
+        }
+      }
+      reader.readAsDataURL(f)
+    }
+
+    const exportPack = (id) => {
+      api('pack.export', { id }).then((r) => {
+        setMsg(r && r.ok ? ('已导出到：' + (r.path || '')) : ((r && r.error) || '导出失败'))
+      }).catch((err) => setMsg('导出失败：' + String((err && err.message) || err)))
+    }
+
+    const compatBanner = (data.packs || []).filter((p) => p.compatOk === false)
+    const running = !!(op && op.status === 'running')
+
+    return h('div', { className: 'mkts' },
+      h('div', { className: 'mkts-sec' }, '📦 功能包',
+        h('small', null, '把插件 + 预设 + 技能打包分发；声明官方内核兼容范围，官方版本升级后自动检出（思路借鉴 HMCL 整合包）。')),
+      compatBanner.length > 0 ? h('div', { className: 'mkts-health' },
+        h('div', { className: 'mkts-health-item mkts-hl-err' }, '官方内核 ' + (data.kernel || '未知') + ' 与以下功能包不兼容（迁移：安装兼容新版；回滚：恢复安装前状态）：'),
+        compatBanner.map((p) => h('div', { className: 'mkts-update-row', key: p.id },
+          h('span', null, p.name + '（v' + p.version + '）'), ' ',
+          h('button', { className: 'mkts-cmdbtn', disabled: running, onClick: () => pickFile('update', p.id) }, '迁移（选新版 .dshpack）'), ' ',
+          h('button', { className: 'mkts-cmdbtn mkts-cmdbtn-danger', disabled: running || !p.snapshotRef,
+            onClick: () => { if (window.confirm('回滚到安装「' + p.name + '」之前的状态？')) runOp('pack.rollback', { id: p.id }, '回滚 ' + p.id) } }, '回滚'),
+        )),
+      ) : null,
+      data.error ? h('div', { className: 'mkts-err' }, '功能包 CLI 不可用：' + data.error + '（请确认本客户端在桌面壳内运行）') : null,
+      h('div', { className: 'mkts-sec' }, '已安装功能包', h('small', null, String((data.packs || []).length) + ' 个')),
+      data.phase === 'ready' && (data.packs || []).length === 0
+        ? h('div', { className: 'mkts-hint' }, '还没有安装功能包：在下方「导入 .dshpack」本地安装，或到「功能包市场」浏览安装。')
+        : (data.packs || []).map((p) => h('div', { className: 'mkts-item', key: p.id },
+            h('div', { className: 'mkts-avatar' }, (p.name || '?').slice(0, 1)),
+            h('div', { className: 'mkts-main' },
+              h('h3', null, p.name, h('span', { className: 'mkts-by' }, 'v' + p.version),
+                p.compatOk === false
+                  ? h('span', { className: 'mkts-state mkts-state-off' }, '⚠ 不兼容')
+                  : h('span', { className: 'mkts-state mkts-state-on' }, p.state === 'active' ? '正常' : '已回滚')),
+              h('p', { className: 'mkts-desc' }, '插件 ' + String((p.plugins || []).length) + ' · 预设 ' + String((p.presets || []).length) + ' · 技能 ' + String((p.skills || []).length)
+                + (p.requires && p.requires.dsh ? ' · 内核要求 ' + p.requires.dsh : '')),
+            ),
+            h('div', { className: 'mkts-actions' },
+              h('button', { className: 'mkts-cmdbtn', disabled: running, onClick: () => pickFile('update', p.id) }, '更新'),
+              h('button', { className: 'mkts-cmdbtn', disabled: running, onClick: () => exportPack(p.id) }, '导出'),
+              h('button', { className: 'mkts-cmdbtn mkts-cmdbtn-danger', disabled: running,
+                onClick: () => { if (window.confirm('卸载功能包「' + p.name + '」？（仅移除该包装配的插件/预设/技能，其余数据不动）')) runOp('pack.uninstall', { id: p.id }, '卸载 ' + p.id) } }, '卸载'),
+            ),
+          )),
+      h('div', { className: 'mkts-sec' }, '导入 / 安装'),
+      h('div', { className: 'mkts-cmdrow' },
+        h('button', { className: 'mkts-cmdbtn mkts-cmdbtn-primary', disabled: running, onClick: () => pickFile('install', null) }, '导入 .dshpack 安装'),
+        h('input', { ref: fileRef, type: 'file', accept: '.dshpack,application/zip', style: { display: 'none' }, onChange: onFile }),
+      ),
+      h('div', { className: 'mkts-sec' }, '功能包市场', h('small', null, market.phase === 'ready' ? '来源：' + market.source : '加载中…')),
+      market.phase === 'ready' && (market.packs || []).length === 0
+        ? h('div', { className: 'mkts-hint' }, '市场索引为空：尚未配置远端仓库（可先用本地导入，或等待正式市场仓库上线）。')
+        : (market.packs || []).map((p) => h('div', { className: 'mkts-item', key: p.id },
+            h('div', { className: 'mkts-avatar' }, (p.name || '?').slice(0, 1)),
+            h('div', { className: 'mkts-main' },
+              h('h3', null, p.name, h('span', { className: 'mkts-by' }, 'v' + p.version + (p.author ? ' · ' + p.author : ''))),
+              h('p', { className: 'mkts-desc' }, p.desc || ''),
+              p.requires && p.requires.dsh ? h('div', { className: 'mkts-hint' }, '内核要求：' + p.requires.dsh) : null,
+            ),
+            h('div', { className: 'mkts-actions' },
+              h('button', { className: 'mkts-cmdbtn mkts-cmdbtn-primary', disabled: running,
+                onClick: () => runOp('pack.install', { target: p.url, sha256: p.sha256 || undefined, label: p.name }, '安装 ' + p.name) }, '安装'),
+            ),
+          )),
+      msg ? h('div', { className: 'mkts-hint' }, msg) : null,
+      op ? h('div', { className: 'mkts-modal-bg' },
+        h('div', { className: 'mkts-modal' },
+          h('h4', null, (op.label || '功能包任务') + (op.status === 'running' ? ' …' : ' [' + op.status + ']')),
+          op.output ? h('pre', { className: 'mkts-log' }, op.output) : h('div', { className: 'mkts-hint' }, '任务进行中…（插件安装可能较长，可收起等待）'),
+          h('div', { className: 'mkts-cmdrow' },
+            op.status === 'running'
+              ? h('button', { className: 'mkts-cmdbtn mkts-cmdbtn-danger', onClick: killOp }, '终止任务')
+              : h('button', { className: 'mkts-cmdbtn mkts-cmdbtn-primary', onClick: closeOp }, op.status === 'failed' ? '关闭' : '完成并刷新'),
+          ),
+          op.status === 'done' ? h('div', { className: 'mkts-hint' }, '完成。若安装了新插件，可能需要在 ⋯ 菜单「重启 Web 服务」后生效。') : null,
+          op.status === 'failed' ? h('div', { className: 'mkts-hint' }, '操作失败：请查看上方输出；文件锁类失败会自动排队，重启服务后完成。') : null,
+        ),
+      ) : null,
+    )
+  }
+
   const inject = ['slots']
 
   function apply(ctx) {
@@ -900,6 +1057,10 @@ window.__ModuleLoader__.load({ id: 'dsh-unified-market', factory: (require) => {
     slots.inject('settings.plugins.tab', () => slots.register(
       { name: 'settings.plugins.tab', id: 'market', order: 5, label: () => (LOCALE === 'zh' ? '🛒 统一市场' : '🛒 Unified Market') },
       MarketPanel,
+    ))
+    slots.inject('settings.plugins.tab', () => slots.register(
+      { name: 'settings.plugins.tab', id: 'feature-pack', order: 6, label: () => (LOCALE === 'zh' ? '📦 功能包' : '📦 Feature Packs') },
+      FeaturePackPanel,
     ))
   }
 

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
@@ -25,7 +25,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { homedir, tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 // pnpm 重写 node_modules 前后快照/回填第三方包的本地构建产物
 // （meow-memory 等人工补齐的 lib/ 不再被每次安装/更新清掉）。
 import { snapshotArtifacts, restoreArtifacts } from './artifact-keep.mjs'
@@ -39,7 +39,7 @@ import { scanCandidate, collectProfileState } from './plugin-conflict-scan.mjs'
 export const name = 'dsh-unified-market'
 
 /** 本市场自身版本（与 package.json 同步；自更新检测用）。 */
-export const SELF_VERSION = '0.2.1'
+export const SELF_VERSION = '0.3.0'
 
 /** Hard dependency: the HTTP carrier must exist before the route registers. */
 export const inject = ['webServer']
@@ -1638,6 +1638,139 @@ function hasUpdateOfVersion(local, latest) {
   } catch { return local !== latest }
 }
 
+// ---------------------------------------------------------------------------
+// 功能包（Feature Pack，.dshpack）—— 交互编排层。
+// 核心（解析/校验/semver/注册表/兼容/装配）在 L2 功能包 CLI
+// （dsh-desktop/scripts/feature-pack-cli.js，经 DSH_DESKTOP_RESOURCE_ROOT
+// 定位）；本层只做：spawn CLI、op 轮询、上传/下载中转、市场索引浏览，
+// 不重复实现任何核心逻辑（避免双实现漂移）。
+// ---------------------------------------------------------------------------
+
+// Phase 3：功能包市场索引（packs-index.json）托管地址；正式仓库确认前保持
+// 为空数组 → 仅离线快照（data/packs-snapshot.json）可用。
+const PACKS_INDEX_URLS = []
+const PACKS_CACHE_TTL = 5 * 60 * 1000
+let packsCache = null // { at, packs, source }
+const PACK_UPLOAD_MAX = 128 * 1024 * 1024
+
+function packCliPath() {
+  const root = process.env.DSH_DESKTOP_RESOURCE_ROOT
+  if (!root) return null
+  const cli = join(root, 'scripts', 'feature-pack-cli.js')
+  try { return existsSync(cli) ? cli : null } catch { return null }
+}
+
+/** 同步跑功能包 CLI（快命令：list/inspect/export/rollback/scan）。 */
+function runPackCli(args) {
+  const cli = packCliPath()
+  if (!cli) return { ok: false, error: '功能包 CLI 不可用（缺少 DSH_DESKTOP_RESOURCE_ROOT，请在桌面壳内使用）' }
+  let r
+  try {
+    r = spawnSync(process.execPath, [cli, ...args], {
+      cwd: dshHome(),
+      env: { ...process.env, CI: 'true' },
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 90000,
+    })
+  } catch (err) {
+    return { ok: false, error: String((err && err.message) || err) }
+  }
+  const out = String(r.stdout || '')
+  if (r.status !== 0) {
+    const tail = (out + '\n' + String(r.stderr || '')).split('\n').filter(Boolean).slice(-3).join('\n')
+    return { ok: false, error: tail || ('功能包 CLI 失败（exit ' + r.status + '）') }
+  }
+  try { return { ok: true, json: JSON.parse(out) } } catch { return { ok: true, output: out } }
+}
+
+/** 异步慢命令（install/uninstall/update）作为 op 跑，复用现有 op 轮询模型。 */
+function startPackOp(packArgs, label, initialOutput) {
+  const cli = packCliPath()
+  if (!cli) return { ok: false, error: '功能包 CLI 不可用（缺少 DSH_DESKTOP_RESOURCE_ROOT，请在桌面壳内使用）' }
+  if (activeOp && activeOp.status === 'running') {
+    return { ok: false, busy: true, output: '已有任务进行中：' + activeOp.label }
+  }
+  const op = {
+    id: 'pack-' + (++opCounter),
+    kind: 'pack', profile: desktopProfile(), target: label, label,
+    startedAt: Date.now(), status: 'running',
+    output: initialOutput || '', exitCode: null, bin: cli, hot: false,
+  }
+  const child = spawn(process.execPath, [cli, ...packArgs], {
+    cwd: dshHome(),
+    env: { ...process.env, CI: 'true' },
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  op.child = child
+  child.stdout.on('data', (d) => appendOutput(op, d.toString()))
+  child.stderr.on('data', (d) => appendOutput(op, d.toString()))
+  child.on('error', (err) => {
+    if (op.status !== 'running') return
+    appendOutput(op, '\n[error] ' + String((err && err.message) || err))
+    settleOp(op, 'failed')
+  })
+  child.on('close', (code) => {
+    if (op.status !== 'running') return
+    settleOp(op, code === 0 ? 'done' : 'failed', code)
+    if (code === 3) {
+      // 文件锁（CLI exit 3）：CLI 已把任务写入 feature-packs/.ops/pending.json，
+      // sidecar 在下次服务启动前的无锁窗口经 feature-pack-cli resume 消费。
+      appendOutput(op, '\n[pending] 文件被运行中的服务占用（Windows 文件锁）。任务已排队：重启 Web 服务后自动完成（功能包排队）。\n')
+    }
+  })
+  op.timer = setTimeout(() => {
+    if (op.status !== 'running') return
+    appendOutput(op, '\n\n[timeout] 操作超过 ' + Math.round(DEFAULT_TIMEOUT / 1000) + ' 秒未完成，已自动终止（可能是网络不通或 pnpm 卡住，可重试）')
+    settleOp(op, 'timeout')
+    killChild(child)
+  }, DEFAULT_TIMEOUT)
+  activeOp = op
+  return { ok: true, opId: op.id, op }
+}
+
+/** 保存客户端上传的 .dshpack（base64）到临时目录，返回本地路径。 */
+function savePackUpload(data64) {
+  let buf
+  try { buf = Buffer.from(String(data64 || ''), 'base64') } catch { return null }
+  if (buf.length === 0 || buf.length > PACK_UPLOAD_MAX) return null
+  const dir = join(dshHome().replace(/[\\/]+$/, ''), 'feature-packs', '.uploads')
+  mkdirSync(dir, { recursive: true })
+  const file = join(dir, 'upload-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8) + '.dshpack')
+  try { writeFileSync(file, buf); return file } catch { return null }
+}
+
+/**
+ * 功能包市场索引（packs-index.json）：live → 5 分钟缓存 → 内置离线快照。
+ * 依赖下载与 SHA-256 校验由安装链路完成（见 pack.install）。
+ */
+async function loadPacksIndex() {
+  if (packsCache && Date.now() - packsCache.at < PACKS_CACHE_TTL) {
+    return { packs: packsCache.packs, source: packsCache.source }
+  }
+  for (const url of PACKS_INDEX_URLS) {
+    try {
+      const r = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(15000) })
+      if (!r.ok) continue
+      const json = await r.json()
+      if (json && Array.isArray(json.packs)) {
+        packsCache = { at: Date.now(), packs: json.packs, source: 'live' }
+        return { packs: json.packs, source: 'live' }
+      }
+    } catch { /* 下一镜像 */ }
+  }
+  const snapFile = join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'packs-snapshot.json')
+  try {
+    const snap = JSON.parse(readFileSync(snapFile, 'utf8'))
+    if (Array.isArray(snap.packs)) {
+      packsCache = { at: Date.now(), packs: snap.packs, source: 'snapshot' }
+      return { packs: snap.packs, source: 'snapshot' }
+    }
+  } catch { /* 无快照 */ }
+  return { packs: [], source: 'none' }
+}
+
 export { classifyPlugin, runProbe, whitelistSource, loadCatalog, parseSimplePatch, checkUpdates, parseSite, registryToCatalog, normalizeRepoUrl, readInstalledProvenance, matchInstalledPackage, resolveProfile, githubList, npmSearch, readZhIntro, selfUpdateCheck, autoUpdateState, setAutoUpdate, desktopProfile, resolveLinkedUpstream, fetchUpstreamVersion, findUpstreamByName, npmLatestInfo, linkedUpdateTarget } // test hooks; cordis only reads name/inject/apply
 
 export function apply(ctx) {
@@ -2040,6 +2173,85 @@ export function apply(ctx) {
         if (method === 'selfUpdate') {
           const r = await selfUpdateCheck()
           return sendJson(res, 200, r)
+        }
+        // ---------- 功能包（Feature Pack）----------（核心逻辑在 L2 CLI）
+        if (method === 'pack.list') {
+          const r = runPackCli(['list'])
+          if (!r.ok) return sendJson(res, 200, r)
+          return sendJson(res, 200, { ok: true, ...(r.json || {}) })
+        }
+        if (method === 'pack.inspect') {
+          // 来源：客户端上传 base64（body.data）或市场 url / 本地路径（body.target）。
+          const target = String(body.target || '').trim()
+          let file = null
+          if (body.data) {
+            file = savePackUpload(body.data)
+            if (!file) return sendJson(res, 400, { ok: false, error: '上传数据无效或超过大小上限' })
+          } else if (!target) {
+            return sendJson(res, 400, { ok: false, error: '缺少 target（url/路径）或 data（base64 文件）' })
+          }
+          const r = runPackCli(['inspect', file || target])
+          if (file) { try { rmSync(file, { force: true, maxRetries: 3 }) } catch {} }
+          if (!r.ok) return sendJson(res, 200, r)
+          return sendJson(res, 200, { ok: true, ...(r.json || {}) })
+        }
+        if (method === 'pack.install' || method === 'pack.update') {
+          if (!sameOrigin(req)) return sendJson(res, 403, { ok: false, error: 'untrusted origin' })
+          const pc = method === 'pack.install'
+          const id = pc ? null : String(body.id || '').trim()
+          if (!pc && !id) return sendJson(res, 400, { ok: false, error: '缺少功能包 id' })
+          // 上传（base64）优先；否则 url / 本地路径（市场条目、手动填写）。
+          let file = null
+          if (body.data) {
+            file = savePackUpload(body.data)
+            if (!file) return sendJson(res, 400, { ok: false, error: '上传数据无效或超过大小上限' })
+          }
+          const target = String(body.target || '').trim()
+          if (!file && !target) return sendJson(res, 400, { ok: false, error: '缺少 target（url/路径）或 data（base64 文件）' })
+          const sha = String(body.sha256 || '').trim()
+          const args = pc
+            ? ['install', file || target, ...(body.force ? ['--force'] : []), ...(sha ? ['--sha256', sha] : [])]
+            : ['update', id, file || target, ...(body.force ? ['--force'] : []), ...(sha ? ['--sha256', sha] : [])]
+          const started = startPackOp(args, (body.label || (pc ? '安装功能包' : '更新功能包 ' + id)) + (file ? '' : '（' + target + '）'),
+            '[功能包] ' + (pc ? '开始安装' : '开始更新') + (file ? '' : ': ' + target) + '\n')
+          if (!started.ok) return sendJson(res, 200, started)
+          if (file && started.op && started.op.child) {
+            // 上传文件在 CLI 使用完毕后清理（op 结束时）。
+            started.op.child.on('close', () => { try { rmSync(file, { force: true, maxRetries: 3 }) } catch {} })
+          }
+          return sendJson(res, 200, { ok: true, opId: started.opId, timeoutMs: DEFAULT_TIMEOUT })
+        }
+        if (method === 'pack.uninstall') {
+          if (!sameOrigin(req)) return sendJson(res, 403, { ok: false, error: 'untrusted origin' })
+          const id = String(body.id || '').trim()
+          if (!id) return sendJson(res, 400, { ok: false, error: '缺少功能包 id' })
+          const started = startPackOp(['uninstall', id], '卸载功能包 ' + id, '[功能包] 开始卸载: ' + id + '\n')
+          if (!started.ok) return sendJson(res, 200, started)
+          return sendJson(res, 200, { ok: true, opId: started.opId, timeoutMs: DEFAULT_TIMEOUT })
+        }
+        if (method === 'pack.export') {
+          const id = String(body.id || '').trim()
+          if (!id) return sendJson(res, 400, { ok: false, error: '缺少功能包 id' })
+          const out = join(dshHome().replace(/[\\/]+$/, ''), 'feature-packs', 'exports', id + '-' + Date.now() + '.dshpack')
+          const r = runPackCli(['export', id, '-o', out])
+          if (!r.ok) return sendJson(res, 200, r)
+          return sendJson(res, 200, { ok: true, path: out, json: r.json || null })
+        }
+        if (method === 'pack.rollback') {
+          const id = String(body.id || '').trim()
+          if (!id) return sendJson(res, 400, { ok: false, error: '缺少功能包 id' })
+          const r = runPackCli(['rollback', id])
+          if (!r.ok) return sendJson(res, 200, r)
+          return sendJson(res, 200, { ok: true, ...(r.json || {}) })
+        }
+        if (method === 'pack.scan') {
+          const r = runPackCli(['scan'])
+          if (!r.ok) return sendJson(res, 200, r)
+          return sendJson(res, 200, { ok: true, ...(r.json || {}) })
+        }
+        if (method === 'pack.market') {
+          const idx = await loadPacksIndex()
+          return sendJson(res, 200, { ok: true, packs: idx.packs, source: idx.source })
         }
         return sendJson(res, 404, { ok: false, error: 'unknown method ' + method })
       } catch (e) {

--- a/dsh-desktop/electron-builder.yml
+++ b/dsh-desktop/electron-builder.yml
@@ -67,6 +67,7 @@ files:
   - lib/desktop/junction-patrol.js
   - lib/desktop/client-update.js
   - lib/desktop/static-preview.js
+  - lib/desktop/feature-pack.js
   - assets/**/*
   # 运行时脚本：koffi 预检探针（scripts/koffi-preflight.cjs）、会话删除补丁与
   # 插件启停手术脚本（main.js 启动时 require）等必须在成品里存在。
@@ -75,6 +76,8 @@ files:
   - scripts/plugin-manager-patch.js
   - scripts/onboarding.js
   - scripts/make-release-hashes.js
+  # 功能包 CLI：L3 市场插件（web 进程）经 DSH_DESKTOP_RESOURCE_ROOT 定位 spawn。
+  - scripts/feature-pack-cli.js
   - package.json
   - "!**/*.md"
   # `!**/*.md` above would strip every .md from node_modules too, which removes

--- a/dsh-desktop/lib/desktop/feature-pack.ts
+++ b/dsh-desktop/lib/desktop/feature-pack.ts
@@ -1,0 +1,1206 @@
+'use strict';
+
+// 功能包（.dshpack）核心（ADR 0002 L2 业务服务层；契约 = docs/feature-pack-spec.md
+// + docs/schemas/feature-pack-pack.json）。
+//
+// 职责：清单解析与校验、内核 semver 范围匹配（matchSemverRange）、注册表 CRUD、
+// 内核兼容检查与启动扫描、安装/卸载/更新/导出/回滚编排、op 状态文件与排队
+// resume。纯 Node 实现，不依赖 Electron/Tauri；由 sidecar（启动扫描、排队消费）
+// 与 scripts/feature-pack-cli.ts 共同使用。
+//
+// 边界（红线）：
+//   · 不修改 @deepseek-ai/* 包本体；插件装配一律经 `dsh plugin` CLI；
+//   · 不手写 cordis.patch.yml（builtin 引用只核验存在并登记）；
+//   · preset/skills 沿用 skip-if-exists；用户自建同名永不覆盖；
+//   · DSH_HOME 仅新增 feature-packs/ 目录；
+//   · 安装/更新事务化：失败按保护中心快照回滚并清理半成品。
+
+import path = require('node:path');
+import fs = require('node:fs');
+import os = require('node:os');
+import cp = require('node:child_process');
+import { pathToFileURL } from 'node:url';
+
+// 应用根目录（本模块位于 <root>/lib/desktop/ 下；与 runtime-paths 的 APP_ROOT 同值，
+// 此处独立声明避免循环依赖）。
+const APP_ROOT = path.resolve(__dirname, '..', '..');
+
+// unzipper（zip 读取）为 devDependency，随 dsh-desktop 整树打包分发；开发态 npm ci
+// 后亦存在。缺失时解析/安装降级为明确报错（不静默）。
+const unzipper = require('unzipper') as {
+  Open: { file(p: string): Promise<{ files: ZipEntry[] }> };
+};
+const archiver = require('archiver') as (format: string, o?: Record<string, unknown>) => ArchiverLike;
+
+interface ZipEntry { path: string; buffer(): Promise<Buffer> }
+interface ArchiverLike {
+  append(content: string | Buffer, o: { name: string }): ArchiverLike;
+  directory(dir: string, dest: string): ArchiverLike;
+  pipe(w: NodeJS.WritableStream): ArchiverLike;
+  finalize(): Promise<void>;
+  on(event: 'error', cb: (err: Error) => void): ArchiverLike;
+}
+
+// ---------------------------------------------------------------------------
+// 注入接口与上下文
+// ---------------------------------------------------------------------------
+
+export interface FeaturePackCtx {
+  log(tag: string, msg: string): void;
+  getDshHome(): string | null;
+  getDesktopProfile(): string;
+  getUserDataDir(): string;
+  getDshBin(): string;
+  getNodeExe(): string;
+  /** 子进程环境（sidecar 传入 childEnv()；CLI 传 process.env）。 */
+  getChildEnv(): NodeJS.ProcessEnv;
+  /** 内置插件源目录解析（companion-sync 的 builtinPluginSourceDir 语义）。 */
+  builtinSourceDir(dirName: string): string;
+  /** 保护中心快照能力（guard-box ensureGuard 语义）；缺省 null = 无快照。 */
+  snapshot?: (label: string) => { id?: string } | null;
+  restoreSnapshot?: (id: string) => { ok: boolean; error?: string };
+  /** 已启用插件名列表（冲突预检用；缺省读 cordis.patch.yml insert name）。 */
+  enabledPluginNames?: () => string[];
+}
+
+let ctx!: FeaturePackCtx;
+export function init(d: FeaturePackCtx): void { ctx = d; }
+
+// 命令行退出码（spec §7）。
+export const EXIT_OK = 0;
+export const EXIT_FAIL = 1;
+export const EXIT_USAGE = 2;
+export const EXIT_LOCK = 3;
+export const EXIT_COMPAT = 4;
+export const EXIT_CONFLICT = 5;
+
+function fail(msg: string): Error { return new Error(msg); }
+
+// ---------------------------------------------------------------------------
+// 路径
+// ---------------------------------------------------------------------------
+
+export function featurePacksRoot(home: string): string { return path.join(home, 'feature-packs'); }
+export function registryFile(home: string): string { return path.join(featurePacksRoot(home), 'registry.json'); }
+export function opsDir(home: string): string { return path.join(featurePacksRoot(home), '.ops'); }
+export function pendingFile(home: string): string { return path.join(opsDir(home), 'pending.json'); }
+export function packDataDir(home: string, id: string): string { return path.join(featurePacksRoot(home), id); }
+export function packPayloadDir(home: string, id: string): string { return path.join(packDataDir(home, id), 'payload'); }
+export function packOverridesDir(home: string, id: string): string { return path.join(packDataDir(home, id), 'overrides'); }
+
+function homeOf(): string {
+  return ctx.getDshHome() || path.join(os.homedir(), '.dsh');
+}
+function profileDirOf(): string {
+  return path.join(homeOf(), 'profiles', ctx.getDesktopProfile());
+}
+
+// ---------------------------------------------------------------------------
+// 第三方构建产物保留（复用 dsh-unified-market 的 artifact-keep）：pnpm add/remove
+// 会按锁文件重写整棵 node_modules，人工补齐的 lib/ 会被清掉 —— 功能包装配前后
+// 快照/回填（与 market.ts / market host 同一份模块）。
+// ---------------------------------------------------------------------------
+
+type EsmModule = Record<string, unknown>;
+// tsc(commonjs) 会把 import() 降级为 require()，而 require() 加载 .mjs 会抛错；
+// 用 new Function 保住原生动态 import（market.ts 同款做法）。
+const dynamicImport = new Function('specifier', 'return import(specifier)') as (s: string) => Promise<unknown>;
+const ARTIFACT_KEEP_MODULE = path.join(APP_ROOT, 'assets', 'plugins', 'dsh-unified-market', 'lib', 'artifact-keep.mjs');
+let artifactKeepMod: EsmModule | null = null;
+
+async function artifactKeep(): Promise<EsmModule> {
+  if (artifactKeepMod) return artifactKeepMod;
+  try {
+    artifactKeepMod = await dynamicImport(pathToFileURL(ARTIFACT_KEEP_MODULE).href) as unknown as EsmModule;
+  } catch (err) {
+    ctx.log('feature-pack', 'artifact-keep 模块加载失败: ' + String((err as Error).message));
+    artifactKeepMod = {};
+  }
+  return artifactKeepMod;
+}
+
+async function snapshotArtifactsFor(profile: string): Promise<void> {
+  try {
+    const ak = await artifactKeep();
+    if (typeof ak.snapshotArtifacts !== 'function') return;
+    const profileDirP = path.join(homeOf(), 'profiles', profile);
+    const cache = path.join(homeOf(), 'plugin-artifact-cache', profile);
+    const builtinFile = path.join(profileDirP, '.dsh-builtin-plugins.json');
+    let managedNames: string[] = [];
+    try {
+      const b = JSON.parse(fs.readFileSync(builtinFile, 'utf8')) as unknown;
+      if (Array.isArray(b)) managedNames = b as string[];
+      else if (b && typeof b === 'object' && Array.isArray((b as Record<string, unknown>).names)) managedNames = (b as Record<string, unknown>).names as string[];
+    } catch { /* 缺省空 */ }
+    await (ak.snapshotArtifacts as (a: string, b: string, o: { managedNames: string[]; log(m: string): void }) => void)(
+      profileDirP, cache, { managedNames, log: (m: string) => ctx.log('feature-pack', '[keep] ' + m) });
+  } catch (err) {
+    ctx.log('feature-pack', 'artifact 快照失败（继续）: ' + String((err as Error).message));
+  }
+}
+
+async function restoreArtifactsFor(profile: string): Promise<void> {
+  try {
+    const ak = await artifactKeep();
+    if (typeof ak.restoreArtifacts !== 'function') return;
+    const profileDirP = path.join(homeOf(), 'profiles', profile);
+    const cache = path.join(homeOf(), 'plugin-artifact-cache', profile);
+    await (ak.restoreArtifacts as (a: string, b: string, o: { log(m: string): void }) => void)(
+      profileDirP, cache, { log: (m: string) => ctx.log('feature-pack', '[keep] ' + m) });
+  } catch (err) {
+    ctx.log('feature-pack', 'artifact 回填失败（继续）: ' + String((err as Error).message));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 清单模型与校验（与 docs/schemas/feature-pack-pack.json 保持一致的实现）
+// ---------------------------------------------------------------------------
+
+export interface PackPluginRef {
+  ref: string;
+  source: 'builtin' | 'github' | 'market';
+  pkg: string | null;      // 装配用的包名/源（npm 名或 github:o/r；builtin 为 null）
+  version?: string | null; // 期望范围（github/market）
+  managed: boolean;        // 是否由本包安装（builtin 恒 false）
+  installed: boolean;
+}
+export interface PackPresetRef { id: string; installed: boolean; skipped: boolean }
+export interface PackSkillRef { id: string; installed: boolean; skipped: boolean }
+
+export interface PackManifest {
+  formatVersion: number;
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  license?: string;
+  icon?: string;
+  requires?: { dsh?: string };
+  plugins?: { ref: string; version?: string; enabled?: boolean }[];
+  presets?: { id: string }[];
+  skills?: { id: string }[];
+  conflicts?: string[];
+  overrides?: string[];
+  changelog?: string;
+}
+
+export interface PackRecord {
+  id: string;
+  version: string;
+  installedAt: string;
+  profile: string;
+  state: 'active' | 'incompatible' | 'rolled-back';
+  source: string;
+  manifest: PackManifest;
+  plugins: PackPluginRef[];
+  presets: PackPresetRef[];
+  skills: PackSkillRef[];
+  snapshotRef: string | null;
+  opRef: string | null;
+}
+
+export interface PackRegistry { version: number; packs: PackRecord[] }
+
+const ID_RE = /^[a-z0-9][a-z0-9._-]{2,63}$/;
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function validateManifest(m: unknown): { ok: boolean; errors: string[] } {
+  const errors: string[] = [];
+  if (!m || typeof m !== 'object') { return { ok: false, errors: ['pack.json 不是对象'] }; }
+  const o = m as Record<string, unknown>;
+  if (o.formatVersion !== 1) errors.push('formatVersion 必须为 1');
+  if (typeof o.id !== 'string' || !ID_RE.test(o.id)) {
+    errors.push('id 必须匹配 ^[a-z0-9][a-z0-9._-]{2,63}$');
+  }
+  if (typeof o.name !== 'string' || o.name.length < 1 || o.name.length > 64) {
+    errors.push('name 必须为 1–64 字符字符串');
+  }
+  if (typeof o.version !== 'string' || !SEMVER_RE.test(o.version)) {
+    errors.push('version 必须为 semver（如 1.2.0 / 0.1.1-rc.2）');
+  }
+  if (o.description !== undefined && (typeof o.description !== 'string' || o.description.length > 500)) {
+    errors.push('description 必须为 ≤500 字符字符串');
+  }
+  if (o.author !== undefined && (typeof o.author !== 'string' || o.author.length > 128)) {
+    errors.push('author 必须为 ≤128 字符字符串');
+  }
+  if (o.license !== undefined && (typeof o.license !== 'string' || o.license.length > 64)) {
+    errors.push('license 必须为 ≤64 字符字符串');
+  }
+  if (o.icon !== undefined && (typeof o.icon !== 'string' || !/^[A-Za-z0-9._/-]+\.png$/.test(o.icon))) {
+    errors.push('icon 必须为包内 .png 相对路径');
+  }
+  if (o.requires !== undefined) {
+    const r = o.requires as Record<string, unknown>;
+    if (!r || typeof r !== 'object' || Array.isArray(r)) {
+      errors.push('requires 必须为对象');
+    } else if (r.dsh !== undefined && (typeof r.dsh !== 'string' || r.dsh.length < 1 || r.dsh.length > 256)) {
+      errors.push('requires.dsh 必须为 1–256 字符范围字符串');
+    }
+  }
+  if (o.plugins !== undefined) {
+    if (!Array.isArray(o.plugins) || o.plugins.length > 64) errors.push('plugins 必须为 ≤64 数组');
+    else for (const [i, p] of o.plugins.entries()) {
+      const pp = p as Record<string, unknown>;
+      if (!pp || typeof pp !== 'object' || typeof pp.ref !== 'string' || !pp.ref) {
+        errors.push(`plugins[${i}].ref 必须为非空字符串`);
+      } else if (pp.version !== undefined && (typeof pp.version !== 'string' || pp.version.length > 256)) {
+        errors.push(`plugins[${i}].version 必须为 ≤256 字符范围字符串`);
+      } else if (pp.enabled !== undefined && typeof pp.enabled !== 'boolean') {
+        errors.push(`plugins[${i}].enabled 必须为布尔`);
+      }
+    }
+  }
+  if (o.presets !== undefined) {
+    if (!Array.isArray(o.presets) || o.presets.length > 32) errors.push('presets 必须为 ≤32 数组');
+    else for (const [i, p] of o.presets.entries()) {
+      const pp = p as Record<string, unknown>;
+      if (!pp || typeof pp !== 'object' || typeof pp.id !== 'string' || !/^[A-Za-z0-9._-]+$/.test(pp.id)) {
+        errors.push(`presets[${i}].id 非法`);
+      }
+    }
+  }
+  if (o.skills !== undefined) {
+    if (!Array.isArray(o.skills) || o.skills.length > 32) errors.push('skills 必须为 ≤32 数组');
+    else for (const [i, s] of o.skills.entries()) {
+      const ss = s as Record<string, unknown>;
+      if (!ss || typeof ss !== 'object' || typeof ss.id !== 'string' || !/^[A-Za-z0-9._-]+$/.test(ss.id)) {
+        errors.push(`skills[${i}].id 非法`);
+      }
+    }
+  }
+  if (o.conflicts !== undefined) {
+    if (!Array.isArray(o.conflicts) || o.conflicts.length > 64) errors.push('conflicts 必须为 ≤64 数组');
+    else for (const c of o.conflicts) if (typeof c !== 'string' || !c) errors.push('conflicts 项必须为非空字符串');
+  }
+  if (o.overrides !== undefined) {
+    // v1 预留：必须为空数组（避免目录穿越路径进入安装器）。
+    if (!Array.isArray(o.overrides) || o.overrides.length !== 0) {
+      errors.push('overrides 为 v1 预留字段，必须为空数组');
+    }
+  }
+  if (o.changelog !== undefined && (typeof o.changelog !== 'string' || o.changelog.length > 2000)) {
+    errors.push('changelog 必须为 ≤2000 字符字符串');
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+// ---------------------------------------------------------------------------
+// semver 范围匹配（spec §5.1；宽容预发布策略）
+// ---------------------------------------------------------------------------
+
+interface Version { major: number; minor: number; patch: number; pre: string[] }
+
+export function parseVersion(v: string): Version | null {
+  const m = SEMVER_RE.exec(v);
+  if (!m) return null;
+  const major = Number(m[1]); const minor = Number(m[2]); const patch = Number(m[3]);
+  const pre = m[4] ? m[4].split('.') : [];
+  return { major, minor, patch, pre };
+}
+
+// 比较两个版本（标准 semver tuple 序；稳定版本恒大于同段的预发布版本）。
+export function compareVersions(a: string, b: string): number {
+  const va = parseVersion(a); const vb = parseVersion(b);
+  if (!va) return a < b ? -1 : a > b ? 1 : 0;
+  if (!vb) return b < a ? 1 : b > a ? -1 : 0;
+  for (const k of ['major', 'minor', 'patch'] as const) {
+    if (va[k] !== vb[k]) return va[k] < vb[k] ? -1 : 1;
+  }
+  if (va.pre.length === 0 && vb.pre.length === 0) return 0;
+  if (va.pre.length === 0) return 1;   // stable > pre
+  if (vb.pre.length === 0) return -1;
+  const n = Math.max(va.pre.length, vb.pre.length);
+  for (let i = 0; i < n; i++) {
+    const pa = va.pre[i]; const pb = vb.pre[i];
+    if (pa === undefined) return -1;
+    if (pb === undefined) return 1;
+    if (pa === pb) continue;
+    const na = /^\d+$/.test(pa); const nb = /^\d+$/.test(pb);
+    if (na && nb) { const d = Number(pa) - Number(pb); if (d) return d < 0 ? -1 : 1; }
+    else if (na) return -1;          // 数字标识符 < 字母标识符
+    else if (nb) return 1;
+    else { const d = pa < pb ? -1 : pa > pb ? 1 : 0; if (d) return d; }
+  }
+  return 0;
+}
+
+interface RangePart {
+  // op: '>=','>','<=','<','='；target 解析后的版本；hasPre：范围已声明预发布。
+  op: '>=' | '>' | '<=' | '<' | '=';
+  target: Version | null;   // null 表示 *（任意）
+  hasPre: boolean;
+}
+
+// 半开区间展开：^ 上界 = 下个 major；~ / 部分版本的上界按段递增。
+function boundMajor(major: number, minor: number, patch: number): RangePart[] {
+  return [
+    { op: '>=', target: { major, minor, patch, pre: [] }, hasPre: false },
+    { op: '<', target: { major: major + 1, minor: 0, patch: 0, pre: [] }, hasPre: false },
+  ];
+}
+function boundMinor(major: number, minor: number, patch: number): RangePart[] {
+  return [
+    { op: '>=', target: { major, minor, patch, pre: [] }, hasPre: false },
+    { op: '<', target: { major, minor: minor + 1, patch: 0, pre: [] }, hasPre: false },
+  ];
+}
+
+function parseRangePart(raw: string): RangePart[] | null {
+  const s = raw.trim();
+  if (!s || s === '*' || s === 'x' || s === 'X') return [{ op: '>=', target: null, hasPre: false }];
+  const m = /^(>=|<=|>|<|=|\^|~)?(.*)$/.exec(s)!;
+  const op = m[1] || '=';
+  let rest = (m[2] || '').trim();
+  // 部分版本（1.2 / 1 / 1.2.x / 1.x）：裸字面量 / ^ / ~ 展开为半开区间；
+  // 比较符（>=<=><）只按补齐零的完整版本单项比较（>=1.2 ≙ >=1.2.0）。
+  // 仅当段数不足三段或含 x 通配时才走部分展开；完整三段走下方 semver 分支。
+  const partialRe = /^(\d+)(?:\.([0-9xX*]+))?(?:\.([0-9xX*]+))?$/;
+  const partial = partialRe.exec(rest);
+  const segCount = rest.split('.').length;
+  if (partial && (/[xX*]/.test(rest) || segCount < 3)) {
+    const major = Number(partial[1]);
+    const minorTxt = partial[2];
+    const patchTxt = partial[3];
+    const minor = minorTxt !== undefined && !/[xX*]/.test(minorTxt) ? Number(minorTxt) : undefined;
+    const patch = patchTxt !== undefined && !/[xX*]/.test(patchTxt) ? Number(patchTxt) : undefined;
+    const rangeLike = op === '=' || op === '^' || op === '~';
+    const single = (): RangePart[] => [{ op: (op as '>=' | '>' | '<=' | '<' | '='), target: { major, minor: minor ?? 0, patch: patch ?? 0, pre: [] }, hasPre: false }];
+    if (minor === undefined) return rangeLike ? boundMajor(major, 0, 0) : single();   // 1 / 1.x → >=1.0.0 <2.0.0
+    if (patch === undefined) return rangeLike ? boundMinor(major, minor, 0) : single(); // 1.2 / 1.2.x → >=1.2.0 <1.3.0
+    return rangeLike ? boundMinor(major, minor, patch) : single();                     // 1.2.3 (≡=) → 精确以上端
+  }
+  // 完整 semver（可带预发布）。
+  const vm = SEMVER_RE.exec(rest);
+  if (!vm) return null;
+  const major = Number(vm[1]); const minor = Number(vm[2]); const patch = Number(vm[3]);
+  const pre = vm[4] ? vm[4].split('.') : [];
+  const hasPre = pre.length > 0;
+  const target: Version = { major, minor, patch, pre };
+  if (op === '^') {
+    if (major > 0) return [{ op: '>=', target, hasPre }, { op: '<', target: { major: major + 1, minor: 0, patch: 0, pre: [] }, hasPre: false }];
+    if (minor > 0) return [{ op: '>=', target, hasPre }, { op: '<', target: { major: 0, minor: minor + 1, patch: 0, pre: [] }, hasPre: false }];
+    return [{ op: '>=', target, hasPre }, { op: '<', target: { major: 0, minor: 0, patch: patch + 1, pre: [] }, hasPre: false }];
+  }
+  if (op === '~') {
+    return [{ op: '>=', target, hasPre }, { op: '<', target: { major, minor: minor + 1, patch: 0, pre: [] }, hasPre: false }];
+  }
+  return [{ op: (op as '>=' | '>' | '<=' | '<' | '='), target, hasPre }];
+}
+
+function partMatch(p: RangePart, v: Version): boolean {
+  if (!p.target) return true;                    // *
+  if (p.hasPre || v.pre.length === 0) {
+    // 标准 tuple 比较。
+    const c = compareVersions(verStr(v), verStr(p.target));
+    switch (p.op) {
+      case '>=': return c >= 0;
+      case '>': return c > 0;
+      case '<=': return c <= 0;
+      case '<': return c < 0;
+      case '=': return c === 0;
+    }
+  }
+  // 宽容策略：范围未声明预发布、候选是预发布 → 按稳定段比较
+  // （0.1.1-rc.2 满足 =0.1.1 / >=0.1.1，不满足 >=0.1.2）。
+  const s = { major: v.major, minor: v.minor, patch: v.patch, pre: [] as string[] };
+  return partMatch({ ...p, target: p.target ? { ...p.target, pre: [] } : null }, s);
+}
+
+function verStr(v: Version): string {
+  return v.major + '.' + v.minor + '.' + v.patch + (v.pre.length ? '-' + v.pre.join('.') : '');
+}
+
+/** 解析若干"空格 AND"比较子 → 部分列表。 */
+function parseRangeParts(clause: string): RangePart[] | null {
+  const out: RangePart[] = [];
+  for (const raw of clause.trim().split(/\s+/)) {
+    if (!raw) continue;
+    const parts = parseRangePart(raw);
+    if (!parts) return null;
+    out.push(...parts);
+  }
+  return out.length ? out : null;
+}
+
+/**
+ * 匹配 semver 范围（spec §5.1）。支持 *｜空｜x.y.z｜比较符｜^｜~｜|| 或组｜
+ * 空格 AND｜部分版本（1.2 ≙ >=1.2.0 <1.3.0）。无法解析 → 保守返回 false。
+ */
+export function matchSemverRange(range: string | undefined, version: string): boolean {
+  if (!range || !range.trim() || range.trim() === '*') return true;
+  const v = parseVersion(version);
+  if (!v) return false;
+  for (const clause of range.split('||')) {
+    if (!clause.trim()) continue;
+    const parts = parseRangeParts(clause);
+    if (!parts) continue;                                    // 子句语法错误 → 跳过（保守不匹配）
+    if (parts.every((p) => partMatch(p, v))) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// zip 读取 / payload 解压
+// ---------------------------------------------------------------------------
+
+async function openZip(zipPath: string): Promise<{ files: ZipEntry[] }> {
+  try {
+    return await unzipper.Open.file(zipPath);
+  } catch (err) {
+    throw fail('打开 .dshpack 失败: ' + String((err as Error).message || err));
+  }
+}
+
+/** 解析 zip → 校验清单 → 返回 { manifest, zipFiles }。 */
+export async function parsePackZip(zipPath: string): Promise<{ manifest: PackManifest; zip: { files: ZipEntry[] } }> {
+  const zip = await openZip(zipPath);
+  const entry = zip.files.find((f) => f.path === 'pack.json');
+  if (!entry) throw fail('归档缺少 pack.json');
+  let raw: string;
+  try {
+    raw = (await entry.buffer()).toString('utf8').replace(/^\uFEFF/, '');
+  } catch (err) {
+    throw fail('读取 pack.json 失败: ' + String((err as Error).message || err));
+  }
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { throw fail('pack.json 不是合法 JSON'); }
+  const v = validateManifest(parsed);
+  if (!v.ok) throw fail('pack.json 校验失败: ' + v.errors.join('；'));
+  const manifest = parsed as PackManifest;
+  if (manifest.id + '-' + manifest.version !== path.basename(zipPath).replace(/\.dshpack$/i, '')) {
+    // 文件名约定校验（<id>-<version>.dshpack）；不强制（允许重命名），仅提示。
+    /* 空 */
+  }
+  return { manifest, zip };
+}
+
+// ---------------------------------------------------------------------------
+// 注册表
+// ---------------------------------------------------------------------------
+
+export function loadRegistry(home: string): PackRegistry {
+  const file = registryFile(home);
+  try {
+    const raw = fs.readFileSync(file, 'utf8').replace(/^\uFEFF/, '');
+    const parsed = JSON.parse(raw) as PackRegistry;
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.packs)) return parsed;
+  } catch { /* 缺省空注册表 */ }
+  return { version: 1, packs: [] };
+}
+
+export function saveRegistry(home: string, reg: PackRegistry): void {
+  fs.mkdirSync(featurePacksRoot(home), { recursive: true });
+  const file = registryFile(home);
+  const tmp = file + '.tmp-' + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify(reg, null, 2), 'utf8');
+  fs.renameSync(tmp, file);   // 原子替换
+}
+
+export function findPack(home: string, id: string): PackRecord | null {
+  return loadRegistry(home).packs.find((p) => p.id === id) || null;
+}
+
+// ---------------------------------------------------------------------------
+// 内核版本与兼容
+// ---------------------------------------------------------------------------
+
+export function resolveKernelVersion(): string {
+  try {
+    const profile = profileDirOf();
+    const pkgFile = path.join(profile, 'node_modules', '@deepseek-ai', 'dsh', 'package.json');
+    if (fs.existsSync(pkgFile)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf8'));
+      if (pkg && typeof pkg.version === 'string' && pkg.version) return pkg.version;
+    }
+  } catch { /* 回退内置 */ }
+  try {
+    const pkgFile = path.join(path.dirname(ctx.getDshBin()), '..', 'package.json');
+    if (fs.existsSync(pkgFile)) {
+      const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf8'));
+      if (pkg && typeof pkg.version === 'string' && pkg.version) return pkg.version;
+    }
+  } catch { /* 未知 */ }
+  return 'unknown';
+}
+
+export function checkPackCompat(manifest: Pick<PackManifest, 'requires'>, kernelVersion: string): { ok: boolean; range?: string } {
+  const range = manifest.requires && manifest.requires.dsh;
+  if (!range) return { ok: true };
+  return { ok: matchSemverRange(range, kernelVersion), range };
+}
+
+/** 启动/手动兼容扫描：active 包失配 → incompatible（幂等）；返回本次更新列表。 */
+export function scanFeaturePackCompatibility(): { checked: number; incompatible: string[] } {
+  const home = homeOf();
+  const reg = loadRegistry(home);
+  const kernel = resolveKernelVersion();
+  const incompatible: string[] = [];
+  let changed = false;
+  for (const pack of reg.packs) {
+    if (pack.state === 'rolled-back') continue;
+    const ok = checkPackCompat(pack.manifest, kernel).ok;
+    const next = ok ? 'active' : 'incompatible';
+    if (pack.state !== next) { pack.state = next; changed = true; }
+    if (!ok) incompatible.push(pack.id);
+  }
+  if (changed) { try { saveRegistry(home, reg); } catch (err) { ctx.log('feature-pack', '兼容扫描写回失败: ' + String((err as Error).message)); } }
+  return { checked: reg.packs.length, incompatible };
+}
+
+// ---------------------------------------------------------------------------
+// 子进程（dsh plugin）
+// ---------------------------------------------------------------------------
+
+export interface SpawnResult { code: number; output: string }
+
+export function runDshPlugin(args: string[], profile: string): Promise<SpawnResult> {
+  return new Promise((resolve) => {
+    const nodeBin = ctx.getNodeExe();
+    const bin = ctx.getDshBin();
+    if (!fs.existsSync(nodeBin) || !fs.existsSync(bin)) {
+      resolve({ code: EXIT_FAIL, output: '找不到 node/dsh CLI' });
+      return;
+    }
+    const child = cp.spawn(nodeBin, [bin, 'plugin', '--profile', profile, ...args], {
+      cwd: ctx.getUserDataDir(),
+      env: { ...ctx.getChildEnv(), CI: 'true' },
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    const onData = (c: Buffer): void => { output = (output + c.toString()).slice(-16000); };
+    child.stdout?.on('data', onData);
+    child.stderr?.on('data', onData);
+    child.on('error', (err) => resolve({ code: EXIT_FAIL, output: String((err as Error).message) }));
+    child.on('close', (code) => resolve({ code: code === null ? EXIT_FAIL : code, output }));
+  });
+}
+
+/** 判断输出是否命中 Windows 文件锁（EPERM/EBUSY）。 */
+export function isFileLockFailure(output: string): boolean {
+  return /EPERM|EBUSY|resource busy|being used by another process/i.test(output);
+}
+
+// ---------------------------------------------------------------------------
+// 内置插件 / 已启用插件
+// ---------------------------------------------------------------------------
+
+export function builtinPluginExists(dirName: string): boolean {
+  try {
+    return fs.existsSync(path.join(ctx.builtinSourceDir(dirName), 'package.json'));
+  } catch { return false; }
+}
+
+function patchEnabledNames(): string[] {
+  try {
+    if (ctx.enabledPluginNames) return ctx.enabledPluginNames();
+    const file = path.join(profileDirOf(), 'cordis.patch.yml');
+    if (!fs.existsSync(file)) return [];
+    const text = fs.readFileSync(file, 'utf8');
+    const names: string[] = [];
+    for (const m of text.matchAll(/-\s+name:\s*['"]?([^'"\s]+)/g)) {
+      const n = m[1];
+      if (n) names.push(n);
+    }
+    return names;
+  } catch { return []; }
+}
+
+// ---------------------------------------------------------------------------
+// payload：preset / skills 同步（沿用 skip-if-exists 纪律）
+// ---------------------------------------------------------------------------
+
+async function writeZipEntries(files: ZipEntry[], prefix: string, destDir: string): Promise<string[]> {
+  const written: string[] = [];
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const f of files) {
+    if (!f.path.startsWith(prefix)) continue;
+    const rel = f.path.slice(prefix.length).replace(/^\/+/, '');
+    if (!rel || rel.endsWith('/')) continue;
+    if (rel.split(/[/\\]/).includes('..')) continue;   // 防目录穿越
+    const out = path.join(destDir, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    fs.writeFileSync(out, await f.buffer());
+    written.push(out);
+  }
+  return written;
+}
+
+/** 安装 payload 中的 preset 目录（skip-if-exists 默认；目标带 .eac-package.json 时覆盖更新）。 */
+async function syncPayloadPreset(files: ZipEntry[], id: string, presetsRoot: string): Promise<{ installed: boolean; skipped: boolean }> {
+  const prefix = 'payload/presets/' + id + '/';
+  const has = files.some((f) => f.path.startsWith(prefix) && f.path.endsWith('preset.yml'));
+  if (!has) {
+    // 引用式：要求目标已存在。
+    if (fs.existsSync(path.join(presetsRoot, id, 'preset.yml'))) return { installed: false, skipped: false };
+    throw fail('preset 未内嵌且目标不存在: ' + id);
+  }
+  const dest = path.join(presetsRoot, id);
+  const managedMarker = path.join(dest, '.eac-package.json');
+  if (fs.existsSync(path.join(dest, 'preset.yml')) && !fs.existsSync(managedMarker)) {
+    return { installed: false, skipped: true };   // 用户自建同名：永不覆盖
+  }
+  await writeZipEntries(files, prefix, dest);
+  try {
+    fs.writeFileSync(managedMarker, JSON.stringify({ packId: null as string | null, managed: true, version: 1 }, null, 2) + '\n');
+  } catch { /* 标记写失败不阻断 */ }
+  return { installed: true, skipped: false };
+}
+
+/** 安装 payload 中的 skill 目录（现有 .eac-skill.json 托管语义 + packId 标记）。 */
+async function syncPayloadSkill(files: ZipEntry[], id: string, skillsRoot: string): Promise<{ installed: boolean; skipped: boolean }> {
+  const prefix = 'payload/skills/' + id + '/';
+  const has = files.some((f) => f.path.startsWith(prefix) && f.path.endsWith('SKILL.md'));
+  if (!has) {
+    if (fs.existsSync(path.join(skillsRoot, id, 'SKILL.md'))) return { installed: false, skipped: false };
+    throw fail('skill 未内嵌且目标不存在: ' + id);
+  }
+  const dest = path.join(skillsRoot, id);
+  const marker = path.join(dest, '.eac-skill.json');
+  const existing = ((): { version?: number; managed?: boolean } | null => {
+    try { return JSON.parse(fs.readFileSync(marker, 'utf8')); } catch { return null; }
+  })();
+  if (existing && fs.existsSync(path.join(dest, 'SKILL.md')) && existing.managed !== false) {
+    // 托管（含用户旧托管或本包）→ 覆盖更新。
+    await writeZipEntries(files, prefix, dest);
+    try {
+      fs.writeFileSync(marker, JSON.stringify({ ...(existing || {}), managed: true, version: (existing?.version || 1) + 1 }, null, 2) + '\n');
+    } catch { /* 尽力 */ }
+    return { installed: true, skipped: false };
+  }
+  if (fs.existsSync(path.join(dest, 'SKILL.md'))) {
+    return { installed: false, skipped: true };    // 用户自建：永不覆盖
+  }
+  await writeZipEntries(files, prefix, dest);
+  try { fs.writeFileSync(marker, JSON.stringify({ packId: null as string | null, managed: true, version: 1 }, null, 2) + '\n'); } catch { /* 尽力 */ }
+  return { installed: true, skipped: false };
+}
+
+// ---------------------------------------------------------------------------
+// 安装 / 卸载 / 更新 / 导出 / 回滚
+// ---------------------------------------------------------------------------
+
+export interface InstallResult { ok: boolean; stage?: string; error?: string; code?: number; recordId?: string; kernel?: string | null; range?: string | null }
+
+function refSourceOf(ref: string): { source: 'builtin' | 'github' | 'market'; pkg: string | null } {
+  if (ref.startsWith('builtin:')) {
+    const dir = ref.slice('builtin:'.length);
+    if (!dir || !/^[A-Za-z0-9._-]+$/.test(dir)) throw fail('builtin 引用非法: ' + ref);
+    return { source: 'builtin', pkg: null };
+  }
+  if (/^github:[^/]+\/[^/]+$/.test(ref)) return { source: 'github', pkg: ref };
+  if (!/^(@[a-z0-9-]+\/)?[a-z0-9._-]+$/.test(ref)) throw fail('插件引用非法: ' + ref);
+  return { source: 'market', pkg: ref };
+}
+
+/** 其他已装包对某插件的引用计数。 */
+function refCount(reg: PackRegistry, excludeId: string, pkg: string): number {
+  let n = 0;
+  for (const p of reg.packs) {
+    if (p.id === excludeId) continue;
+    if (p.plugins.some((pl) => pl.pkg === pkg || pl.ref === pkg)) n += 1;
+  }
+  return n;
+}
+
+async function assemblePlugin(plugin: { ref: string; version?: string }, profile: string): Promise<{ installed: boolean }> {
+  const { source, pkg } = refSourceOf(plugin.ref);
+  if (source === 'builtin') {
+    const dir = plugin.ref.slice('builtin:'.length);
+    if (!builtinPluginExists(dir)) throw fail('内置插件不存在: ' + dir);
+    return { installed: true };   // 只核验并登记，不复制不写行
+  }
+  if (!pkg) throw fail('插件装配目标缺失: ' + plugin.ref);
+  const r = await runDshPlugin(['add', pkg], profile);
+  if (r.code !== 0) {
+    if (isFileLockFailure(r.output)) throw Object.assign(fail('插件安装被文件锁阻塞: ' + pkg), { lock: true });
+    throw fail('插件安装失败 ' + pkg + ':\n' + r.output.slice(0, 800));
+  }
+  return { installed: true };
+}
+
+async function removePlugin(plugin: PackPluginRef, profile: string): Promise<void> {
+  if (plugin.source === 'builtin' || !plugin.pkg) return;
+  const r = await runDshPlugin(['remove', plugin.pkg], profile);
+  if (r.code !== 0) {
+    if (isFileLockFailure(r.output)) throw Object.assign(fail('插件移除被文件锁阻塞: ' + plugin.pkg), { lock: true });
+    if (!/not installed|没有安装|unknown/i.test(r.output)) {
+      ctx.log('feature-pack', '插件移除失败（继续） ' + plugin.pkg + ': ' + r.output.slice(0, 300));
+    }
+  }
+}
+
+async function extractZipTo(zip: { files: ZipEntry[] }, prefix: string, destDir: string): Promise<void> {
+  await writeZipEntries(zip.files, prefix, destDir);
+}
+
+export async function installPack(args: {
+  zipPath?: string;
+  manifest?: PackManifest;
+  zip?: { files: ZipEntry[] };
+  profile?: string;
+  force?: boolean;
+  opRef?: string | null;
+  source?: string;
+}): Promise<InstallResult> {
+  const home = homeOf();
+  const profile = args.profile || ctx.getDesktopProfile();
+  const source = args.source || (args.zipPath ? 'local-file' : 'manual');
+  const opRef = args.opRef || null;
+  const stage = (s: string): void => { ctx.log('feature-pack', '[install] ' + s); if (opRef) writeOpState(opRef, { stage: s, pct: null, message: s, done: false }); };
+  let manifestId: string | null = null;
+  try {
+    let manifest = args.manifest;
+    let zip = args.zip;
+    if (!manifest) {
+      if (!args.zipPath) throw fail('缺少 zipPath 或 manifest');
+      stage('解析清单');
+      const parsed = await parsePackZip(args.zipPath);
+      manifest = parsed.manifest; zip = parsed.zip;
+    }
+    if (!zip) zip = { files: [] };
+    const id = manifest.id;
+    manifestId = id;
+
+    stage('内核兼容检查');
+    const kernel = resolveKernelVersion();
+    const compat = checkPackCompat(manifest, kernel);
+    if (!compat.ok && !args.force) {
+      return { ok: false, code: EXIT_COMPAT, error: '内核 ' + kernel + ' 不在功能包兼容范围 ' + compat.range + '（可 --force 强制安装并标记不兼容）', kernel, range: compat.range || null };
+    }
+
+    stage('冲突预检');
+    const reg = loadRegistry(home);
+    const existing = findPack(home, id);
+    if (existing) {
+      return { ok: false, error: '功能包已安装（v' + existing.version + '），请使用 update', recordId: id };
+    }
+    const enabledNames = patchEnabledNames();
+    const conflictHits = (manifest.conflicts || []).filter((c) =>
+      reg.packs.some((p) => p.plugins.some((pl) => pl.ref === c || (pl.pkg && pl.pkg === c))) ||
+      enabledNames.some((n) => n === c || n === c.replace(/^builtin:/, '')));
+    if (conflictHits.length > 0) {
+      return { ok: false, code: EXIT_CONFLICT, error: '与已启用插件冲突: ' + conflictHits.join(', ') };
+    }
+
+    stage('保护中心快照');
+    let snapshotRef: string | null = null;
+    if (ctx.snapshot) {
+      try { snapshotRef = ctx.snapshot('pack:' + id + ':' + manifest.version)?.id || null; } catch (err) { ctx.log('feature-pack', '快照失败（继续）: ' + String((err as Error).message)); }
+    }
+
+    // 包数据目录（payload/icon 保留，供导出与覆盖更新）。
+    const dataDir = packDataDir(home, id);
+    fs.mkdirSync(dataDir, { recursive: true });
+
+    // 装配 plugins。
+    const plugins: PackPluginRef[] = [];
+    stage('装配插件（' + (manifest.plugins || []).length + ' 个）');
+    await snapshotArtifactsFor(profile);
+    for (const p of manifest.plugins || []) {
+      const { source: src, pkg } = refSourceOf(p.ref);
+      const installed = await assemblePlugin(p, profile);
+      plugins.push({ ref: p.ref, source: src, pkg, version: p.version || null, managed: src !== 'builtin', installed: installed.installed });
+    }
+
+    // payload：presets / skills。
+    const presets: PackPresetRef[] = [];
+    stage('同步预设（' + (manifest.presets || []).length + ' 个）');
+    for (const pr of manifest.presets || []) {
+      const r = await syncPayloadPreset(zip.files, pr.id, path.join(home, '.agent-presets'));
+      presets.push({ id: pr.id, installed: r.installed, skipped: r.skipped });
+    }
+    const skills: PackSkillRef[] = [];
+    stage('同步技能（' + (manifest.skills || []).length + ' 个）');
+    for (const sk of manifest.skills || []) {
+      const r = await syncPayloadSkill(zip.files, sk.id, path.join(home, 'skills'));
+      skills.push({ id: sk.id, installed: r.installed, skipped: r.skipped });
+    }
+
+    // payload 原始目录保留到包数据目录（导出用）；icon 同样。
+    if (zip.files.some((f) => f.path.startsWith('payload/'))) {
+      await extractZipTo(zip, 'payload/', packPayloadDir(home, id));
+    }
+    if (manifest.icon && zip.files.some((f) => f.path === manifest.icon)) {
+      await extractZipTo(zip, manifest.icon.slice(0, manifest.icon.lastIndexOf('/') + 1), dataDir);
+    }
+    await restoreArtifactsFor(profile);
+
+    // 注册表。
+    const record: PackRecord = {
+      id, version: manifest.version,
+      installedAt: new Date().toISOString(),
+      profile, state: compat.ok ? 'active' : 'incompatible',
+      source, manifest, plugins, presets, skills,
+      snapshotRef, opRef,
+    };
+    reg.packs.push(record);
+    saveRegistry(home, reg);
+    stage('安装完成');
+    if (opRef) writeOpState(opRef, { stage: 'done', pct: 100, message: '安装完成', done: true, ok: true });
+    return { ok: true, recordId: id };
+  } catch (err) {
+    const e = err as Error & { lock?: boolean };
+    ctx.log('feature-pack', '安装失败: ' + e.message);
+    if (opRef) writeOpState(opRef, { stage: 'failed', pct: null, message: e.message, done: true, ok: false, error: e.message });
+    // 清理半成品包数据目录（未入册，无需回滚注册表）。
+    if (manifestId) {
+      try { fs.rmSync(packDataDir(home, manifestId), { recursive: true, force: true }); } catch { /* 尽力清理 */ }
+    }
+    return { ok: false, stage: 'error', error: e.message, code: e.lock ? EXIT_LOCK : EXIT_FAIL };
+  }
+}
+
+export async function uninstallPack(id: string, opts: { opRef?: string | null } = {}): Promise<{ ok: boolean; error?: string; code?: number }> {
+  const home = homeOf();
+  const opRef = opts.opRef || null;
+  try {
+    const reg = loadRegistry(home);
+    const rec = reg.packs.find((p) => p.id === id);
+    if (!rec) return { ok: false, error: '未安装该功能包: ' + id, code: EXIT_FAIL };
+    const profile = rec.profile || ctx.getDesktopProfile();
+
+    // 插件：managed 且无其他包引用 → 移除（builtin 不动作）。
+    await snapshotArtifactsFor(profile);
+    for (const pl of rec.plugins) {
+      if (pl.source === 'builtin' || !pl.managed) continue;
+      if (refCount(reg, id, pl.pkg || pl.ref) > 0) continue;
+      ctx.log('feature-pack', '移除包所属插件: ' + (pl.pkg || pl.ref));
+      await removePlugin(pl, profile);
+    }
+    await restoreArtifactsFor(profile);
+
+    // preset：由本包装且未被跳过 → 带托管标记的目录删除。
+    for (const pr of rec.presets) {
+      if (!pr.installed || pr.skipped) continue;
+      const dest = path.join(home, '.agent-presets', pr.id);
+      try {
+        if (fs.existsSync(path.join(dest, '.eac-package.json'))) fs.rmSync(dest, { recursive: true, force: true });
+      } catch (err) { ctx.log('feature-pack', 'preset 清理失败（继续）: ' + String((err as Error).message)); }
+    }
+
+    // skills：托管标记删除。
+    for (const sk of rec.skills) {
+      if (!sk.installed || sk.skipped) continue;
+      const dest = path.join(home, 'skills', sk.id);
+      try {
+        const marker = path.join(dest, '.eac-skill.json');
+        if (fs.existsSync(marker)) {
+          const m = JSON.parse(fs.readFileSync(marker, 'utf8')) as { managed?: boolean };
+          if (m.managed !== false) fs.rmSync(dest, { recursive: true, force: true });
+        }
+      } catch (err) { ctx.log('feature-pack', 'skill 清理失败（继续）: ' + String((err as Error).message)); }
+    }
+
+    // 包数据目录 + 注册表记录。
+    fs.rmSync(packDataDir(home, id), { recursive: true, force: true });
+    reg.packs = reg.packs.filter((p) => p.id !== id);
+    saveRegistry(home, reg);
+    if (opRef) writeOpState(opRef, { stage: 'done', pct: 100, message: '卸载完成', done: true, ok: true });
+    return { ok: true };
+  } catch (err) {
+    const e = err as Error;
+    if (opRef) writeOpState(opRef, { stage: 'failed', pct: null, message: e.message, done: true, ok: false, error: e.message });
+    return { ok: false, error: e.message, code: EXIT_FAIL };
+  }
+}
+
+export async function updatePack(id: string, args: { zipPath?: string; manifest?: PackManifest; zip?: { files: ZipEntry[] }; force?: boolean; opRef?: string | null }): Promise<InstallResult> {
+  const home = homeOf();
+  const opRef = args.opRef || null;
+  const stage = (s: string): void => { ctx.log('feature-pack', '[update] ' + s); if (opRef) writeOpState(opRef, { stage: s, pct: null, message: s, done: false }); };
+  try {
+    const reg = loadRegistry(home);
+    const rec = reg.packs.find((p) => p.id === id);
+    if (!rec) return { ok: false, error: '未安装该功能包: ' + id, code: EXIT_FAIL };
+    let manifest = args.manifest;
+    let zip = args.zip;
+    if (!manifest) {
+      if (!args.zipPath) throw fail('缺少 zipPath 或 manifest');
+      const parsed = await parsePackZip(args.zipPath);
+      manifest = parsed.manifest; zip = parsed.zip;
+    }
+    if (manifest.id !== id) throw fail('更新包 id 不一致: ' + manifest.id);
+    if (!zip) zip = { files: [] };
+
+    stage('内核兼容检查');
+    const kernel = resolveKernelVersion();
+    const compat = checkPackCompat(manifest, kernel);
+    if (!compat.ok && !args.force) {
+      return { ok: false, code: EXIT_COMPAT, error: '内核 ' + kernel + ' 不在新版本兼容范围 ' + compat.range, kernel, range: compat.range || null };
+    }
+
+    stage('冲突预检');
+    const enabledNames = patchEnabledNames();
+    const conflictHits = (manifest.conflicts || []).filter((c) =>
+      reg.packs.some((p) => p.id !== id && p.plugins.some((pl) => pl.ref === c || (pl.pkg && pl.pkg === c))) ||
+      enabledNames.some((n) => n === c || n === c.replace(/^builtin:/, '')));
+    if (conflictHits.length > 0) return { ok: false, code: EXIT_CONFLICT, error: '与已启用插件冲突: ' + conflictHits.join(', ') };
+
+    stage('保护中心快照');
+    let snapshotRef: string | null = null;
+    if (ctx.snapshot) {
+      try { snapshotRef = ctx.snapshot('pack-update:' + id + ':' + manifest.version)?.id || null; } catch { /* 继续 */ }
+    }
+
+    // 插件差异：移除不再引用的 owned；新增引用装配。
+    const profile = rec.profile || ctx.getDesktopProfile();
+    await snapshotArtifactsFor(profile);
+    const oldPlugins = rec.plugins;
+    const newRefs = (manifest.plugins || []).map((p) => p.ref);
+    const plugins: PackPluginRef[] = [];
+    for (const old of oldPlugins) {
+      if (old.managed && !newRefs.includes(old.ref)) {
+        if (refCount(reg, id, old.pkg || old.ref) === 0) {
+          ctx.log('feature-pack', '更新移除不再引用插件: ' + (old.pkg || old.ref));
+          removePlugin(old, profile);
+        }
+      }
+    }
+    for (const p of manifest.plugins || []) {
+      const prev = oldPlugins.find((o) => o.ref === p.ref);
+      const { source: src, pkg } = refSourceOf(p.ref);
+      const versionChanged = !!prev && !!p.version && prev.version !== p.version;
+      if (versionChanged && src !== 'builtin' && pkg) {
+        // 期望版本变化 → 升级式重装（remove + add）。
+        await removePlugin(prev, profile);
+      }
+      if (!prev || versionChanged) {
+        const installed = await assemblePlugin(p, profile);
+        plugins.push({ ref: p.ref, source: src, pkg, version: p.version || null, managed: src !== 'builtin', installed: installed.installed });
+      } else {
+        plugins.push({ ...prev, version: p.version || prev.version || null });
+      }
+    }
+    await restoreArtifactsFor(profile);
+
+    // payload 差异。
+    const presets: PackPresetRef[] = [];
+    for (const pr of manifest.presets || []) {
+      const r = await syncPayloadPreset(zip.files, pr.id, path.join(home, '.agent-presets'));
+      presets.push({ id: pr.id, installed: r.installed, skipped: r.skipped });
+    }
+    const skills: PackSkillRef[] = [];
+    for (const sk of manifest.skills || []) {
+      const r = await syncPayloadSkill(zip.files, sk.id, path.join(home, 'skills'));
+      skills.push({ id: sk.id, installed: r.installed, skipped: r.skipped });
+    }
+    // 不再引用的 managed payload 删除。
+    for (const pr of rec.presets) {
+      if (pr.installed && !pr.skipped && !presets.some((n) => n.id === pr.id)) {
+        const dest = path.join(home, '.agent-presets', pr.id);
+        try { if (fs.existsSync(path.join(dest, '.eac-package.json'))) fs.rmSync(dest, { recursive: true, force: true }); } catch { /* 继续 */ }
+      }
+    }
+    for (const sk of rec.skills) {
+      if (sk.installed && !sk.skipped && !skills.some((n) => n.id === sk.id)) {
+        const dest = path.join(home, 'skills', sk.id);
+        try {
+          const marker = path.join(dest, '.eac-skill.json');
+          if (fs.existsSync(marker)) {
+            const m = JSON.parse(fs.readFileSync(marker, 'utf8')) as { managed?: boolean };
+            if (m.managed !== false) fs.rmSync(dest, { recursive: true, force: true });
+          }
+        } catch { /* 继续 */ }
+      }
+    }
+
+    // payload/icon 更新到包数据目录。
+    if (zip.files.some((f) => f.path.startsWith('payload/'))) {
+      fs.rmSync(packPayloadDir(home, id), { recursive: true, force: true });
+      await extractZipTo(zip, 'payload/', packPayloadDir(home, id));
+    }
+    if (manifest.icon && zip.files.some((f) => f.path === manifest.icon)) {
+      await extractZipTo(zip, manifest.icon.slice(0, manifest.icon.lastIndexOf('/') + 1), packDataDir(home, id));
+    }
+
+    rec.version = manifest.version;
+    rec.manifest = manifest;
+    rec.state = compat.ok ? 'active' : 'incompatible';
+    rec.plugins = plugins;
+    rec.presets = presets;
+    rec.skills = skills;
+    rec.snapshotRef = snapshotRef;
+    rec.opRef = opRef;
+    saveRegistry(home, reg);
+    stage('更新完成');
+    if (opRef) writeOpState(opRef, { stage: 'done', pct: 100, message: '更新完成', done: true, ok: true });
+    return { ok: true, recordId: id };
+  } catch (err) {
+    const e = err as Error & { lock?: boolean };
+    ctx.log('feature-pack', '更新失败: ' + e.message);
+    if (opRef) writeOpState(opRef, { stage: 'failed', pct: null, message: e.message, done: true, ok: false, error: e.message });
+    return { ok: false, stage: 'error', error: e.message, code: e.lock ? EXIT_LOCK : EXIT_FAIL };
+  }
+}
+
+export async function exportPack(id: string, outZip: string): Promise<{ ok: boolean; error?: string; path?: string }> {
+  try {
+    const home = homeOf();
+    const rec = findPack(home, id);
+    if (!rec) return { ok: false, error: '未安装该功能包: ' + id };
+    const dataDir = packDataDir(home, id);
+    const payloadDir = packPayloadDir(home, id);
+    fs.mkdirSync(path.dirname(outZip), { recursive: true });
+    return new Promise<{ ok: boolean; error?: string; path?: string }>((resolve) => {
+      const z = archiver('zip', { zlib: { level: 9 } });
+      const out = fs.createWriteStream(outZip);
+      const done = (r: { ok: boolean; error?: string; path?: string }): void => { try { out.close(); } catch { /* 已关闭 */ } resolve(r); };
+      z.on('error', (err) => done({ ok: false, error: String((err as Error).message) }));
+      out.on('error', (err) => done({ ok: false, error: String((err as Error).message) }));
+      z.pipe(out);
+      z.append(JSON.stringify({ ...rec.manifest, formatVersion: 1 }, null, 2) + '\n', { name: 'pack.json' });
+      // 保留的 payload。
+      try {
+        if (fs.existsSync(payloadDir)) {
+          for (const dir of ['presets', 'skills']) {
+            const base = path.join(payloadDir, dir);
+            if (!fs.existsSync(base)) continue;
+            for (const name of fs.readdirSync(base)) {
+              z.directory(path.join(base, name), 'payload/' + dir + '/' + name);
+            }
+          }
+        }
+      } catch { /* payload 缺失不影响导出 */
+      }
+      // icon。
+      try {
+        if (rec.manifest.icon) {
+          const iconPath = path.join(dataDir, path.basename(rec.manifest.icon));
+          if (fs.existsSync(iconPath)) {
+            z.append(fs.readFileSync(iconPath), { name: rec.manifest.icon });
+          }
+        }
+      } catch { /* 忽略 */ }
+      z.finalize().then(() => done({ ok: true, path: outZip })).catch((err: Error) => done({ ok: false, error: err.message }));
+    });
+  } catch (err) {
+    return { ok: false, error: String((err as Error).message) };
+  }
+}
+
+export function rollbackPack(id: string): { ok: boolean; error?: string } {
+  const home = homeOf();
+  const rec = findPack(home, id);
+  if (!rec) return { ok: false, error: '未安装该功能包: ' + id };
+  if (!rec.snapshotRef) return { ok: false, error: '该功能包没有保护中心快照（无法回滚）' };
+  if (!ctx.restoreSnapshot) return { ok: false, error: '保护中心回滚能力不可用' };
+  const r = ctx.restoreSnapshot(rec.snapshotRef);
+  if (!r.ok) return { ok: false, error: r.error || '回滚失败' };
+  rec.state = 'rolled-back';
+  const reg = loadRegistry(home);
+  const rec2 = reg.packs.find((p) => p.id === id);
+  if (rec2) { rec2.state = 'rolled-back'; saveRegistry(home, reg); }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// op 状态文件与排队 resume
+// ---------------------------------------------------------------------------
+
+export interface OpState {
+  opRef: string;
+  action: string;
+  stage: string;
+  pct: number | null;
+  message: string;
+  done: boolean;
+  ok: boolean | undefined;
+  error: string | undefined;
+}
+
+export function writeOpState(opRef: string, partial: Omit<OpState, 'opRef' | 'action' | 'ok' | 'error'> & { action?: string; ok?: boolean; error?: string }): void {
+  try {
+    const home = homeOf();
+    fs.mkdirSync(opsDir(home), { recursive: true });
+    const prev = readOpState(opRef);
+    const next: OpState = { opRef, action: partial.action || prev?.action || 'op', stage: partial.stage, pct: partial.pct ?? prev?.pct ?? null, message: partial.message, done: partial.done, ok: partial.ok, error: partial.error };
+    const file = path.join(opsDir(home), opRef + '.json');
+    const tmp = file + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2), 'utf8');
+    fs.renameSync(tmp, file);
+  } catch { /* 状态文件尽力而为 */ }
+}
+
+export function readOpState(opRef: string): OpState | null {
+  try {
+    const file = path.join(opsDir(homeOf()), opRef + '.json');
+    if (!fs.existsSync(file)) return null;
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as OpState;
+  } catch { return null; }
+}
+
+export interface PendingTask { action: 'install' | 'uninstall' | 'update'; id?: string; zipPath?: string; force?: boolean; opRef?: string; attempts?: number; ts?: number }
+export interface PendingFile { version: number; tasks: PendingTask[] }
+
+export function loadPending(): PendingFile {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(pendingFile(homeOf()), 'utf8')) as PendingFile;
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.tasks)) return parsed;
+  } catch { /* 缺省空 */ }
+  return { version: 1, tasks: [] };
+}
+
+export function savePending(p: PendingFile): void {
+  const home = homeOf();
+  fs.mkdirSync(opsDir(home), { recursive: true });
+  const file = pendingFile(home);
+  const tmp = file + '.tmp-' + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify(p, null, 2), 'utf8');
+  fs.renameSync(tmp, file);
+}
+
+export function enqueuePending(task: PendingTask): void {
+  const p = loadPending();
+  p.tasks.push({ ...task, attempts: task.attempts || 0, ts: Date.now() });
+  savePending(p);
+}
+
+/** 无锁窗口消费排队任务（sidecar 在旧进程退出后调用）；失败任务 attempts+1，超限丢弃。 */
+export async function resumePending(): Promise<{ ok: boolean; results: { action: string; id: string | undefined; ok: boolean; error: string | undefined }[]; skipped: string[] }> {
+  const p = loadPending();
+  if (p.tasks.length === 0) return { ok: true, results: [], skipped: [] };
+  const results: { action: string; id: string | undefined; ok: boolean; error: string | undefined }[] = [];
+  const skipped: string[] = [];
+  const PENDING_MAX = 3;
+  for (const t of p.tasks) {
+    const attempts = t.attempts || 0;
+    try {
+      let r: InstallResult | { ok: boolean; error?: string; code?: number };
+      if (t.action === 'install') {
+        r = await installPack({ ...(t.zipPath ? { zipPath: t.zipPath } : {}), ...(t.force ? { force: true } : {}), opRef: t.opRef ?? null, source: 'pending' });
+      } else if (t.action === 'update') {
+        if (!t.id) { skipped.push('update 缺少 id'); continue; }
+        r = await updatePack(t.id, { ...(t.zipPath ? { zipPath: t.zipPath } : {}), ...(t.force ? { force: true } : {}), opRef: t.opRef ?? null });
+      } else {
+        if (!t.id) { skipped.push('uninstall 缺少 id'); continue; }
+        r = await uninstallPack(t.id, { opRef: t.opRef ?? null });
+      }
+      if (!r.ok) {
+        const error = r.error || '';
+        if (attempts + 1 >= PENDING_MAX) {
+          skipped.push((t.id || t.zipPath || '?') + '（连续 ' + (attempts + 1) + ' 次失败，放弃: ' + error.slice(0, 200) + '）');
+        } else {
+          t.attempts = attempts + 1;
+          results.push({ action: t.action, id: t.id, ok: false, error: '待重试: ' + error.slice(0, 200) });
+          continue;   // 保留任务
+        }
+      } else {
+        results.push({ action: t.action, id: t.id, ok: true, error: undefined });
+      }
+    } catch (err) {
+      const error = String((err as Error).message);
+      if (attempts + 1 >= PENDING_MAX) skipped.push((t.id || t.zipPath || '?') + '（异常放弃: ' + error.slice(0, 200) + '）');
+      else { t.attempts = attempts + 1; results.push({ action: t.action, id: t.id, ok: false, error: '待重试: ' + error.slice(0, 200) }); continue; }
+    }
+    p.tasks = p.tasks.filter((x) => x !== t);
+  }
+  if (p.tasks.length === 0) {
+    try { fs.rmSync(pendingFile(homeOf()), { force: true }); } catch { /* 尽力 */ }
+  } else {
+    savePending(p);
+  }
+  return { ok: true, results, skipped };
+}

--- a/dsh-desktop/lib/desktop/market.ts
+++ b/dsh-desktop/lib/desktop/market.ts
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 // 插件市场排队任务（ADR 0002 L2 业务服务层；Wave 2 自 market.js 类型化迁出，
 // 行为零变更）：服务运行中安装/卸载撞上 Windows 文件锁（EPERM，如
@@ -41,10 +41,14 @@ export function init(d: MarketCtx): void { ctx = d; }
 interface MarketJob {
   target: string;
   profile: string;
-  kind: 'install' | 'uninstall';
+  kind: 'install' | 'uninstall' | 'pack-install' | 'pack-uninstall' | 'pack-update';
   label?: string;
+  /** 功能包任务专用：包 id（pack-update / pack-uninstall）。 */
+  packId?: string;
   attempts?: number;
 }
+
+const MARKET_KINDS: ReadonlySet<string> = new Set(['install', 'uninstall', 'pack-install', 'pack-uninstall', 'pack-update']);
 
 // V4 退出清理：当前正在执行的插件市场排队任务子进程（退出时强杀）。
 // 由 main.js 的 before-quit 经 getMarketOpChild() 读取。
@@ -84,7 +88,7 @@ export function pendingMarketMarkers(): { marker: string; job: MarketJob }[] {
         const job = JSON.parse(fs.readFileSync(marker, 'utf8').replace(/^\uFEFF/, '')) as MarketJob;
         if (job && typeof job.target === 'string' && job.target
           && typeof job.profile === 'string' && /^[A-Za-z0-9_-]+$/.test(job.profile)
-          && (job.kind === 'install' || job.kind === 'uninstall')) {
+          && MARKET_KINDS.has(job.kind)) {
           // V4.2：旧版 host 可能把目录默认 profile 'web' 写进标记（桌面壳跑
           // 在 web-desktop，profiles/web 不存在）—— 归一化后再执行，避免对
           // 不存在的 profile 跑 pnpm（spawn 报 node.exe ENOENT）。
@@ -245,12 +249,24 @@ export async function processPendingMarketOps(): Promise<void> {
       const { marker, job } = items[idx]!;
       const retried = retriedMarkers.has(marker);
       const attempts = Number(job.attempts || 0) + 1;
-      const action = job.kind === 'uninstall' ? 'remove' : 'add';
+      // 功能包任务（pack-install / pack-uninstall / pack-update）走功能包 CLI；
+      // 普通插件任务走 dsh plugin CLI。
+      const isPack = job.kind.startsWith('pack-');
+      const packCli = path.join(APP_ROOT, 'scripts', 'feature-pack-cli.js');
+      const spawnArgs = isPack
+        ? [
+            packCli,
+            job.kind === 'pack-install' ? 'install'
+              : job.kind === 'pack-uninstall' ? 'uninstall' : 'update',
+            ...(job.kind === 'pack-update' && job.packId ? [job.packId] : []),
+            ...(job.kind === 'pack-update' ? [job.target] : [job.target]),
+          ]
+        : [bin, 'plugin', '--profile', job.profile, job.kind === 'uninstall' ? 'remove' : 'add', job.target];
       // 安装前快照（保护中心）：排队任务改的是 profile 配置面，出问题可
       // 一键/自动回滚到这里。
-      ensureGuard().snapshot('market:' + job.target);
-      ctx.log('market-pending', `执行(${attempts}/${MARKER_MAX_ATTEMPTS}): dsh plugin --profile ${job.profile} ${action} ${job.target}`);
-      const child = spawn(nodeBin, [bin, 'plugin', '--profile', job.profile, action, job.target], {
+      ensureGuard().snapshot('market:' + job.label || job.target);
+      ctx.log('market-pending', `执行(${attempts}/${MARKER_MAX_ATTEMPTS}): ${spawnArgs.join(' ')}`);
+      const child = spawn(nodeBin, spawnArgs, {
         cwd: ctx.getUserDataDir(),
         // CI=true 与市场插件 host 侧一致：pnpm v10 无 TTY 时对被忽略的构建
         // 脚本（如 node-llama-cpp）静默放行，而不是 ERR_PNPM_IGNORED_BUILDS 硬失败。

--- a/dsh-desktop/lib/desktop/proc.ts
+++ b/dsh-desktop/lib/desktop/proc.ts
@@ -7,6 +7,7 @@ import cp = require('node:child_process');
 import type { ChildProcess } from 'node:child_process';
 import fs = require('node:fs');
 import path = require('node:path');
+import { APP_ROOT } from './runtime-paths';
 
 const IS_WIN = process.platform === 'win32';
 
@@ -120,6 +121,8 @@ export function childEnv(): NodeJS.ProcessEnv {
   // MCP 等）据此把安装/读写落到桌面专属 profile，而不是原生的 web profile。
   env.DSH_DESKTOP = '1';
   env.DSH_DESKTOP_PROFILE = ctx.getDesktopProfile();
+  // 资源根（dsh-desktop 树）：L3 插件进程据此定位功能包 CLI 等随包资源。
+  env.DSH_DESKTOP_RESOURCE_ROOT = APP_ROOT;
   if (dshHome && userDefaultPreset() === 'danger-full-access') {
     env.DSH_PERMISSION_MODE = 'danger-full-access';
   }

--- a/dsh-desktop/main.js
+++ b/dsh-desktop/main.js
@@ -72,6 +72,7 @@ const runtimePatchesMod = require('./lib/desktop/runtime-patches');
 const companionSyncMod = require('./lib/desktop/companion-sync');
 const pluginOpsMod = require('./lib/desktop/plugin-ops');
 const marketMod = require('./lib/desktop/market');
+const featurePackMod = require('./lib/desktop/feature-pack');
 const { killTree, killTreeAndWait, childEnv, waitForProcExit } = procMod;
 const { nodeExe, npmCli, updCtx, dshBin, dshVersion, dshVersionSource } = pathsMod;
 const { DESKTOP_PROFILE, DESKTOP_PROFILE_BUNDLES, desktopProfile, desktopProfileDir, ensureDesktopProfileInit } = profileMod;
@@ -132,6 +133,18 @@ companionSyncMod.init({
 });
 pluginOpsMod.init({ log });
 marketMod.init({ log, getDshHome: () => dshHome, getUserDataDir: () => userDataDir });
+featurePackMod.init({
+  log,
+  getDshHome: () => dshHome,
+  getDesktopProfile: desktopProfile,
+  getUserDataDir: () => userDataDir,
+  getDshBin: dshBin,
+  getNodeExe: nodeExe,
+  getChildEnv: childEnv,
+  builtinSourceDir,
+  snapshot: (label) => { try { return ensureGuard().snapshot(label); } catch (err) { log('feature-pack', '快照失败: ' + String((err && err.message) || err)); return null; } },
+  restoreSnapshot: (id) => { try { return ensureGuard().restore(id); } catch (err) { return { ok: false, error: String((err && err.message) || err) }; } },
+});
 const shortcutsMod = require('./lib/desktop/shortcuts');
 const junctionPatrolMod = require('./lib/desktop/junction-patrol');
 const clientUpdateMod = require('./lib/desktop/client-update');
@@ -2186,11 +2199,17 @@ async function restartWebServiceCore() {
     // 最后才拉起新服务 —— 排队安装正需要这个"无锁窗口"。
     await waitForProcExit(oldProc, 20000);
     await processPendingMarketOps();
+    // 功能包排队任务（CLI 撞文件锁时写入 feature-packs/.ops/pending.json）：
+    // 同样趁"无锁窗口"由功能包核心引擎自动续跑。
+    try { await featurePackMod.resumePending(); } catch (err) { log('feature-pack', '功能包排队任务消费失败: ' + String((err && err.message) || err)); }
     // pnpm（排队安装/卸载）会重写 profile node_modules：可能删掉配套插件
     // 副本、重新 hoist 核心包。服务拉起前重建 + 清理，顺序不能反。
     syncCompanionPlugins();
     healProfileModules();
     await restoreKeptArtifacts(desktopProfile());
+    // 功能包兼容扫描：官方内核版本可能随更新变化，把失配包置 incompatible
+    // （幂等），供「功能包」UI 提示一键迁移/回滚。
+    try { featurePackMod.scanFeaturePackCompatibility(); } catch (err) { log('feature-pack', '兼容扫描失败: ' + String((err && err.message) || err)); }
     const url = await startAndShowGuarded();
     log('service', 'dsh web 服务已重启: ' + url);
     return { ok: true, url };
@@ -3260,6 +3279,8 @@ async function boot() {
     // 尚未启动、无文件锁时先完成，再拉起 Web 服务。
     .then(() => processPendingMarketOps())
     .then(async () => {
+      // 功能包排队任务（CLI 撞文件锁时写入）一样在无锁窗口续跑。
+      try { await featurePackMod.resumePending(); } catch (err) { log('feature-pack', '功能包排队任务消费失败: ' + String((err && err.message) || err)); }
       retireRemovedBuiltinPlugins(desktopProfileDir());
       // 排队的 pnpm 操作可能刚重写 profile node_modules（删掉配套插件副本、
       // hoist 核心包形成双实例）—— 服务启动前重建副本并清理遮蔽，
@@ -3271,6 +3292,10 @@ async function boot() {
       // 的 lib/ 等）在这里补上（processPendingMarketOps 正常路径已含回填，
       // 这里覆盖崩溃/强杀场景；无缓存时为空操作）。
       await restoreKeptArtifacts(desktopProfile());
+    })
+    .then(() => {
+      // 功能包兼容扫描（内核版本可能随官方更新变化，幂等写回 state）。
+      try { featurePackMod.scanFeaturePackCompatibility(); } catch (err) { log('feature-pack', '兼容扫描失败: ' + String((err && err.message) || err)); }
     })
     .then(() => verifyBundledModules())
     .then(() => startAndShowGuarded())

--- a/dsh-desktop/package-lock.json
+++ b/dsh-desktop/package-lock.json
@@ -36,14 +36,14 @@
         "nanoid": "^3.3.18",
         "pino": "~8.21.0",
         "schemastery": "^3.18.0",
+        "unzipper": "^0.12.3",
         "zstddec": "0.2.0"
       },
       "devDependencies": {
         "@types/node": "24.13.3",
         "electron": "^43.4.0",
         "electron-builder": "^26.15.3",
-        "typescript": "^7.0.2",
-        "unzipper": "^0.12.3"
+        "typescript": "^7.0.2"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -7009,7 +7009,6 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmmirror.com/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -7891,7 +7890,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmmirror.com/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "readable-stream": "^2.0.2"
@@ -7901,7 +7899,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7917,14 +7914,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/duplexer2/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -9294,7 +9289,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -9947,7 +9941,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-pty": {
@@ -11587,7 +11580,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -11606,7 +11598,6 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmmirror.com/unzipper/-/unzipper-0.12.5.tgz",
       "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bluebird": "~3.7.2",
@@ -11620,7 +11611,6 @@
       "version": "11.3.1",
       "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.3.1.tgz",
       "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",

--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -53,13 +53,13 @@
     "nanoid": "^3.3.18",
     "pino": "~8.21.0",
     "schemastery": "^3.18.0",
+    "unzipper": "^0.12.3",
     "zstddec": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "24.13.3",
     "electron": "^43.4.0",
     "electron-builder": "^26.15.3",
-    "typescript": "^7.0.2",
-    "unzipper": "^0.12.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/dsh-desktop/scripts/feature-pack-cli.ts
+++ b/dsh-desktop/scripts/feature-pack-cli.ts
@@ -1,0 +1,251 @@
+'use strict';
+
+// 功能包 CLI（执行体唯一入口，契约 docs/feature-pack-spec.md §7）。
+//
+// 由 L3 市场插件经 DSH_DESKTOP_RESOURCE_ROOT 定位 spawn（node feature-pack-cli.js
+// <cmd> ...），或由 sidecar 在无锁窗口直接调用（resume）。
+//
+// 子命令：
+//   inspect  <zip|url>            # 只解析校验，stdout 输出 manifest JSON
+//   list                          # 注册表 + 实时兼容标注
+//   install  <zip|url> [--force] [--op <opRef>]
+//   update   <id> <zip|url> [--force] [--op <opRef>]
+//   uninstall <id> [--op <opRef>]
+//   export   <id> [-o <out.zip>]
+//   scan                          # 启动兼容扫描（写回 state）
+//   resume                        # 消费 .ops/pending.json 排队任务（无锁窗口）
+//
+// 退出码：0 成功｜1 一般失败｜2 用法错误｜3 文件锁待排队｜4 兼容失配｜5 冲突阻断。
+// 进度：install/update/uninstall 若有 --op，把进度写 <DSH_HOME>/feature-packs/.ops/<opRef>.json。
+
+import fs = require('node:fs');
+import os = require('node:os');
+import path = require('node:path');
+import {
+  init as initFeaturePack,
+  EXIT_OK, EXIT_FAIL, EXIT_USAGE, EXIT_LOCK,
+  parsePackZip, resolveKernelVersion, checkPackCompat,
+  loadRegistry, scanFeaturePackCompatibility, installPack, updatePack,
+  uninstallPack, exportPack, rollbackPack, resumePending, enqueuePending,
+  type FeaturePackCtx, type PackManifest,
+} from '../lib/desktop/feature-pack';
+
+const CLI_ROOT = path.resolve(path.dirname(process.argv[1] || __filename), '..');
+
+function homeOf(): string {
+  return process.env.DSH_HOME || path.join(os.homedir(), '.dsh');
+}
+
+function log(tag: string, msg: string): void {
+  console.error('[' + tag + '] ' + msg);
+}
+
+// 与 sidecar 相同的能力复用：profile 初始化 + 保护中心快照/回滚。
+function initShared(): void {
+  const profile = require('../lib/desktop/profile') as {
+    init(d: { log(tag: string, msg: string): void; getDshHome(): string | null }): void;
+    ensureDesktopProfileInit(): void;
+    desktopProfile(): string;
+  };
+  profile.init({ log, getDshHome: () => process.env.DSH_HOME || null });
+  try { profile.ensureDesktopProfileInit(); } catch { /* 尽力 */ }
+  const guardBox = require('../lib/desktop/guard-box') as {
+    init(d: { log(tag: string, msg: string): void; getDshHome(): string | null; getDesktopProfile(): string; getDshBin(): string }): void;
+    ensureGuard(): { snapshot(label: string): { id?: string } | null; restore(id: string): { ok: boolean; error?: string } };
+  };
+  guardBox.init({
+    log,
+    getDshHome: () => process.env.DSH_HOME || null,
+    getDesktopProfile: () => process.env.DSH_DESKTOP_PROFILE || 'web-desktop',
+    getDshBin: () => {
+      try { return require.resolve('@deepseek-ai/dsh/lib/bin.js'); } catch { return ''; }
+    },
+  });
+  try {
+    (globalThis as Record<string, unknown>).__fpGuard = guardBox.ensureGuard();
+  } catch (err) {
+    log('feature-pack', '保护中心初始化失败（功能包继续，快照/回滚不可用）: ' + String((err as Error).message));
+    (globalThis as Record<string, unknown>).__fpGuard = { snapshot: () => null, restore: () => ({ ok: false, error: '保护中心不可用' }) };
+  }
+}
+
+function guardBox(): { snapshot(label: string): { id?: string } | null; restore(id: string): { ok: boolean; error?: string } } {
+  return (globalThis as Record<string, unknown>).__fpGuard as { snapshot(label: string): { id?: string } | null; restore(id: string): { ok: boolean; error?: string } };
+}
+
+function makeCtx(): FeaturePackCtx {
+  if (!(globalThis as Record<string, unknown>).__fpGuard) initShared();
+  const guard = guardBox();
+  return {
+    log,
+    getDshHome: () => process.env.DSH_HOME || null,
+    getDesktopProfile: () => process.env.DSH_DESKTOP_PROFILE || 'web-desktop',
+    getUserDataDir: () => process.env.DSH_DESKTOP_USER_DATA || path.join(os.homedir(), '.dsh-desktop'),
+    getDshBin: () => {
+      try { return require.resolve('@deepseek-ai/dsh/lib/bin.js'); } catch { return ''; }
+    },
+    getNodeExe: () => process.execPath,
+    getChildEnv: () => process.env,
+    builtinSourceDir: (dirName: string) => path.join(CLI_ROOT, 'assets', 'plugins', dirName),
+    snapshot: (label) => guard.snapshot(label),
+    restoreSnapshot: (id) => guard.restore(id),
+  };
+}
+
+// URL → 临时 .dshpack 文件（宿主通常已下载，这里兜底支持 URL；可传 --sha256 校验）。
+async function fetchPackToTemp(target: string, sha256?: string): Promise<string> {
+  if (/^https?:\/\//i.test(target)) {
+    const res = await fetch(target, { redirect: 'follow', signal: AbortSignal.timeout(120000) });
+    if (!res.ok) throw new Error('下载失败 HTTP ' + res.status + ': ' + target);
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (sha256) {
+      const crypto = require('node:crypto') as { createHash(a: string): { update(b: Buffer): { digest(e: string): string } } };
+      const h = crypto.createHash('sha256').update(buf).digest('hex');
+      if (h.toLowerCase() !== String(sha256).toLowerCase()) {
+        throw new Error('SHA-256 校验失败（期望 ' + String(sha256).slice(0, 12) + '…，实际 ' + h.slice(0, 12) + '…）');
+      }
+    }
+    const name = path.basename(new URL(target).pathname) || 'pack.dshpack';
+    const tmp = path.join(os.tmpdir(), 'dshpack-' + process.pid + '-' + name.replace(/[^A-Za-z0-9._-]/g, '_'));
+    fs.writeFileSync(tmp, buf);
+    return tmp;
+  }
+  if (!fs.existsSync(target)) throw new Error('文件不存在: ' + target);
+  return target;
+}
+
+function printJson(v: unknown): void {
+  process.stdout.write(JSON.stringify(v, null, 2) + '\n');
+}
+
+/** 注册表 + 实时兼容标注（list）。 */
+function listPacks(): Array<{
+  id: string; name: string; version: string; state: string;
+  installedAt: string; source: string; requires: PackManifest['requires'];
+  compatOk: boolean; compatRange: string | null;
+  plugins: unknown[]; presets: unknown[]; skills: unknown[];
+}> {
+  const home = homeOf();
+  const reg = loadRegistry(home);
+  const kernel = resolveKernelVersion();
+  return reg.packs.map((p) => {
+    const compat = checkPackCompat(p.manifest, kernel);
+    return {
+      id: p.id, name: p.manifest.name, version: p.version, state: p.state,
+      installedAt: p.installedAt, source: p.source,
+      requires: p.manifest.requires,
+      compatOk: compat.ok, compatRange: compat.range || null,
+      snapshotRef: p.snapshotRef,
+      plugins: p.plugins, presets: p.presets, skills: p.skills,
+    };
+  });
+}
+
+async function main(): Promise<number> {
+  const args = process.argv.slice(2);
+  const cmd = args[0];
+  if (!cmd) { printJson({ ok: false, error: '用法：feature-pack-cli inspect|list|install|update|uninstall|export|scan|resume …' }); return EXIT_USAGE; }
+
+  const flag = (name: string): string | undefined => {
+    const i = args.indexOf('--' + name);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const hasFlag = (name: string): boolean => args.includes('--' + name);
+
+  initFeaturePack(makeCtx());
+
+  try {
+    switch (cmd) {
+      case 'inspect': {
+        const target = args[1];
+        if (!target) { printJson({ ok: false, error: '用法：feature-pack-cli inspect <zip|url>' }); return EXIT_USAGE; }
+        const tmp = await fetchPackToTemp(target);
+        const { manifest, zip } = await parsePackZip(tmp);
+        printJson({ ok: true, manifest, payloadPresets: zip.files.filter((f) => f.path.startsWith('payload/presets/')).length > 0, payloadSkills: zip.files.filter((f) => f.path.startsWith('payload/skills/')).length > 0 });
+        return EXIT_OK;
+      }
+      case 'list': {
+        printJson({ ok: true, kernel: resolveKernelVersion(), packs: listPacks() });
+        return EXIT_OK;
+      }
+      case 'install': {
+        const target = args[1];
+        if (!target) { printJson({ ok: false, error: '用法：feature-pack-cli install <zip|url> [--force] [--op <opRef>] [--sha256 <hex>]' }); return EXIT_USAGE; }
+        console.error('[feature-pack] 下载/定位包: ' + target);
+        const tmp = await fetchPackToTemp(target, flag('sha256'));
+        const r = await installPack({ zipPath: tmp, force: hasFlag('force'), opRef: flag('op') ?? null, source: /^https?:\/\//i.test(target) ? 'url' : 'local-file' });
+        if (!r.ok && r.code === EXIT_LOCK) {
+          const opRef = flag('op');
+          enqueuePending({ action: 'install', zipPath: tmp, force: hasFlag('force'), ...(opRef ? { opRef } : {}) });
+          console.error('[feature-pack] 文件被占用（Windows 文件锁）：任务已排队，等待服务重启后的无锁窗口自动完成');
+        }
+        printJson(r);
+        return r.ok ? EXIT_OK : (r.code ?? EXIT_FAIL);
+      }
+      case 'update': {
+        const id = args[1];
+        const target = args[2];
+        if (!id || !target) { printJson({ ok: false, error: '用法：feature-pack-cli update <id> <zip|url> [--force] [--op <opRef>] [--sha256 <hex>]' }); return EXIT_USAGE; }
+        const tmp = await fetchPackToTemp(target, flag('sha256'));
+        const r = await updatePack(id, { zipPath: tmp, force: hasFlag('force'), opRef: flag('op') ?? null });
+        if (!r.ok && r.code === EXIT_LOCK) {
+          const opRef = flag('op');
+          enqueuePending({ action: 'update', id, zipPath: tmp, force: hasFlag('force'), ...(opRef ? { opRef } : {}) });
+          console.error('[feature-pack] 文件被占用（Windows 文件锁）：任务已排队，等待服务重启后的无锁窗口自动完成');
+        }
+        printJson(r);
+        return r.ok ? EXIT_OK : (r.code ?? EXIT_FAIL);
+      }
+      case 'uninstall': {
+        const id = args[1];
+        if (!id) { printJson({ ok: false, error: '用法：feature-pack-cli uninstall <id> [--op <opRef>]' }); return EXIT_USAGE; }
+        const r = await uninstallPack(id, { opRef: flag('op') ?? null });
+        if (!r.ok && r.code === EXIT_LOCK) {
+          const opRef = flag('op');
+          enqueuePending({ action: 'uninstall', id, ...(opRef ? { opRef } : {}) });
+          console.error('[feature-pack] 文件被占用（Windows 文件锁）：任务已排队，等待服务重启后的无锁窗口自动完成');
+        }
+        printJson(r);
+        return r.ok ? EXIT_OK : (r.code ?? EXIT_FAIL);
+      }
+      case 'export': {
+        const id = args[1];
+        const out = flag('o') || (args[2] && !args[2].startsWith('-') ? args[2] : undefined);
+        if (!id || !out) { printJson({ ok: false, error: '用法：feature-pack-cli export <id> [-o <out.zip>]' }); return EXIT_USAGE; }
+        const r = await exportPack(id, out);
+        printJson(r);
+        return r.ok ? EXIT_OK : EXIT_FAIL;
+      }
+      case 'rollback': {
+        const id = args[1];
+        if (!id) { printJson({ ok: false, error: '用法：feature-pack-cli rollback <id>' }); return EXIT_USAGE; }
+        const r = rollbackPack(id);
+        printJson(r);
+        return r.ok ? EXIT_OK : EXIT_FAIL;
+      }
+      case 'scan': {
+        const r = scanFeaturePackCompatibility();
+        printJson({ ok: true, ...r });
+        return EXIT_OK;
+      }
+      case 'resume': {
+        const r = await resumePending();
+        printJson({ ok: r.ok, results: r.results, skipped: r.skipped });
+        return EXIT_OK;
+      }
+      default:
+        printJson({ ok: false, error: '未知子命令: ' + cmd });
+        return EXIT_USAGE;
+    }
+  } catch (err) {
+    const e = err as Error;
+    printJson({ ok: false, error: e.message });
+    return EXIT_FAIL;
+  }
+}
+
+// tsconfig.module=commonjs：top-level await 不可用，用 .then 收口。
+main().then((code) => { process.exitCode = code; }).catch((err) => {
+  console.error('[feature-pack] 致命错误: ' + String((err && (err as Error).message) || err));
+  process.exitCode = EXIT_FAIL;
+});

--- a/dsh-desktop/scripts/publish-pack-index.mjs
+++ b/dsh-desktop/scripts/publish-pack-index.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+'use strict';
+
+// 功能包市场索引生成器（包作者用，对应 docs/feature-pack-spec.md 附录 A）。
+//
+// 用法：
+//   node scripts/publish-pack-index.mjs <pack 文件|目录> [--index packs-index.json] [--url-prefix https://…]
+//
+// 行为：
+//   · 扫描给定 .dshpack 文件或目录；逐个读取 pack.json（unzipper），计算 SHA-256；
+//   · 合并 `--index` 指向的既有索引（同 id 覆盖为新版本，保留原 url 与 added）；
+//   · url 取 `--url-prefix` + <id>-<version>.dshpack（未提供前缀则置 null，需人工补）；
+//   · 结果写回 `--index`（缺省 out/packs-index.json），stdout 打印摘要。
+//
+// 仅供包作者/维护者使用，不构成桌面端功能；桌面端索引获取见 host.js 的
+// PACKS_INDEX_URLS 与 data/packs-snapshot.json（离线快照）。
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, mkdirSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const unzipper = require('unzipper');
+
+function sha256Of(file) {
+  return createHash('sha256').update(readFileSync(file)).digest('hex');
+}
+
+async function packMetaOf(file) {
+  const zip = await unzipper.Open.file(file);
+  const entry = zip.files.find((f) => f.path === 'pack.json');
+  if (!entry) throw new Error(basename(file) + ': 缺少 pack.json，跳过');
+  const raw = (await entry.buffer()).toString('utf8').replace(/^\uFEFF/, '');
+  const manifest = JSON.parse(raw);
+  const idOk = typeof manifest.id === 'string' && typeof manifest.version === 'string';
+  if (!idOk) throw new Error(basename(file) + ': pack.json 缺 id/version，跳过');
+  return { manifest, sha256: sha256Of(file) };
+}
+
+function usage() {
+  console.error('用法: node scripts/publish-pack-index.mjs <pack|dir> [--index <json>] [--url-prefix <prefix>]');
+  process.exit(2);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const target = args[0];
+  if (!target) usage();
+  const indexOf = (name) => {
+    const i = args.indexOf('--' + name);
+    return i >= 0 ? args[i + 1] : undefined;
+  };
+  const indexFile = indexOf('index') || 'out/packs-index.json';
+  const urlPrefix = indexOf('url-prefix');
+
+  const files = [];
+  if (statSync(target).isDirectory()) {
+    for (const name of readdirSync(target)) {
+      if (/\.dshpack$/i.test(name)) files.push(join(target, name));
+    }
+  } else if (/\.dshpack$/i.test(target)) {
+    files.push(target);
+  } else {
+    console.error('目标不是 .dshpack 文件或目录: ' + target);
+    process.exit(2);
+  }
+  if (files.length === 0) {
+    console.error('没有找到 .dshpack 文件');
+    process.exit(1);
+  }
+
+  // 既有索引（合并）。
+  let existing = { updated: '', source: 'live', packs: [] };
+  if (existsSync(indexFile)) {
+    try { existing = JSON.parse(readFileSync(indexFile, 'utf8')); } catch (err) {
+      console.error('既有索引解析失败: ' + err.message);
+      process.exit(1);
+    }
+  }
+  if (!existing.packs) existing.packs = [];
+
+  const added = [];
+  for (const file of files) {
+    try {
+      const { manifest, sha256 } = await packMetaOf(file);
+      const prev = existing.packs.find((p) => p.id === manifest.id);
+      const entry = {
+        id: manifest.id,
+        name: manifest.name,
+        version: manifest.version,
+        author: manifest.author || (prev && prev.author) || null,
+        desc: manifest.description || (prev && prev.desc) || '',
+        url: urlPrefix ? urlPrefix.replace(/\/+$/, '') + '/' + manifest.id + '-' + manifest.version + '.dshpack' : (prev && prev.url) || null,
+        sha256,
+        requires: manifest.requires || undefined,
+        added: (prev && prev.added) || new Date().toISOString().slice(0, 10),
+      };
+      existing.packs = existing.packs.filter((p) => p.id !== manifest.id);
+      existing.packs.push(entry);
+      added.push(manifest.id + '@' + manifest.version);
+      console.log('[publish-pack-index] ' + manifest.id + ' v' + manifest.version + ' → sha256 ' + sha256.slice(0, 16) + '…');
+    } catch (err) {
+      console.error('[publish-pack-index] 跳过 ' + basename(file) + ': ' + err.message);
+    }
+  }
+
+  existing.updated = new Date().toISOString().slice(0, 10);
+  mkdirSync(dirname(indexFile), { recursive: true });
+  writeFileSync(indexFile, JSON.stringify(existing, null, 2) + '\n', 'utf8');
+  console.log('[publish-pack-index] 已更新 ' + indexFile + '（' + existing.packs.length + ' 个条目，本次 ' + added.join(', ') + '）');
+}
+
+main().catch((err) => {
+  console.error('[publish-pack-index] 失败: ' + String((err && err.message) || err));
+  process.exit(1);
+});

--- a/dsh-desktop/test/feature-pack.test.ts
+++ b/dsh-desktop/test/feature-pack.test.ts
@@ -1,0 +1,391 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import cp from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const fp = require(join(root, 'lib', 'desktop', 'feature-pack.js'));
+const archiver = require('archiver') as (format: string, o?: Record<string, unknown>) => ArchiverLike;
+
+interface ArchiverLike {
+  append(content: string | Buffer, o: { name: string }): ArchiverLike;
+  finalize(): Promise<void>;
+  on(event: 'error', cb: (err: Error) => void): ArchiverLike;
+}
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), 'dsh-feature-pack-'));
+}
+
+interface ZipInput { name: string; content: string | Buffer | null; dir?: string }
+
+async function makePackZip(outZip: string, manifest: Record<string, unknown> | null, files: ZipInput[]): Promise<void> {
+  mkdirSync(dirname(outZip), { recursive: true });
+  await new Promise<void>((resolve, reject) => {
+    const z = archiver('zip', { zlib: { level: 9 } });
+    const out = require('node:fs').createWriteStream(outZip);
+    z.on('error', reject);
+    out.on('error', reject);
+    out.on('close', resolve);
+    z.pipe(out);
+    if (manifest !== null) {
+      z.append(JSON.stringify({ formatVersion: 1, ...manifest }, null, 2) + '\n', { name: 'pack.json' });
+    }
+    for (const f of files) {
+      const name = f.dir ? join(f.dir.replace(/\/+$/, ''), f.name) : f.name;
+      if (f.content === null) z.append(Buffer.alloc(0), { name });
+      else z.append(f.content, { name });
+    }
+    z.finalize().catch(reject);
+  });
+}
+
+// --- 构造临时 DSH_HOME + mock ctx -------------------------------------------------
+
+function setupCtx(dir: string, overrides: Record<string, unknown> = {}): { ctx: Record<string, unknown>; assets: string } {
+  const home = join(dir, 'home');
+  const assets = join(dir, 'assets');
+  mkdirSync(join(assets, 'plugins', 'dsh-terminal'), { recursive: true });
+  writeFileSync(join(assets, 'plugins', 'dsh-terminal', 'package.json'), JSON.stringify({ name: 'dsh-terminal', version: '1.0.0' }));
+  mkdirSync(home, { recursive: true });
+  const ctx = {
+    log: () => {},
+    getDshHome: () => home,
+    getDesktopProfile: () => 'web-desktop',
+    getUserDataDir: () => dir,
+    getDshBin: () => join(dir, 'fake-bin.js'),
+    getNodeExe: () => process.execPath,
+    getChildEnv: () => ({ ...process.env, DSH_HOME: home }),
+    builtinSourceDir: (dirName: string) => join(assets, 'plugins', dirName),
+    snapshot: () => ({ id: 'snap-' + Date.now() }),
+    restoreSnapshot: () => ({ ok: true }),
+    ...overrides,
+  };
+  fp.init(ctx);
+  return { ctx, assets };
+}
+
+const MANIFEST = {
+  id: 'com.example.coder-pack',
+  name: '全能编码功能包',
+  version: '1.2.0',
+  description: '测试包',
+  requires: { dsh: '>=0.1.1-rc.2 <0.2.0' },
+  plugins: [{ ref: 'builtin:dsh-terminal' }],
+  presets: [{ id: 'p-example' }],
+  skills: [{ id: 's-example' }],
+};
+
+function packFiles(): ZipInput[] {
+  return [
+    { name: 'preset.yml', dir: 'payload/presets/p-example', content: 'name: p-example\n' },
+    { name: 'SKILL.md', dir: 'payload/skills/s-example', content: '# s-example\n' },
+    { name: 'extra.txt', dir: 'payload/skills/s-example', content: 'x' },
+  ];
+}
+
+// --- matchSemverRange --------------------------------------------------------------
+
+test('matchSemverRange: 精确与比较符', () => {
+  assert.equal(fp.matchSemverRange('1.2.3', '1.2.3'), true);
+  assert.equal(fp.matchSemverRange('1.2.3', '1.2.4'), false);
+  assert.equal(fp.matchSemverRange('=1.2.3', '1.2.3'), true);
+  assert.equal(fp.matchSemverRange('>1.2.3', '1.2.4'), true);
+  assert.equal(fp.matchSemverRange('>1.2.3', '1.2.3'), false);
+  assert.equal(fp.matchSemverRange('>=1.2.3', '1.2.3'), true);
+  assert.equal(fp.matchSemverRange('<2.0.0', '1.9.9'), true);
+  assert.equal(fp.matchSemverRange('<=2.0.0', '2.0.0'), true);
+  // 部分版本 + 比较符：>=1.2 ≙ >=1.2.0
+  assert.equal(fp.matchSemverRange('>=1.2', '1.2.0'), true);
+  assert.equal(fp.matchSemverRange('>=1.2', '1.1.9'), false);
+  assert.equal(fp.matchSemverRange('<1.2', '1.1.9'), true);
+  assert.equal(fp.matchSemverRange('<1.2', '1.2.0'), false);
+});
+
+test('matchSemverRange: ^ ~ 与 x 范围', () => {
+  assert.equal(fp.matchSemverRange('~1.2.3', '1.2.3'), true);
+  assert.equal(fp.matchSemverRange('~1.2.3', '1.2.9'), true);
+  assert.equal(fp.matchSemverRange('~1.2.3', '1.3.0'), false);
+  assert.equal(fp.matchSemverRange('^1.2.3', '1.9.9'), true);
+  assert.equal(fp.matchSemverRange('^1.2.3', '2.0.0'), false);
+  assert.equal(fp.matchSemverRange('^0.2.3', '0.2.9'), true);
+  assert.equal(fp.matchSemverRange('^0.2.3', '0.3.0'), false);
+  assert.equal(fp.matchSemverRange('^0.0.3', '0.0.3'), true);
+  assert.equal(fp.matchSemverRange('^0.0.3', '0.0.4'), false);
+  assert.equal(fp.matchSemverRange('1.2.x', '1.2.9'), true);
+  assert.equal(fp.matchSemverRange('1.2.x', '1.3.0'), false);
+  assert.equal(fp.matchSemverRange('1.x', '1.5.0'), true);
+  assert.equal(fp.matchSemverRange('1.x', '2.0.0'), false);
+  assert.equal(fp.matchSemverRange('1.2', '1.2.9'), true);
+  assert.equal(fp.matchSemverRange('1.2', '1.3.0'), false);
+  assert.equal(fp.matchSemverRange('1', '1.9.0'), true);
+  assert.equal(fp.matchSemverRange('1', '2.0.0'), false);
+  assert.equal(fp.matchSemverRange('*', '0.0.1'), true);
+  assert.equal(fp.matchSemverRange('', '9.9.9'), true);
+  assert.equal(fp.matchSemverRange(undefined, '9.9.9'), true);
+});
+
+test('matchSemverRange: 空格 AND 与 || 或组', () => {
+  assert.equal(fp.matchSemverRange('>=1.0.0 <2.0.0', '1.5.0'), true);
+  assert.equal(fp.matchSemverRange('>=1.0.0 <2.0.0', '2.0.0'), false);
+  assert.equal(fp.matchSemverRange('>=1.0.0 <2.0.0 || >=3.0.0', '3.1.0'), true);
+  assert.equal(fp.matchSemverRange('>=1.0.0 <2.0.0 || >=3.0.0', '2.5.0'), false);
+});
+
+test('matchSemverRange: 预发布宽容（EAC 内核 rc 命名）', () => {
+  // 范围未声明预发布：同段 rc 视为满足。
+  assert.equal(fp.matchSemverRange('>=0.1.1', '0.1.1-rc.2'), true);
+  assert.equal(fp.matchSemverRange('=0.1.1', '0.1.1-rc.2'), true);
+  assert.equal(fp.matchSemverRange('>=0.1.2', '0.1.1-rc.2'), false);
+  assert.equal(fp.matchSemverRange('<0.2.0', '0.1.19-rc.1'), true);
+  assert.equal(fp.matchSemverRange('~1.2.3', '1.2.3-rc.1'), true);
+  // 范围显式声明预发布：按 tuple 精确比较。
+  assert.equal(fp.matchSemverRange('>=0.1.1-rc.2', '0.1.1-rc.2'), true);
+  assert.equal(fp.matchSemverRange('>=0.1.1-rc.2', '0.1.1-rc.1'), false);
+  assert.equal(fp.matchSemverRange('>=0.1.1-rc.2 <0.2.0', '0.1.1'), true);
+  assert.equal(fp.matchSemverRange('0.1.1-rc.2', '0.1.1-rc.2'), true);
+  // 稳定版本恒大于同段预发布。
+  assert.equal(fp.compareVersions('0.1.1', '0.1.1-rc.2'), 1);
+  assert.equal(fp.compareVersions('0.1.1-rc.2', '0.1.1'), -1);
+});
+
+test('matchSemverRange: 非法语法保守不匹配', () => {
+  assert.equal(fp.matchSemverRange('not-a-version', '1.2.3'), false);
+  assert.equal(fp.matchSemverRange('>=foo', '1.2.3'), false);
+});
+
+// --- validateManifest ---------------------------------------------------------------
+
+test('validateManifest: 合法清单通过', () => {
+  const r = fp.validateManifest({ formatVersion: 1, id: 'com.example.ok', name: 'OK', version: '1.0.0', plugins: [{ ref: 'github:user/repo' }] });
+  assert.equal(r.ok, true);
+});
+
+test('validateManifest: 非法清单报错', () => {
+  assert.equal(fp.validateManifest(null).ok, false);
+  assert.equal(fp.validateManifest({}).ok, false);
+  assert.equal(fp.validateManifest({ formatVersion: 2, id: 'x', name: 'x', version: '1.0.0' }).ok, false);
+  assert.equal(fp.validateManifest({ formatVersion: 1, id: 'bad id!', name: 'x', version: '1.0.0' }).ok, false);
+  assert.equal(fp.validateManifest({ formatVersion: 1, id: 'com.example.ok', name: 'x', version: 'nope' }).ok, false);
+  // overrides v1 预留：非空数组判无效。
+  assert.equal(fp.validateManifest({ formatVersion: 1, id: 'com.example.ok', name: 'x', version: '1.0.0', overrides: ['a'] }).ok, false);
+  assert.equal(fp.validateManifest({ formatVersion: 1, id: 'com.example.ok', name: 'x', version: '1.0.0', overrides: [] }).ok, true);
+  // 非法插件 ref。
+  assert.equal(fp.validateManifest({ formatVersion: 1, id: 'com.example.ok', name: 'x', version: '1.0.0', plugins: [{ ref: '' }] }).ok, false);
+});
+
+// --- 注册表 CRUD --------------------------------------------------------------------
+
+test('注册表: 空加载与原子写往返', () => {
+  const dir = tmp();
+  try {
+    const { ctx } = setupCtx(dir);
+    const home = ctx.getDshHome() as string;
+    assert.equal(fp.loadRegistry(home).packs.length, 0);
+    const reg = fp.loadRegistry(home);
+    reg.packs.push({
+      id: 'com.example.r1', version: '1.0.0', installedAt: new Date().toISOString(),
+      profile: 'web-desktop', state: 'active', source: 'local-file',
+      manifest: { formatVersion: 1, id: 'com.example.r1', name: 'R1', version: '1.0.0' },
+      plugins: [], presets: [], skills: [], snapshotRef: null, opRef: null,
+    });
+    fp.saveRegistry(home, reg);
+    const reloaded = fp.loadRegistry(home);
+    assert.equal(reloaded.packs.length, 1);
+    assert.equal(reloaded.packs[0]!.id, 'com.example.r1');
+    assert.equal(fp.findPack(home, 'com.example.r1')!.version, '1.0.0');
+    assert.equal(fp.findPack(home, 'nope'), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- parsePackZip -------------------------------------------------------------------
+
+test('parsePackZip: 解析合法 .dshpack，非法报错', async () => {
+  const dir = tmp();
+  try {
+    const zip = join(dir, 'com.example.coder-pack-1.2.0.dshpack');
+    await makePackZip(zip, MANIFEST, packFiles());
+    const { manifest, zip: z } = await fp.parsePackZip(zip);
+    assert.equal(manifest.id, 'com.example.coder-pack');
+    assert.equal(z.files.length >= 4, true);
+    // 缺 pack.json
+    const bad = join(dir, 'bad.dshpack');
+    await makePackZip(bad, null, [{ name: 'x.txt', content: 'x' }]);
+    await assert.rejects(() => fp.parsePackZip(bad), /pack.json/);
+    // 校验失败
+    const bad2 = join(dir, 'bad2.dshpack');
+    await makePackZip(bad2, { id: 'bad id!', name: 'x', version: '1.0.0' }, []);
+    await assert.rejects(() => fp.parsePackZip(bad2), /校验失败/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- 安装 / 卸载往返 -----------------------------------------------------------------
+
+test('安装 → 卸载：payload 装配、注册表、托管清理、用户自建保护', async () => {
+  const dir = tmp();
+  try {
+    const { ctx } = setupCtx(dir);
+    const home = ctx.getDshHome() as string;
+    const zip = join(dir, 'com.example.coder-pack-1.2.0.dshpack');
+    await makePackZip(zip, MANIFEST, packFiles());
+
+    // 内核未知（fake bin）→ requires 不匹配；force 安装。
+    const r = await fp.installPack({ zipPath: zip, force: true, source: 'local-file' });
+    assert.equal(r.ok, true, r.error);
+    assert.equal(r.recordId, 'com.example.coder-pack');
+
+    // 注册表 + payload 落位。
+    const rec = fp.findPack(home, 'com.example.coder-pack')!;
+    assert.equal(rec.state, 'incompatible');   // force 安装 → 标 incompatible
+    assert.equal(rec.plugins.length, 1);
+    assert.equal(rec.plugins[0]!.source, 'builtin');
+    assert.equal(rec.plugins[0]!.managed, false);   // builtin 不卸载
+    assert.ok(existsSync(join(home, '.agent-presets', 'p-example', 'preset.yml')));
+    assert.ok(existsSync(join(home, 'skills', 's-example', 'SKILL.md')));
+    assert.ok(existsSync(join(home, 'feature-packs', 'com.example.coder-pack', 'payload')));
+
+    // 二次安装被拒（提示 update）。
+    const r2 = await fp.installPack({ zipPath: zip, force: true });
+    assert.equal(r2.ok, false);
+    assert.match(r2.error || '', /已安装/);
+
+    // 卸载。
+    const u = await fp.uninstallPack('com.example.coder-pack');
+    assert.equal(u.ok, true, u.error);
+    assert.equal(fp.findPack(home, 'com.example.coder-pack'), null);
+    assert.ok(!existsSync(join(home, '.agent-presets', 'p-example')));
+    assert.ok(!existsSync(join(home, 'skills', 's-example')));
+    assert.ok(!existsSync(join(home, 'feature-packs', 'com.example.coder-pack')));
+    // builtin 插件（mock assets 内）由 companion 同步管理，卸载不触碰。
+    assert.ok(existsSync(dir));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('安装遇用户自建同名 preset/skill：跳过不覆盖，卸载不清除', async () => {
+  const dir = tmp();
+  try {
+    const { ctx } = setupCtx(dir);
+    const home = ctx.getDshHome() as string;
+    // 用户自建同名 preset / skill（无托管标记）。
+    mkdirSync(join(home, '.agent-presets', 'p-example'), { recursive: true });
+    writeFileSync(join(home, '.agent-presets', 'p-example', 'preset.yml'), 'name: user-owned\n');
+    mkdirSync(join(home, 'skills', 's-example'), { recursive: true });
+    writeFileSync(join(home, 'skills', 's-example', 'SKILL.md'), '# user\n');
+
+    const zip = join(dir, 'com.example.coder-pack-1.2.0.dshpack');
+    await makePackZip(zip, MANIFEST, packFiles());
+    const r = await fp.installPack({ zipPath: zip, force: true });
+    assert.equal(r.ok, true, r.error);
+
+    const rec = fp.findPack(home, 'com.example.coder-pack')!;
+    assert.equal(rec.presets[0]!.skipped, true);
+    assert.equal(rec.skills[0]!.skipped, true);
+    // 内容未被覆盖。
+    assert.equal(readFileSync(join(home, '.agent-presets', 'p-example', 'preset.yml'), 'utf8'), 'name: user-owned\n');
+
+    const u = await fp.uninstallPack('com.example.coder-pack');
+    assert.equal(u.ok, true);
+    // 用户目录保留。
+    assert.ok(existsSync(join(home, '.agent-presets', 'p-example', 'preset.yml')));
+    assert.ok(existsSync(join(home, 'skills', 's-example', 'SKILL.md')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('兼容失配被拒；scan 幂等写回 incompatible', async () => {
+  const dir = tmp();
+  try {
+    const { ctx } = setupCtx(dir);
+    const home = ctx.getDshHome() as string;
+    // 让内核版本可控：mock resolveKernelVersion？改通过 fake profile 版本文件。
+    const profileNpm = join(home, 'profiles', 'web-desktop', 'node_modules', '@deepseek-ai', 'dsh');
+    mkdirSync(profileNpm, { recursive: true });
+    writeFileSync(join(profileNpm, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.1.1-rc.2' }));
+
+    const zip = join(dir, 'com.example.coder-pack-1.2.0.dshpack');
+    await makePackZip(zip, MANIFEST, packFiles());
+    // 不 force：兼容检查应拒绝（0.1.1-rc.2 在 >=0.1.1-rc.2 <0.2.0 内 → 应允许！）
+    const r = await fp.installPack({ zipPath: zip });
+    assert.equal(r.ok, true, r.error);
+
+    // 内核版本变化（模拟官方升级到 0.2.5）：scan → incompatible。
+    writeFileSync(join(profileNpm, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.2.5' }));
+    const s1 = fp.scanFeaturePackCompatibility();
+    assert.equal(s1.incompatible.includes('com.example.coder-pack'), true);
+    assert.equal(fp.findPack(home, 'com.example.coder-pack')!.state, 'incompatible');
+    // 幂等：再扫仍在列表。
+    const s2 = fp.scanFeaturePackCompatibility();
+    assert.equal(s2.incompatible.length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- 导出 ----------------------------------------------------------------------------
+
+test('exportPack: 从注册表重建 .dshpack（palyload 保留）', async () => {
+  const dir = tmp();
+  try {
+    const { ctx } = setupCtx(dir);
+    const home = ctx.getDshHome() as string;
+    const zip = join(dir, 'com.example.coder-pack-1.2.0.dshpack');
+    await makePackZip(zip, MANIFEST, packFiles());
+    const r = await fp.installPack({ zipPath: zip, force: true });
+    assert.equal(r.ok, true, r.error);
+
+    const out = join(dir, 'export', 'out.dshpack');
+    const e = await fp.exportPack('com.example.coder-pack', out);
+    assert.equal(e.ok, true, e.error);
+    assert.ok(existsSync(out));
+    const parsed = await fp.parsePackZip(out);
+    assert.equal(parsed.manifest.id, 'com.example.coder-pack');
+    assert.equal(parsed.manifest.version, '1.2.0');
+    assert.equal(parsed.zip.files.some((f) => f.path.startsWith('payload/presets/')), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- CLI（编译产物） ------------------------------------------------------------------
+
+const CLI = join(root, 'scripts', 'feature-pack-cli.js');
+
+test('CLI: inspect / list（编译产物存在时）', async () => {
+  if (!existsSync(CLI)) return;   // 未 build（npm run build 前置）时跳过
+  const dir = tmp();
+  try {
+    const { ctx } = setupCtx(dir);
+    const home = ctx.getDshHome() as string;
+    const zip = join(dir, 'com.example.coder-pack-1.2.0.dshpack');
+    await makePackZip(zip, MANIFEST, packFiles());
+
+    const env = { ...process.env, DSH_HOME: home as string };
+    const r1 = spawnSync(process.execPath, [CLI, 'inspect', zip], { encoding: 'utf8', env });
+    assert.equal(r1.status, 0);
+    const out1 = JSON.parse(r1.stdout);
+    assert.equal(out1.ok, true);
+    assert.equal(out1.manifest.id, 'com.example.coder-pack');
+    // 用法错误
+    const r2 = spawnSync(process.execPath, [CLI, 'nope'], { encoding: 'utf8', env });
+    assert.equal(r2.status, 2);
+    // list（空注册表）
+    const r3 = spawnSync(process.execPath, [CLI, 'list'], { encoding: 'utf8', env });
+    assert.equal(r3.status, 0);
+    assert.deepEqual(JSON.parse(r3.stdout).packs, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 背景

借鉴 HMCL（Hello Minecraft! Launcher）经 10+ 年迭代沉淀的整合包/组件化体系，为 EAC 桌面端引入「功能包（.dshpack）」：把「插件组合 + 预设 + 技能」打包为可分发、可安装/卸载/更新/导出/回滚的包，并声明对官方内核（@deepseek-ai/dsh）的兼容范围——官方版本升级后自动检出失配并给出一键迁移/回滚，解决「直接适配官方版本」的痛点。

分工：核心引擎与编排归 dsheac 主体 L2（功能包 CLI 形态，sidecar 注入 DSH_DESKTOP_RESOURCE_ROOT 定位）；交互层（UI/op 轮询/市场浏览）集成进内置插件 dsh-unified-market（不重复实现核心逻辑，避免双实现漂移）。

## 改动

- **规范与契约**：`docs/feature-pack-spec.md` + `docs/schemas/feature-pack-pack.json`
- **L2 核心**（`dsh-desktop/lib/desktop/feature-pack.ts`）：
  - 清单解析/校验；`matchSemverRange`（^ ~ x、部分版本、`||`/空格组合、预发布宽容适配 rc 内核）
  - 注册表（`DSH_HOME/feature-packs/registry.json`，原子写）；内核版本探测
  - 安装/卸载/更新/导出/回滚编排：保护中心快照（guard-box）→ 装配（`dsh plugin` CLI + artifact-keep 保护第三方构建产物）→ 失败回滚；preset/skills 沿用 skip-if-exists，用户自建永不覆盖；卸载只拆本包登记物（引用计数保护共享插件）
  - 启动兼容扫描：内核版本变化自动把失配包置 `incompatible`（幂等）
- **功能包 CLI**（`scripts/feature-pack-cli.ts`）：inspect/list/install/update/uninstall/export/rollback/scan/resume；退出码 0/1/2/3/4/5（3=文件锁待排队，4=兼容失配，5=冲突阻断）；URL 安装 + `--sha256` 校验；撞文件锁自动写 `feature-packs/.ops/pending.json`，sidecar 无锁窗口经 resume 自动续跑
- **市场插件集成**（dsh-unified-market，SELF_VERSION 0.2.1 → 0.3.0）：
  - host：`pack.list/inspect/install/uninstall/update/export/rollback/scan/market` 方法（spawn CLI + 复用 op 串行/轮询/超时；市场索引 live→缓存→内置 `packs-snapshot.json` 离线快照）
  - client：设置页新增「📦 功能包」tab（已安装列表/导入安装/市场浏览/兼容提示条 + 一键迁移/回滚）
- **打包与依赖**：electron-builder 清单补 feature-pack 文件；unzipper 移入 dependencies（CLI 运行时依赖）
- **测试**：新增 `test/feature-pack.test.ts` 14 项（semver 全分支/校验/注册表/装卸往返/用户保护/兼容扫描/导出/CLI）；全量 777 项通过

## 验证

- `npm run typecheck`（tsc 零错误）
- `npm test` 全量：777 tests, 772 pass, 0 fail, 5 skip（既有）
- feature-pack 定向 14 项测试全绿；发布脚本 publish-pack-index.mjs 已用样例包实测
- 未验证（如实标注）：真实 Windows 文件锁排队/恢复、NSIS/便携包真实安装链（留待发布链）

## 后续（本期不做）

- 功能包市场正式托管仓库（host.js `PACKS_INDEX_URLS` 占位为空 → 仅离线快照）；确认仓库后填地址 + 内置快照
- 内核多版本共存（HMCL 式版本目录）作为后续评估方向
