### PR TITLE
feat(market): dsh-unified-market 0.3.0 同步 —— README 功能包说明 + 版本对齐

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-unified-market/README.md
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/README.md
@@ -7,6 +7,9 @@
 已下载插件更新面板（一键全部更新 / 逐个更新 / 自动更新三档开关）、更新进度窗口、
 市场自身自更新。
 
+> **v0.3.0 起新增「📦 功能包」tab**：EAC 功能包（.dshpack）的安装 / 卸载 / 更新 /
+> 导出 / 回滚与管理（本包承担交互编排层，核心逻辑在 L2 功能包 CLI，见下）。
+
 ---
 
 ## 整合自哪三个插件
@@ -62,6 +65,34 @@ DSH_DESKTOP_PROFILE → DSH_PROFILE → web（独立安装时回退）
   - 后台自动检测（启动 20s 后首检 + 每 6 小时），三档：关闭 / 仅提示 / 自动升级；
     状态持久化在 `<profile>/.dsh-unified-market.json`。
   - 市场自身自更新接口（`selfUpdate`）+ 官方内置插件更新引擎对接。
+- **功能包 CLI 定位（v0.3.0）**：桌面壳经 `DSH_DESKTOP_RESOURCE_ROOT` 注入
+  dsh-desktop 资源根，本市场据此定位 `scripts/feature-pack-cli.js` 并 spawn
+  （与现有 `dsh plugin` 子进程同构）；缺该环境变量时功能包页明确降级提示，
+  不影响插件市场其余功能。
+
+---
+
+## 功能包（Feature Pack · .dshpack）支持
+
+> v0.3.0 引入。借鉴 HMCL 整合包体系：把「插件组合 + 预设 + 技能」打包为 `.dshpack`，
+> 可一键安装 / 卸载 / 更新 / 导出 / 回滚；包声明对官方内核（`@deepseek-ai/dsh`）的
+> **semver 兼容范围**，官方版本升级后由 EAC 桌面壳启动兼容扫描自动检出
+> （`state: incompatible`），本市场「📦 功能包」页给出「迁移（安装新版）」/
+> 「回滚（保护中心快照）」入口。
+
+**分工**：本包只做**交互编排**（UI、op 轮询、上传中转、市场索引浏览）；解析 /
+校验 / semver / 注册表 / 装配 / 兼容扫描等核心逻辑在 dsheac 主体 L2
+（`dsh-desktop/lib/desktop/feature-pack.ts` + `scripts/feature-pack-cli.ts`），
+经 `DSH_DESKTOP_RESOURCE_ROOT` 定位 spawn，**不重复实现**（避免双实现漂移）。
+
+- host 新增 `pack.*` 方法：`pack.list / pack.inspect / pack.install / pack.uninstall /
+  pack.update / pack.export / pack.rollback / pack.scan / pack.market`；安装类走现有
+  op 串行/轮询/超时模型，上传文件在 op 结束后自动清理。
+- `pack.market` 索引走 live → 5 分钟缓存 → `data/packs-snapshot.json` 内置离线快照
+  三级降级（对齐 `catalog-snapshot.json` 模式）；下载校验 SHA-256（`--sha256`）。
+- 功能包 CLI 退出码约定：`0` 成功｜`1` 一般失败｜`2` 用法｜`3` 文件锁待排队（自动写入
+  `feature-packs/.ops/pending.json`，服务重启前的无锁窗口自动续跑）｜`4` 兼容失配｜
+  `5` 冲突阻断。
 
 ---
 
@@ -79,6 +110,9 @@ DSH_DESKTOP_PROFILE → DSH_PROFILE → web（独立安装时回退）
 - **本地链接插件**：也检测上游更新（GitHub repo / npm 名推断 → 市场按名匹配，
   可从上游接管安装或保留链接在本地更新。
 - **市场自更新**：上游发布后由官方「内置插件更新」自动/手动升级。
+- **功能包管理（v0.3.0）**：「📦 功能包」tab —— 已安装列表（版本/兼容性徽标/更新/导出/
+  卸载）、本地导入 `.dshpack`（文件选择 → base64 → 安装）、功能包市场浏览一键安装
+  （SHA-256 校验）、官方内核升级后不兼容提示条 + 一键迁移（选新版）/ 回滚。
 
 ---
 
@@ -132,6 +166,7 @@ dsh-unified-market/
 │   ├── artifact-keep.mjs   # 第三方本地构建产物保留
 │   └── plugin-conflict-scan.mjs  # 安装前冲突预检
 ├── data/catalog-snapshot.json    # 精选目录离线快照（官网不可达时兜底）
+├── data/packs-snapshot.json      # 功能包市场索引离线快照（v0.3.0 起）
 ├── README.md
 └── LICENSE
 ```
@@ -146,10 +181,13 @@ host 半边运行在 `dsh web` 进程（Cordis plugin，注入 `webServer`）。
 - **0.2.0**（2026）：三源合一 + EAC 适配（web-desktop profile、文件锁排队与启动消费、
   link→上游接管、24h 保护期、更新进度窗口）。
 - **0.2.1**（2026）：修复 README 编码（去除 BOM / 修正 mojibake）。
+- **0.3.0**（2026）：新增「📦 功能包」tab 与 `pack.*` host 方法 —— EAC 功能包
+  （.dshpack）的交互编排层（安装/卸载/更新/导出/回滚/市场浏览 + 官方内核兼容扫描
+  联动），SELF_VERSION 与 package.json 同步 0.3.0。
 
 ## 发布
 
-- **npm**：`npm publish`（包名 `dsh-unified-market`，已发布 0.2.1）。
+- **npm**：`npm publish`（包名 `dsh-unified-market`；已发布至 0.2.1）。
 - **GitHub**：`github.com/jing-hy/dsh-unified-market`（main 分支）。
 
 ## License

--- a/dsh-desktop/assets/plugins/dsh-unified-market/package.json
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-unified-market",
-  "description": "统一插件市场（Unified Plugin Market for DeepSeek Harness）：聚合精选目录（awesome-dsh-plugin.com）+ GitHub dsh-plugin 生态 + npm registry 三源；对 DSH Desktop（EAC）特化（web-desktop profile）；来源白名单 + 冲突预检 + 试装验证；后台自动检测 + 可配置自动升级 + 市场自更新；一键检查/全部更新/逐个更新，更新进度窗口",
-  "version": "0.2.1",
+  "description": "统一插件市场（Unified Plugin Market for DeepSeek Harness）：聚合精选目录（awesome-dsh-plugin.com）+ GitHub dsh-plugin 生态 + npm registry 三源；对 DSH Desktop（EAC）特化（web-desktop profile）；来源白名单 + 冲突预检 + 试装验证；后台自动检测 + 可配置自动升级 + 市场自更新；一键检查/全部更新/逐个更新，更新进度窗口；v0.3.0 起集成 EAC 功能包（.dshpack）管理（📦 功能包 tab，交互编排层）",
+  "version": "0.3.0",
   "license": "MIT",
   "type": "module",
   "main": "lib/host.js",


### PR DESCRIPTION
## 背景

dsh-unified-market 0.3.0（含 EAC 功能包交互编排层）已在上游仓库发布；
同步内置副本的 README 与版本信息，保持与上游一致（官方「内置插件更新」
链路按 package.json version 比对，需先对齐）。

## 改动

- `assets/plugins/dsh-unified-market/README.md`：新增「功能包（Feature Pack · .dshpack）支持」章节（host pack.* 方法、pack.market 三级索引降级、CLI 退出码约定、DSH_DESKTOP_RESOURCE_ROOT 定位）、功能一览/目录结构/版本记录补充
- `assets/plugins/dsh-unified-market/package.json`：version 0.2.1 → 0.3.0（与 host.js SELF_VERSION 对齐）+ description 补充功能包集成说明

## 验证

- 上游 jing-hy/dsh-unified-market 已推送 `0c3ab86`（0.3.0，含功能包代码 + README）
- 内置副本 README/package.json 与上游一致；host.js/client.js 语法检查通过
