### PR TITLE
fix(test): computer-user 批准流 + client 契约测试同步到 0.3.6 / 3.3.1 行为

### DIFF
--- a/dsh-desktop/test/computer-user-approval.test.ts
+++ b/dsh-desktop/test/computer-user-approval.test.ts
@@ -3,21 +3,28 @@ import assert from 'node:assert/strict'
 import { createComputerTools } from '../assets/plugins/computer-user/src/tools.js'
 
 // ---------------------------------------------------------------------------
-// computer-user 5.1.1 手动批准流单测：
-//   1) 优先弹官方批准问答（requestApproval → allowed-once 放行）
-//   2) 拒绝 / 取消 / 服务不可用 时给出一致的错误标记
-//   3) /computer 已批准会话直接放行
+// computer-user 手动批准流单测（manual 模式 /computer 批准语义）：
+//   1) manual 模式未批准会话 → awaitingApproval（提示发送 /computer 批准）
+//   2) /computer 已批准会话 → 直接放行执行
+//   3) 批准是会话级别的：其他会话已批准不影响本会话
 //   4) 只读工具在 manual 模式不要求批准
+//   5) disabled / readonly 模式拒绝副作用工具（readonly 下截图类放行）
+//
+// 兼容说明：历史版本（main 上的 tools.js）通过 exec.agent.session.header.sessionId
+// 判定已批准会话；0.3.6 之后改为构造入参 sessionId。为同时覆盖两种接线方式，
+// 本测试既在构造时传入 sessionId，也在 execute 时携带会话头 —— 两者任一命中
+// approvedSessions 均视为已批准。测试不再依赖 5.1.1 的 requestApproval 问答
+// （0.3.6 已移除该流程，manual 模式统一由 /computer 命令批准）。
 // ---------------------------------------------------------------------------
 
-function makeTools({ mode = 'manual', approvedSessions, requestApproval } = {}) {
+function makeTools({ mode = 'manual', approvedSessions, sessionId } = {}) {
   const calls = []
   const runPs = async (script, payload) => {
     calls.push({ script, payload })
     return { ok: true, cursor: [1, 2] }
   }
   const getConfig = () => ({ mode, screenshot_dir: '', default_scale: 1, typing_interval_ms: 0, scroll_units: 120, debug: false })
-  const tools = createComputerTools({ runPs, getConfig, approvedSessions, setMode: async () => {}, requestApproval })
+  const tools = createComputerTools({ runPs, getConfig, approvedSessions, sessionId, setMode: async () => {} })
   const byName = (name) => tools.find((t) => t.name === name)
   return { calls, byName, runPs }
 }
@@ -31,71 +38,35 @@ function execFor(sid) {
   }
 }
 
-test('manual + approval 问答 allowed-once → 工具放行执行', async () => {
-  const asks = []
-  const t = makeTools({
-    requestApproval: async (req) => { asks.push(req); return 'allowed-once' },
-  })
-  const res = await t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1'))
-  assert.equal(res.clicked !== undefined, true)
-  assert.equal(asks.length, 1)
-  assert.equal(asks[0].toolName, 'computer_click')
-  assert.equal(asks[0].callId, 'call-1')
-  assert.match(asks[0].reason, /computer_click/)
-  assert.ok(t.calls.some((c) => c.script === 'input.ps1'))
-})
-
-test('manual + approval 拒绝 → 抛 approvalRejected 且不执行', async () => {
-  const t = makeTools({ requestApproval: async () => 'rejected' })
+test('manual + 未批准会话 → 抛 awaitingApproval 且不执行', async () => {
+  const t = makeTools({ approvedSessions: new Set() })
   await assert.rejects(
     () => t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1')),
-    (err) => err.approvalRejected === true && /已拒绝/.test(err.message),
+    (err) => err.awaitingApproval === true && /\/computer/.test(err.message),
   )
   assert.equal(t.calls.length, 0)
 })
 
-test('manual + approval 取消 → 抛 approvalCancelled', async () => {
-  const t = makeTools({ requestApproval: async () => 'cancelled' })
-  await assert.rejects(
-    () => t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1')),
-    (err) => err.approvalCancelled === true,
-  )
-})
-
-test('manual + 批准服务不可用（返回 unavailable 或未提供）→ 落回 /computer 指令路径', async () => {
-  const cases = [
-    makeTools({ requestApproval: async () => 'unavailable' }),
-    makeTools({ requestApproval: undefined }),
-  ]
-  for (const t of cases) {
-    await assert.rejects(
-      () => t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1')),
-      (err) => err.awaitingApproval === true && /\/computer/.test(err.message),
-    )
-    assert.equal(t.calls.length, 0)
-  }
-})
-
-test('manual + /computer 已批准会话 → 直接放行（不再弹问答）', async () => {
-  const asks = []
-  const approvedSessions = new Set(['s1'])
-  const t = makeTools({
-    approvedSessions,
-    requestApproval: async (req) => { asks.push(req); return 'allowed-once' },
-  })
-  await t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1'))
-  assert.equal(asks.length, 0, '已批准会话不应再发批准请求')
+test('manual + 已批准会话 → 直接放行执行', async () => {
+  const t = makeTools({ approvedSessions: new Set(['s1']), sessionId: 's1' })
+  const res = await t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1'))
+  assert.equal(res.clicked !== undefined, true)
   assert.ok(t.calls.some((c) => c.script === 'input.ps1'))
 })
 
+test('manual + 其他会话已批准 → 本会话仍要求批准', async () => {
+  const t = makeTools({ approvedSessions: new Set(['s-other']), sessionId: 's1' })
+  await assert.rejects(
+    () => t.byName('computer_click').execute({ coordinate: [10, 20] }, execFor('s1')),
+    (err) => err.awaitingApproval === true,
+  )
+  assert.equal(t.calls.length, 0)
+})
+
 test('readonly 工具在 manual 模式不要求批准', async () => {
-  const asks = []
-  const t = makeTools({
-    requestApproval: async (req) => { asks.push(req); return 'allowed-once' },
-  })
+  const t = makeTools({ approvedSessions: new Set() })
   const res = await t.byName('computer_wait').execute({ ms: 1 }, execFor('s1'))
   assert.equal(res.waited, 1)
-  assert.equal(asks.length, 0)
 })
 
 test('disabled 与 readonly 模式拒绝副作用工具', async () => {

--- a/dsh-desktop/test/plugin-client-contract.test.ts
+++ b/dsh-desktop/test/plugin-client-contract.test.ts
@@ -38,10 +38,22 @@ test('5 个 uSES 插件：不再 require ui-renderer，且内联 shim 存在、�
   }
 });
 
-test('3 个 scope.load 插件：不再出现 scope.load 调用', () => {
+test('3 个 scope.load 插件：scope.load 调用必须是守卫式（rc.2 宿主无 load）', () => {
+  // rc.2 设置作用域（SettingsScopeController）无 load()，裸调 scope.load() 会
+  // 在无 load 宿主上崩溃；守卫式（typeof scope.load === "function" 或
+  // scope.load && …）与 dsh-easy-setup 同款，允许保留。注释里的提及不算调用。
   for (const rel of SCOPE_LOAD_PLUGINS) {
     const src = readFileSync(join(PLUGINS, rel), 'utf8');
-    assert.doesNotMatch(src, /scope\.load/, `${rel} 仍引用 scope.load`);
+    for (const m of src.matchAll(/scope\.load\s*\(/g)) {
+      const lineStart = src.lastIndexOf('\n', m.index) + 1;
+      const lineHead = src.slice(lineStart, m.index).trimStart();
+      if (lineHead.startsWith('//') || lineHead.startsWith('*') || lineHead.startsWith('/*')) continue;
+      const pre = src.slice(Math.max(0, m.index - 120), m.index);
+      const guarded =
+        /typeof\s+scope\.load\s*===/.test(pre) ||
+        /scope\.load\s*&&/.test(pre);
+      assert.ok(guarded, `${rel} 存在未守卫的 scope.load() 调用（字符 ${m.index}）：rc.2 宿主无 load()，必须 typeof 守卫或短路守卫`);
+    }
     assert.doesNotThrow(() => new Function(src), `${rel} 语法解析失败`);
   }
 });


### PR DESCRIPTION
## 背景

PR #239 将内置插件升级到 picturereader 3.3.1 / computer-user 0.3.6 后，CI（Tauri Ubuntu job）的「类型检查与全量测试」失败。本 PR 修复两个宿主导航测试与上游新版插件契约的失配。

## 改动一：`test/computer-user-approval.test.ts`

- 根因：`main` 上的测试按旧版（5.1.1）的「官方批准问答」契约编写；computer-user **0.3.6 已移除 requestApproval 问答**，manual 模式统一由 `/computer` 命令批准会话（`approvedSessions`），未批准直接抛 `awaitingApproval` → 4 个问答用例失败。
- 重写为 0.3.6 的 `/computer` 批准语义 5 个用例：
  1. manual + 未批准会话 → 抛 `awaitingApproval` 且不执行
  2. manual + 已批准会话 → 直接放行执行
  3. 批准是会话级别的：其他会话已批准不影响本会话
  4. 只读工具在 manual 模式不要求批准
  5. disabled / readonly 拒绝副作用工具（readonly 下截图类放行）
- 兼容两种 sessionId 接线：历史 tools.js 从 `exec.agent.session.header.sessionId` 判定，0.3.6 改为构造入参 `sessionId`，测试两者都覆盖。

## 改动二：`test/plugin-client-contract.test.ts`

- 根因：断言对 3 个插件 client.js 一刀切 `doesNotMatch(/scope\.load/)`，连守卫式调用也禁止，与契约本意（文件头注释：rc.2 宿主无 load()，禁止**未守卫**的 scope.load(）不符——同文件 dsh-easy-setup 的守卫式 `scope.load && scope.load()` 本就合法且有断言。
- 上游 picturereader 3.3.1 / computer-user 0.3.6 的 client.js 采用守卫式 `typeof scope.load === "function"` 重新引入 load（兼容有无 load 宿主），与 dsh-easy-setup 同款。
- 断言改为逐一检查每个 `scope.load()` 调用点必须带守卫（typeof 守卫或短路守卫），注释提及不计入调用。

## 验证

- 两个测试文件在 main 版插件上：`node --test` 全部通过（computer-user 5/5、plugin-client-contract 4/4）
- 临时替换为 #239 版插件文件（0.3.6 tools.js / 3.3.1+0.3.6 client.js）后同样全部通过
- 守卫检测逻辑做了反向验证：裸调用会被抓住、六种守卫/注释形态正确放行

## 后续

#239 已并入本分支，重跑 CI。
