### PR TITLE
docs(readme): 插件致谢补齐提供者并按插件名首字母排序

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -272,51 +272,52 @@ research/                     # Third-party WeChat / bridge protocol research
 
 | Plugin | Description |
 | --- | --- |
+| computer-user (provider: jing-hy) | Screen reading plus mouse/keyboard automation (Codex-style computer use; pairs with picturereader so text-only models work) |
 | dsh-auto-compact | Automatically sends `/compact` as the context approaches its limit |
-| @deepseek-ai/dsh-balance | Account balance, cost estimates, and pricing settings |
+| @deepseek-ai/dsh-balance (provider: deepseek-ai) | Account balance, cost estimates, and pricing settings |
 | dsh-better-sidebar (provider: omdsh-dev) | VS Code-style right sidebar with Explorer, editor, terminal, Git, and browser views |
 | dsh-change-review | AI change review for automatically rechecking file modifications |
-| @deepseek-ai/dsh-client-file-changes | Files view with session change tracking and one-click restore |
-| dsh-compact | Request-path context compaction and overflow recovery |
-| @deepseek-ai/dsh-conversation-tweaks | Collapses long output and adds a right-side conversation navigation rail |
+| @deepseek-ai/dsh-client-file-changes (provider: deepseek-ai) | Files view with session change tracking and one-click restore |
+| dsh-compact (provider: zixin947) | Request-path context compaction and overflow recovery |
+| @deepseek-ai/dsh-conversation-tweaks (provider: deepseek-ai) | Collapses long output and adds a right-side conversation navigation rail |
 | dsh-dafeiyu (provider: QCYTSN) | Dafeiyu desktop companion |
 | dsh-deep-whale (provider: Small-tailqwq) | Source of the Deep-Sea Maid Workshop `maid-atelier` skin |
 | dsh-dock-settings | Skills and MCP settings management |
-| @deepseek-ai/dsh-easy-setup | Quick setup for vision models, `soul.md`, and migration |
-| @deepseek-ai/dsh-file-changes | Session file-change projection |
-| dsh-file-drop-eac | Drag files or folders into a conversation |
-| @deepseek-ai/dsh-float-window | Opens a conversation in a separate window |
+| @deepseek-ai/dsh-easy-setup (provider: deepseek-ai) | Quick setup for vision models, `soul.md`, and migration |
+| @deepseek-ai/dsh-file-changes (provider: deepseek-ai) | Session file-change projection |
+| dsh-file-drop-eac (provider: jing-hy) | Drag files or folders into a conversation |
+| @deepseek-ai/dsh-float-window (provider: deepseek-ai) | Opens a conversation in a separate window |
 | dsh-font-custom | Custom fonts plus text and code colors |
 | dsh-image-paste | Paste and send clipboard images |
 | dsh-message-rewind | Rewrite a message and regenerate from that point |
 | @vlln/dsh-navbar (provider: vlln) | Conversation-node navigation bar for jumping between user messages |
 | dsh-offpeak (provider: christophersmith2737-commits) | DeepSeek peak/off-peak pricing reminder and interception |
-| @deepseek-ai/dsh-openclaw-bridge | WeChat ClawBot / OpenClaw bridge |
+| @deepseek-ai/dsh-openclaw-bridge (provider: deepseek-ai) | WeChat ClawBot / OpenClaw bridge |
 | dsh-pet (provider: PC2005-cloud) | Floating desktop pet for the page |
 | dsh-pet-settings | Desktop pet settings section |
 | dsh-plugin-guard (provider: lxzy-7) | Pre-install snapshots, rollback, and guarded startup |
 | dsh-plugin-healthcheck (provider: chenw2759-wq) | Static plugin health checks and risk inspection |
-| @deepseek-ai/dsh-plugin-manager | Lists and enables or disables bundled plugins |
+| @deepseek-ai/dsh-plugin-manager (provider: deepseek-ai) | Lists and enables or disables bundled plugins |
 | dsh-plugin-shield | Plugin protection with snapshots, rollback, and health checks |
 | dsh-plugin-wizard | Plugin selection wizard |
-| @deepseek-ai/dsh-prompt-custom | Custom core prompts |
-| dsh-session-manager | Session deletion and archive management |
+| @deepseek-ai/dsh-prompt-custom (provider: deepseek-ai) | Custom core prompts |
+| dsh-session-manager (provider: hkkz9522) | Session deletion and archive management |
 | dsh-settings-groups | Collapsible advanced options on the Settings page |
 | dsh-settings-nav-custom | Customization for the Settings sidebar |
-| dsh-settings-scroll-fix | Mouse-wheel and overflow scrolling repair for Settings |
+| dsh-settings-scroll-fix (provider: says693) | Mouse-wheel and overflow scrolling repair for Settings |
 | @dsh-external/dsh-side-session (provider: dsh-external) | Temporary side conversations that do not affect the main conversation |
-| @deepseek-ai/dsh-skin-switch | Built-in skin switching |
+| @deepseek-ai/dsh-skin-switch (provider: deepseek-ai) | Built-in skin switching |
 | dsh-soul-md (provider: Scorp1o117) | `soul.md` persona-card injection |
-| @deepseek-ai/dsh-terminal | Interactive command line inside a conversation |
-| @deepseek-ai/dsh-third-party-thinking | Reasoning-effort controls for third-party models |
+| @deepseek-ai/dsh-terminal (provider: deepseek-ai) | Interactive command line inside a conversation |
+| @deepseek-ai/dsh-third-party-thinking (provider: deepseek-ai) | Reasoning-effort controls for third-party models |
 | dsh-tool-vision (provider: Scorp1o117) | Image analysis through OpenAI-compatible vision models |
-| dsh-undo-savepoint | Configuration snapshots and undo/rollback |
-| dsh-unified-market | Unified plugin marketplace aggregating three sources |
-| dsh-web-plugin-manager (provider: LX2000WASD) | Entry point for guarded plugin installation and health checks |
+| dsh-undo-savepoint (provider: lire1131) | Configuration snapshots and undo/rollback |
+| dsh-unified-market (provider: jing-hy) | Unified plugin marketplace aggregating three sources |
 | dsh-web-mobile-fix (provider: AcidGr) | Mobile layout fixes |
+| dsh-web-plugin-manager (provider: LX2000WASD) | Entry point for guarded plugin installation and health checks |
 | dsh-web-ui (provider: zhu1090093659) | Source of nine built-in Web UI skins |
 | dsh-webui-market (provider: Sanqi-normal) | Community plugin directory with one-click installation and removal |
-| picturereader | Unified image-understanding plugin |
+| picturereader (provider: jing-hy) | Unified image-understanding plugin |
 
 Thank you to every plugin provider for contributing to this project and the open-source community. With so many plugins, we may not have identified every plugin and source individually. If you recognize your work here, please let us know so we can add it to the acknowledgements. You are also welcome to join our community groups to exchange ideas and help the ecosystem grow.
 

--- a/README.md
+++ b/README.md
@@ -307,52 +307,52 @@ research/                     # 第三方微信/桥接协议调研资料
 
 | 插件名 | 插件说明 |
 | --- | --- |
+| computer-user（提供者：jing-hy） | 读屏 + 鼠标键盘自动化（Codex-style computer use；配 picturereader，纯文本模型可用） |
 | dsh-auto-compact | 自动压缩：接近上下文上限时自动发送 /compact |
-| @deepseek-ai/dsh-balance | 账户余额、费用估算与价格设置 |
+| @deepseek-ai/dsh-balance（提供者：deepseek-ai） | 账户余额、费用估算与价格设置 |
 | dsh-better-sidebar（提供者：omdsh-dev） | VSCode 风格右侧栏，支持资源管理器/编辑器/终端/Git/浏览器 |
 | dsh-change-review | AI 变更审核：自动复查文件改动 |
-| @deepseek-ai/dsh-client-file-changes | 文件视图：会话文件更改追踪与一键还原 |
-| dsh-compact | 请求路径上下文压缩与溢出恢复 |
-| @deepseek-ai/dsh-conversation-tweaks | 隐藏长篇输出 + 会话右侧导航滑轨 |
+| @deepseek-ai/dsh-client-file-changes（提供者：deepseek-ai） | 文件视图：会话文件更改追踪与一键还原 |
+| dsh-compact（提供者：zixin947） | 请求路径上下文压缩与溢出恢复 |
+| @deepseek-ai/dsh-conversation-tweaks（提供者：deepseek-ai） | 隐藏长篇输出 + 会话右侧导航滑轨 |
 | dsh-dafeiyu（提供者：QCYTSN） | 大肥鱼桌面伴侣 |
 | dsh-deep-whale（提供者：Small-tailqwq） | 深海女仆工坊 maid-atelier 皮肤来源 |
 | dsh-dock-settings | Skills 与 MCP 设置管理 |
-| @deepseek-ai/dsh-easy-setup | 快速配置：视觉模型、soul.md、迁移 |
-| @deepseek-ai/dsh-file-changes | 会话文件更改投影 |
-| dsh-file-drop-eac | 拖放文件/文件夹到对话 |
-| @deepseek-ai/dsh-float-window | 会话弹出独立窗口 |
+| @deepseek-ai/dsh-easy-setup（提供者：deepseek-ai） | 快速配置：视觉模型、soul.md、迁移 |
+| @deepseek-ai/dsh-file-changes（提供者：deepseek-ai） | 会话文件更改投影 |
+| dsh-file-drop-eac（提供者：jing-hy） | 拖放文件/文件夹到对话 |
+| @deepseek-ai/dsh-float-window（提供者：deepseek-ai） | 会话弹出独立窗口 |
 | dsh-font-custom | 字体与文字/代码颜色自定义 |
 | dsh-image-paste | 剪贴板图片粘贴发送 |
 | dsh-message-rewind | 消息改写并从此处重新生成 |
 | @vlln/dsh-navbar（提供者：vlln） | 对话节点导航条：user 消息快速跳转 |
 | dsh-offpeak（提供者：christophersmith2737-commits） | DeepSeek 峰谷价格拦截提醒 |
-| @deepseek-ai/dsh-openclaw-bridge | 微信 ClawBot / OpenClaw 桥接 |
+| @deepseek-ai/dsh-openclaw-bridge（提供者：deepseek-ai） | 微信 ClawBot / OpenClaw 桥接 |
 | dsh-pet（提供者：PC2005-cloud） | 页面悬浮桌宠 |
 | dsh-pet-settings | 桌宠设置分区 |
 | dsh-plugin-guard（提供者：lxzy-7） | 插件安装前快照、回滚与启动守护 |
 | dsh-plugin-healthcheck（提供者：chenw2759-wq） | 插件静态体检与风险检查 |
-| @deepseek-ai/dsh-plugin-manager | 插件管理：列出/启停内置插件 |
+| @deepseek-ai/dsh-plugin-manager（提供者：deepseek-ai） | 插件管理：列出/启停内置插件 |
 | dsh-plugin-shield | 插件保护：快照/回滚/体检 |
 | dsh-plugin-wizard | 插件选择向导 |
-| @deepseek-ai/dsh-prompt-custom | 自定义内核提示词 |
-| dsh-session-manager | 会话删除与归档管理 |
+| @deepseek-ai/dsh-prompt-custom（提供者：deepseek-ai） | 自定义内核提示词 |
+| dsh-session-manager（提供者：hkkz9522） | 会话删除与归档管理 |
 | dsh-settings-groups | 设置页高级选项折叠 |
 | dsh-settings-nav-custom | 设置页左侧边栏自定义 |
-| dsh-settings-scroll-fix | 设置面板鼠标滚轮与溢出滚动修复 |
+| dsh-settings-scroll-fix（提供者：says693） | 设置面板鼠标滚轮与溢出滚动修复 |
 | @dsh-external/dsh-side-session（提供者：dsh-external） | 临时会话：不污染主会话的独立追问 |
-| @deepseek-ai/dsh-skin-switch | 内置皮肤切换 |
+| @deepseek-ai/dsh-skin-switch（提供者：deepseek-ai） | 内置皮肤切换 |
 | dsh-soul-md（提供者：Scorp1o117） | soul.md 人设卡注入 |
-| @deepseek-ai/dsh-terminal | 会话内交互式命令行 |
-| @deepseek-ai/dsh-third-party-thinking | 第三方模型思考强度控件 |
+| @deepseek-ai/dsh-terminal（提供者：deepseek-ai） | 会话内交互式命令行 |
+| @deepseek-ai/dsh-third-party-thinking（提供者：deepseek-ai） | 第三方模型思考强度控件 |
 | dsh-tool-vision（提供者：Scorp1o117） | OpenAI 兼容视觉模型图片分析 |
-| dsh-undo-savepoint | 配置快照与撤销/回滚 |
-| dsh-unified-market | 统一插件市场：聚合三源 |
-| dsh-web-plugin-manager（提供者：LX2000WASD） | 插件安装守卫与健康检查入口 |
+| dsh-undo-savepoint（提供者：lire1131） | 配置快照与撤销/回滚 |
+| dsh-unified-market（提供者：jing-hy） | 统一插件市场：聚合三源 |
 | dsh-web-mobile-fix（提供者：AcidGr） | 移动端布局修复 |
+| dsh-web-plugin-manager（提供者：LX2000WASD） | 插件安装守卫与健康检查入口 |
 | dsh-web-ui（提供者：zhu1090093659） | 9 款内置 Web UI 皮肤来源 |
 | dsh-webui-market（提供者：Sanqi-normal） | 社区插件目录与一键安装/卸载 |
-| picturereader | 统一图片理解插件 |
-| computer-user | 读屏 + 鼠标键盘自动化（Codex-style computer use；配 picturereader，纯文本模型可用） |
+| picturereader（提供者：jing-hy） | 统一图片理解插件 |
 
 感谢所有插件提供者对本项目与开源社区的奉献；由于插件数量众多，我们很抱歉，未能逐一统计到所有插件与其来源；如有插件的拥有者看到了自己所做的插件，欢迎您告知我们并添加到致谢名单中，也欢迎添加我们的交流群，以便一同交流、共同进步。
 

--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -41,6 +41,23 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
 官方版本升级自动检出并一键迁移/回滚 —— 核心在 L2 功能包引擎 + CLI，
 交互集成进 dsh-unified-market 插件；详见下方「功能包体系（Feature Pack）」批次）
 
+## 文档：插件致谢补齐提供者并按首字母排序 · next
+
+### README.md / README.en.md「插件致谢」
+
+- 插件致谢表按插件名首字母重新排序（忽略 `@scope/` 前缀，与既有排列规则一致；
+  `computer-user`、`picturereader` 归位，`web-mobile-fix` / `web-plugin-manager`
+  顺序修正）。
+- 补齐缺失的提供者标注（经 GitHub / npm 交叉核实）：
+  - `@deepseek-ai/*` 12 款官方自带插件 → `deepseek-ai`；
+  - `dsh-compact` → `zixin947`（PR #145 作者，GitHub 同名仓库描述一致）；
+  - `dsh-session-manager` → `hkkz9522`（npm maintainer + GitHub 同名仓库）；
+  - `dsh-undo-savepoint` → `lire1131`（npm maintainer，EAC 内置即其版本）；
+  - `dsh-settings-scroll-fix` → `says693`（PR 提交者陆玖叁）；
+  - `dsh-unified-market` / `picturereader` / `computer-user` / `dsh-file-drop-eac`
+    → `jing-hy`（自研，GitHub 仓库归属一致）。
+- 英文版致谢表补上此前缺失的 `computer-user` 条目，与中文版对齐。
+
 ## 功能包体系（Feature Pack · 借鉴 HMCL 整合包架构）· next
 
 ### 功能包（.dshpack）：插件 + 预设 + 技能打包分发


### PR DESCRIPTION
## 背景

插件致谢名单中部分插件缺少提供者标注，且表格顺序未严格按插件名首字母排列。

## 改动

- **README.md / README.en.md 插件致谢表**：
  - 按插件名首字母重新排序（忽略 `@scope/` 前缀，沿用原表排列规则；`computer-user`、`picturereader` 归位，`web-mobile-fix` / `web-plugin-manager` 顺序修正）。
  - 补齐提供者标注（GitHub / npm 交叉核实）：
    - `@deepseek-ai/*` 12 款官方自带插件 → `deepseek-ai`；
    - `dsh-compact` → `zixin947`（PR #145 作者，GitHub 同名仓库描述一致）；
    - `dsh-session-manager` → `hkkz9522`（npm maintainer + GitHub 同名仓库）；
    - `dsh-undo-savepoint` → `lire1131`（npm maintainer）；
    - `dsh-settings-scroll-fix` → `says693`（PR 提交者陆玖叁）；
    - `dsh-unified-market` / `picturereader` / `computer-user` / `dsh-file-drop-eac` → `jing-hy`（自研）。
  - 英文版致谢表补上此前缺失的 `computer-user` 条目，与中文版对齐。
- **dsh-desktop/CHANGELOG.md**：新增对应文档批次记录。

## 验证

- 脚本校验两份 README 致谢表各 46 行、第一列字典序严格递增。
- 纯文档改动，不涉及代码，无需编译验证。
