### PR TITLE
fix(market+shell): 功能包 CLI 打包白名单补齐 + Windows 任务栏图标 + 统一市场 0.3.1

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -58,6 +58,33 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
     → `jing-hy`（自研，GitHub 仓库归属一致）。
 - 英文版致谢表补上此前缺失的 `computer-user` 条目，与中文版对齐。
 
+## 功能包链路修复 + 任务栏图标 · next
+
+### 打包装配：功能包 CLI 白名单补齐（tauri-shell/stage-resources.mjs）
+
+- 修复功能包体系随包分发缺失：#237 新增的 `scripts/feature-pack-cli.js` 与
+  `lib/desktop/feature-pack.js` 未加入 stage 脚本的 `LIB_DESKTOP`/`SCRIPTS`
+  人工白名单，导致打包产出的客户端缺失功能包 CLI，统一市场「📦 功能包」
+  全部操作报「功能包 CLI 不可用（缺少 DSH_DESKTOP_RESOURCE_ROOT）」。
+- 两文件补入白名单，并新增成对装配自检：CLI 与核心模块必须同时入包，
+  缺一即 stage 直接失败（后续新增随包 CLI 照此成对补充）。
+
+### Tauri 壳：Windows 任务栏图标修复（tauri-shell/src/main.rs）
+
+- tao 注册的窗口 class 不带图标（`WNDCLASSEXW.hIcon` 为 NULL），动态创建的
+  窗口不显式注入图标时，Windows 任务栏按钮显示空白默认图。
+- 主窗 / 会话浮窗 / 恢复中心 / died 页四处窗口统一在 build 成功后经
+  `apply_window_icon` 注入 `default_window_icon`（与托盘图标同源，tauri-build
+  嵌入的 bundle icon）；注入失败仅打印告警，不阻塞窗口创建。
+
+### 内置插件：dsh-unified-market 0.3.0 → 0.3.1
+
+- 同步上游 0.3.1（npm `dsh-unified-market@0.3.1`）：功能包 CLI 定位失败区分
+  「桌面壳未注入 `DSH_DESKTOP_RESOURCE_ROOT`」与「CLI 文件不存在（客户端安装
+  不完整或版本过旧）」两种原因，给出可行动提示（升级 / 重装桌面客户端），
+  修复 0.3.0 及之前统一误报"缺少 DSH_DESKTOP_RESOURCE_ROOT"导致用户在桌面端
+  却被提示去桌面端的排障误导。
+
 ## 功能包体系（Feature Pack · 借鉴 HMCL 整合包架构）· next
 
 ### 功能包（.dshpack）：插件 + 预设 + 技能打包分发

--- a/dsh-desktop/assets/plugins/dsh-unified-market/CHANGELOG.md
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/CHANGELOG.md
@@ -1,0 +1,29 @@
+# 更新日志
+
+本文件记录 dsh-unified-market 对外可见的变更。
+
+## 0.3.1
+
+- 修复功能包 CLI 定位失败的误导性报错：0.3.0 及之前，「桌面壳未注入
+  `DSH_DESKTOP_RESOURCE_ROOT`」与「CLI 文件不存在（客户端安装不完整或版本
+  过旧）」两种失败统一误报"缺少 DSH_DESKTOP_RESOURCE_ROOT"，用户在桌面端
+  却被提示去桌面端，排障困难。
+- 现 `packCliStatus()` 区分两种原因并给出可行动提示（升级 / 重装桌面客户端），
+  `pack.*` 全部方法同步使用新文案。
+
+## 0.3.0
+
+- 新增「📦 功能包」tab 与 `pack.*` host 方法：EAC 功能包（.dshpack）的交互编排层
+  （安装 / 卸载 / 更新 / 导出 / 回滚 / 市场浏览 + 官方内核兼容扫描联动）。
+- `SELF_VERSION` 与 package.json 同步至 0.3.0。
+- 针对 DSH Desktop（EAC）5.1 与 dsh 0.1.1-rc.2 完成专项适配测试。
+
+## 0.2.1
+
+- 修复 README 编码问题（去除 BOM、修正 mojibake）。
+
+## 0.2.0
+
+- 三源合一：精选目录（awesome-dsh-plugin.com）+ GitHub `dsh-plugin` 生态 + npm registry。
+- EAC 适配：web-desktop profile 解析链（DSH_DESKTOP_PROFILE → DSH_PROFILE → web）、
+  文件锁排队与启动消费、link → 上游接管、24h 保护期、更新进度窗口。

--- a/dsh-desktop/assets/plugins/dsh-unified-market/README.md
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/README.md
@@ -1,11 +1,15 @@
 # dsh-unified-market — 统一插件市场（Unified Plugin Market for DeepSeek Harness）
 
+[![version](https://img.shields.io/badge/version-0.3.0-2563eb)](https://github.com/jing-hy/dsh-unified-market/releases) [![license](https://img.shields.io/badge/license-MIT-green)](./LICENSE) [![node ≥18.18](https://img.shields.io/badge/node-%E2%89%A518.18-339933?logo=nodedotjs&logoColor=white)](https://github.com/jing-hy/dsh-unified-market)
+
 > 一个市场，三个数据源：**精选目录 + GitHub dsh-plugin 生态 + npm registry**。
 > 对 DSH Desktop（EAC）针对性适配，开箱即用的插件安装 / 更新 / 自动更新 / 管理。
 
 在设置页 **设置 → 插件 → 🛒 统一市场** 提供一站式体验：三源切换、分类下拉筛选、
 已下载插件更新面板（一键全部更新 / 逐个更新 / 自动更新三档开关）、更新进度窗口、
 市场自身自更新。
+
+**English**: A unified plugin marketplace for DeepSeek Harness. It merges three sources — the curated awesome-dsh-plugin catalog, the GitHub `dsh-plugin` ecosystem and the npm registry — into one storefront inside DSH Desktop (EAC), with source whitelisting, conflict pre-checks, trial-boot install verification, update management (manual / batch / auto) and `.dshpack` feature-pack management.
 
 > **v0.3.0 起新增「📦 功能包」tab**：EAC 功能包（.dshpack）的安装 / 卸载 / 更新 /
 > 导出 / 回滚与管理（本包承担交互编排层，核心逻辑在 L2 功能包 CLI，见下）。
@@ -29,6 +33,8 @@
 ---
 
 ## 对 EAC 的针对性适配
+
+> **版本适配基线**：当前版本对 **DSH Desktop（EAC）5.1** 与 **dsh 0.1.1-rc.2** 进行过专项适配测试，为推荐的运行组合；其余官方版本的兼容性以桌面壳内置的兼容扫描结果为准。
 
 EAC（DeepSeek Harness Desktop）的 Web UI 跑在**桌面专属 profile `web-desktop`**
 （由主进程通过 `DSH_DESKTOP_PROFILE` 注入）。旧市场中：
@@ -184,6 +190,11 @@ host 半边运行在 `dsh web` 进程（Cordis plugin，注入 `webServer`）。
 - **0.3.0**（2026）：新增「📦 功能包」tab 与 `pack.*` host 方法 —— EAC 功能包
   （.dshpack）的交互编排层（安装/卸载/更新/导出/回滚/市场浏览 + 官方内核兼容扫描
   联动），SELF_VERSION 与 package.json 同步 0.3.0。
+- **0.3.1**（2026）：修复功能包 CLI 定位失败的误导性报错 —— 0.3.0 及之前，
+  「桌面壳未注入 `DSH_DESKTOP_RESOURCE_ROOT`」与「CLI 文件不存在（客户端安装
+  不完整/版本过旧）」两种失败统一误报"缺少 DSH_DESKTOP_RESOURCE_ROOT"，用户
+  明明在桌面端却被提示去桌面端，排障困难；现 `packCliStatus()` 区分两种原因
+  并给出可行动提示（升级/重装桌面客户端）。
 
 ## 发布
 

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
@@ -39,7 +39,7 @@ import { scanCandidate, collectProfileState } from './plugin-conflict-scan.mjs'
 export const name = 'dsh-unified-market'
 
 /** 本市场自身版本（与 package.json 同步；自更新检测用）。 */
-export const SELF_VERSION = '0.3.0'
+export const SELF_VERSION = '0.3.1'
 
 /** Hard dependency: the HTTP carrier must exist before the route registers. */
 export const inject = ['webServer']
@@ -1653,17 +1653,30 @@ const PACKS_CACHE_TTL = 5 * 60 * 1000
 let packsCache = null // { at, packs, source }
 const PACK_UPLOAD_MAX = 128 * 1024 * 1024
 
-function packCliPath() {
+// 定位功能包 CLI，返回 { cli, reason }：cli 为 null 时 reason 给出用户可
+// 行动的原因 —— 区分「桌面壳未注入环境变量」（壳过旧/非桌面端）与「CLI
+// 文件不存在」（客户端安装不完整或版本过旧，需升级/重装客户端）。
+// 0.3.0 及之前两种失败统一误报"缺少 DSH_DESKTOP_RESOURCE_ROOT"，排障困难。
+function packCliStatus() {
   const root = process.env.DSH_DESKTOP_RESOURCE_ROOT
-  if (!root) return null
+  if (!root) {
+    return { cli: null, reason: '功能包 CLI 不可用（桌面壳未注入 DSH_DESKTOP_RESOURCE_ROOT：若在浏览器等非桌面环境请改用桌面客户端，若已在桌面端请升级客户端）' }
+  }
   const cli = join(root, 'scripts', 'feature-pack-cli.js')
-  try { return existsSync(cli) ? cli : null } catch { return null }
+  try {
+    if (existsSync(cli)) return { cli, reason: null }
+  } catch { /* existsSync 异常按缺失处理 */ }
+  return { cli: null, reason: '功能包 CLI 不可用（桌面客户端缺少 ' + cli + '，客户端安装不完整或版本过旧，请升级或重装桌面客户端）' }
+}
+
+function packCliPath() {
+  return packCliStatus().cli
 }
 
 /** 同步跑功能包 CLI（快命令：list/inspect/export/rollback/scan）。 */
 function runPackCli(args) {
-  const cli = packCliPath()
-  if (!cli) return { ok: false, error: '功能包 CLI 不可用（缺少 DSH_DESKTOP_RESOURCE_ROOT，请在桌面壳内使用）' }
+  const { cli, reason } = packCliStatus()
+  if (!cli) return { ok: false, error: reason }
   let r
   try {
     r = spawnSync(process.execPath, [cli, ...args], {
@@ -1686,8 +1699,8 @@ function runPackCli(args) {
 
 /** 异步慢命令（install/uninstall/update）作为 op 跑，复用现有 op 轮询模型。 */
 function startPackOp(packArgs, label, initialOutput) {
-  const cli = packCliPath()
-  if (!cli) return { ok: false, error: '功能包 CLI 不可用（缺少 DSH_DESKTOP_RESOURCE_ROOT，请在桌面壳内使用）' }
+  const { cli, reason } = packCliStatus()
+  if (!cli) return { ok: false, error: reason }
   if (activeOp && activeOp.status === 'running') {
     return { ok: false, busy: true, output: '已有任务进行中：' + activeOp.label }
   }

--- a/dsh-desktop/assets/plugins/dsh-unified-market/package.json
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-unified-market",
   "description": "统一插件市场（Unified Plugin Market for DeepSeek Harness）：聚合精选目录（awesome-dsh-plugin.com）+ GitHub dsh-plugin 生态 + npm registry 三源；对 DSH Desktop（EAC）特化（web-desktop profile）；来源白名单 + 冲突预检 + 试装验证；后台自动检测 + 可配置自动升级 + 市场自更新；一键检查/全部更新/逐个更新，更新进度窗口；v0.3.0 起集成 EAC 功能包（.dshpack）管理（📦 功能包 tab，交互编排层）",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "type": "module",
   "main": "lib/host.js",
@@ -33,6 +33,7 @@
     "data/",
     "cordis.patch.yml",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "engines": {

--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -954,6 +954,18 @@ fn sanitize_label(s: &str) -> String {
     }
 }
 
+/// Windows 任务栏/标题栏图标：tao 注册的窗口 class 不带图标（WNDCLASSEXW
+/// 的 hIcon/hIconSm 为 NULL），动态创建的窗口不显式注入图标时，任务栏按钮
+/// 会显示空白默认图。default_window_icon 与托盘同源（tauri-build 嵌入的
+/// bundle icon）；set_icon 失败只影响观感，不阻塞窗口创建。
+fn apply_window_icon(win: &tauri::WebviewWindow, app: &tauri::AppHandle) {
+    if let Some(icon) = app.default_window_icon() {
+        if let Err(e) = win.set_icon(icon.clone()) {
+            eprintln!("[shell] window icon set failed: {}", e);
+        }
+    }
+}
+
 /// 会话浮窗（硬门槛①）：第二个 WebviewWindow + 独立 data_directory
 /// （= Electron 的 persist:dsh-float 分区），与主窗 localStorage 隔离。
 /// 同一会话复用同一标签 → 单浮窗；返回 false 表示已存在（show+focus）。
@@ -1001,9 +1013,8 @@ fn open_float_window(app: &tauri::AppHandle, session_id: &str) -> Result<bool, S
             ));
         }
     }
-    builder
-        .build()
-        .map_err(|e| e.to_string())?;
+    let win = builder.build().map_err(|e| e.to_string())?;
+    apply_window_icon(&win, app);
     println!("[shell] float window {} created", label);
     Ok(true)
 }
@@ -1037,9 +1048,12 @@ fn open_recovery_center_window(app: &tauri::AppHandle) -> bool {
         .data_directory(data_dir)
         .disable_drag_drop_handler()
         .focused(true);
-    if let Err(e) = builder.build() {
-        eprintln!("[shell] recovery-center window build failed: {}", e);
-        return false;
+    match builder.build() {
+        Ok(win) => apply_window_icon(&win, app),
+        Err(e) => {
+            eprintln!("[shell] recovery-center window build failed: {}", e);
+            return false;
+        }
     }
     println!("[shell] recovery-center window created");
     true
@@ -1697,6 +1711,7 @@ fn main() {
                                     }
                                     match builder.build() {
                                         Ok(win) => {
+                                            apply_window_icon(&win, &app_win);
                                             if sim_max {
                                                 let _ = win.maximize();
                                             }
@@ -1787,6 +1802,7 @@ fn main() {
                                         }
                                         match builder.build() {
                                             Ok(win) => {
+                                                apply_window_icon(&win, &app_died);
                                                 if sim_max {
                                                     let _ = win.maximize();
                                                 }

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -42,11 +42,11 @@ const LIB_DESKTOP = [
   'file-roots.js', 'proc.js', 'platform.js', 'runtime-paths.js', 'profile.js', 'guard-box.js',
   'runtime-patches.js', 'companion-sync.js', 'plugin-ops.js', 'market.js',
   'shortcuts.js', 'junction-patrol.js', 'client-update.js', 'static-preview.js',
-  'boot-server.js',
+  'boot-server.js', 'feature-pack.js',
 ];
 const SCRIPTS = [
   'patch-session-manage.js', 'plugin-manager-patch.js',
-  'onboarding.js', 'patch-deps.js',
+  'onboarding.js', 'patch-deps.js', 'feature-pack-cli.js',
 ];
 
 // vnext 隔离体系（vnext-absorb Phase 2）：sidecar require 的 lib/{state,log,
@@ -247,6 +247,18 @@ for (const f of NATIVE_MODULES) {
 mkdirSync(path.join(staged, 'dsh-desktop', 'scripts'), { recursive: true });
 for (const f of SCRIPTS) {
   copyRequired(path.join(dd, 'scripts', f), path.join(staged, 'dsh-desktop', 'scripts', f), '脚本');
+}
+// 功能包链路自检（copyRequired 保证源存在，这里校验"成对"装配）：
+// scripts/feature-pack-cli.js 与 lib/desktop/feature-pack.js 必须同时入包 ——
+// CLI 运行时 require ../lib/desktop/feature-pack，漏一个功能包页就整体不可用
+// （市场插件只能报"功能包 CLI 不可用"）。后续新增随包 CLI 照此成对补充。
+{
+  const cli = path.join(staged, 'dsh-desktop', 'scripts', 'feature-pack-cli.js');
+  const core = path.join(staged, 'dsh-desktop', 'lib', 'desktop', 'feature-pack.js');
+  if (existsSync(cli) !== existsSync(core)) {
+    throw new Error('[stage] 功能包链路装配不完整：feature-pack-cli.js 与 feature-pack.js 必须同时入包');
+  }
+  if (existsSync(cli)) console.log('[stage] 功能包链路自检通过（CLI + 核心）');
 }
 // package.json + lock 原样拷贝（npm ci 要求两者一致；--omit=dev 只装生产树）。
 // .npmrc（legacy-peer-deps）必须随行：内核包互相声明 peer，staged 目录里的


### PR DESCRIPTION
## 背景

用户桌面端「📦 功能包」页全部操作报「功能包 CLI 不可用（缺少 DSH_DESKTOP_RESOURCE_ROOT，请在桌面壳内使用）」，但进程环境变量注入正常（实测 dsh 内核进程环境块中 `DSH_DESKTOP_RESOURCE_ROOT` 存在且指向正确）。排查确认：**#237 引入的功能包两个编译产物（`scripts/feature-pack-cli.js`、`lib/desktop/feature-pack.js`）未加入 `tauri-shell/stage-resources.mjs` 的人工装配白名单**，打包产出的客户端缺文件，而插件把「CLI 文件不存在」与「环境变量缺失」统一误报为后者，排障误导。另收到反馈：最新版 Tauri 壳在 Windows 任务栏不显示窗口图标。

## 改动

### 1. 打包装配白名单补齐 + 成对自检（tauri-shell/stage-resources.mjs）

- `LIB_DESKTOP` 补 `feature-pack.js`、`SCRIPTS` 补 `feature-pack-cli.js`（#237 新增文件漏入人工白名单是本次故障根因）。
- 新增功能包链路成对装配自检：CLI 与核心模块必须同时入包，缺一即 stage 失败，防同类回归。

### 2. Windows 任务栏图标修复（tauri-shell/src/main.rs）

- 根因：tao 注册的窗口 class 不带图标（`WNDCLASSEXW.hIcon/hIconSm` 为 NULL，tao 0.35.3 源码实证），动态创建的窗口未显式注入图标时任务栏按钮显示空白默认图（exe 内嵌图标资源正常，ExtractAssociatedIcon 可提取 32x32）。
- 新增 `apply_window_icon` 辅助：主窗 / 会话浮窗 / 恢复中心 / died 页四处动态窗口在 build 成功后注入 `default_window_icon`（与托盘图标同源，tauri-build 嵌入的 bundle icon）；失败仅告警不阻塞窗口创建。

### 3. 统一插件市场 0.3.0 → 0.3.1（assets/plugins/dsh-unified-market）

- 同步上游 `dsh-unified-market@0.3.1`（npm 已发布，shasum 8cae29b4；上游 commit 61dc51a）。
- 插件侧 `packCliStatus()` 区分两种定位失败：「桌面壳未注入环境变量」提示改用桌面客户端/升级客户端；「CLI 文件不存在」给出具体缺失路径 + 升级/重装客户端指引。`pack.*` 全部方法同步新文案。
- 同步 package.json 0.3.1、README、CHANGELOG.md（新增，含本批说明）。

### 4. dsh-desktop/CHANGELOG.md

- 新增「功能包链路修复 + 任务栏图标 · next」批次记录以上三项。

## 验证

- `cargo check`（tauri-shell，WinLibs GNU dlltool）：通过，零警告。
- `npm test`（dsh-desktop，V2 全量）：713 通过 / 0 失败 / 10 平台性跳过，含直接 import 新 host.js 的 `market-installed` / `resolve-profile` 契约测试。
- `node --check stage-resources.mjs`：通过。
- 插件三场景 smoke：无环境变量 → 「未注入+升级客户端」提示；有变量无 CLI → 「路径+升级或重装」提示；真实部署树 → 正常定位。
- 版本一致性：package.json 0.3.1 = host.js `SELF_VERSION` 0.3.1。

## 未验证项

- 真实 NSIS/便携包产出（V5）：stage-resources 成对自检在打包机生效，本次未跑完整 `tauri build` 装配链。
- 任务栏图标的实际运行时效果需重打包后目视确认（修复依据 tao 源码实证 + API 正确性）。
