### PR TITLE
fix(shell): 任务栏 Big 图标 WM_SETICON 补齐 + 主窗首启尺寸自适应与坏状态防御

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -58,7 +58,7 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
     → `jing-hy`（自研，GitHub 仓库归属一致）。
 - 英文版致谢表补上此前缺失的 `computer-user` 条目，与中文版对齐。
 
-## 功能包链路修复 + 任务栏图标 · next
+## 功能包链路修复 + 任务栏图标 + 窗口尺寸 · next
 
 ### 打包装配：功能包 CLI 白名单补齐（tauri-shell/stage-resources.mjs）
 
@@ -69,13 +69,28 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
 - 两文件补入白名单，并新增成对装配自检：CLI 与核心模块必须同时入包，
   缺一即 stage 直接失败（后续新增随包 CLI 照此成对补充）。
 
-### Tauri 壳：Windows 任务栏图标修复（tauri-shell/src/main.rs）
+### Tauri 壳：Windows 任务栏图标修复（tauri-shell/src/main.rs + Cargo.toml）
 
-- tao 注册的窗口 class 不带图标（`WNDCLASSEXW.hIcon` 为 NULL），动态创建的
-  窗口不显式注入图标时，Windows 任务栏按钮显示空白默认图。
-- 主窗 / 会话浮窗 / 恢复中心 / died 页四处窗口统一在 build 成功后经
-  `apply_window_icon` 注入 `default_window_icon`（与托盘图标同源，tauri-build
-  嵌入的 bundle icon）；注入失败仅打印告警，不阻塞窗口创建。
+- 根因分两层：① tao 注册的窗口 class 不带图标（`WNDCLASSEXW.hIcon` 为 NULL）；
+  ② tao 区分 Small（`set_window_icon`，标题栏）与 Big（`set_taskbar_icon`，
+  任务栏）两套图标 —— tauri 的 `set_icon` 只映射 Small 且未暴露 Big API，
+  动态创建的无框窗口两套均空，任务栏显示空白默认图（白色文件图标）。
+- 修复：新增 `apply_taskbar_icon_big` —— 经 `hwnd()` 从 exe 内嵌资源加载
+  tauri-build 以 ID 32512 嵌入的 bundle .ico（`LoadImageW`），`WM_SETICON`
+  同时补 Big（任务栏）与 Small（标题栏）；Small 仍由 `default_window_icon`
+  （tauri `set_icon`）负责。主窗 / 会话浮窗 / 恢复中心 / died 页四处窗口
+  统一接入；失败仅打印告警，不阻塞窗口创建。
+- 依赖：新增 `windows-sys 0.61`（仅 Windows 目标；版本对齐依赖树既有条目，
+  复用不新增编译单元）。
+
+### Tauri 壳：主窗默认尺寸自适应 + 坏状态防御（tauri-shell/src/main.rs）
+
+- 首启默认（无 `window-state.json`）：改为 work area（去双边距）的 80%，
+  收敛到 [1200×800, 1920×1080] 逻辑区间 —— 1080p 及以上屏幕首启即约八成
+  宽高；`DSH_WINDOW_W/H` 显式覆盖保留。
+- 坏状态防御（重装后窗口很小的根因）：恢复历史状态时尺寸 < 600×400（逻辑）
+  判为旧版本异常残留，直接丢弃走首启默认并打印告警，不再每次启动都恢复成
+  小窗；正常拖小（≥ 下限）的窗口记忆不受影响。
 
 ### 内置插件：dsh-unified-market 0.3.0 → 0.3.1
 

--- a/tauri-shell/Cargo.lock
+++ b/tauri-shell/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tokio",
  "tokio-tungstenite",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tauri-shell/Cargo.toml
+++ b/tauri-shell/Cargo.toml
@@ -17,6 +17,14 @@ tokio-tungstenite = "0.24"
 futures-util = "0.3"
 http = "1"
 
+# 任务栏 Big 图标（WM_SETICON）专用：tauri 未暴露 tao 的 set_taskbar_icon，
+# 经 hwnd() 直呼 USER32。版本对齐依赖树既有 0.61.x（复用，不新增编译单元）。
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+  "Win32_UI_WindowsAndMessaging",
+  "Win32_System_LibraryLoader",
+] }
+
 [[bin]]
 name = "dsh-eac-shell"
 path = "src/main.rs"

--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -277,6 +277,16 @@ fn resolved_initial_bounds(
         // 范围），窗口将永远无法完整显示 —— 以 work area 为实际下限（保底 1px）。
         let eff_min_w = min_w.min(work_w - FIRST_RUN_MARGIN).max(1.0);
         let eff_min_h = min_h.min(work_h - FIRST_RUN_MARGIN).max(1.0);
+        if std::env::var_os("DSH_WINDOW_W").is_none() && std::env::var_os("DSH_WINDOW_H").is_none()
+        {
+            // 自适应首启默认（issue：重装/首启窗口过小）：work area 双边距后
+            // 取 80%，收敛到 [1200×800, 1920×1080] 逻辑区间 —— 1080p 及以上
+            // 屏幕首启即约八成宽高，窄副屏由下方 work-area 收敛兜底。
+            let fit_w = (work_w - FIRST_RUN_MARGIN * 2.0) * 0.8;
+            let fit_h = (work_h - FIRST_RUN_MARGIN * 2.0) * 0.8;
+            out_w = fit_w.clamp(1200.0, 1920.0);
+            out_h = fit_h.clamp(800.0, 1080.0);
+        }
         out_w = out_w.min(work_w - FIRST_RUN_MARGIN).max(eff_min_w);
         out_h = out_h.min(work_h - FIRST_RUN_MARGIN).max(eff_min_h);
         let cx = ct.position.x as f64 + (ct.size.width as f64 - out_w * scale) / 2.0;
@@ -285,6 +295,16 @@ fn resolved_initial_bounds(
     }
 
     if let Some(st) = load_window_state(app) {
+        // 坏状态防御（issue：重装后窗口很小）：历史尺寸过小（<600×400 逻辑，
+        // 低于有意义的可用下限）多为旧版本异常会话/坏写盘残留 —— 直接丢弃
+        // 走上面的首启默认，避免每次启动都恢复成小窗。正常拖小的窗口首次
+        // 调整后重新记忆即可恢复。
+        if st.w < 600.0 || st.h < 400.0 {
+            eprintln!(
+                "[shell] window-state too small ({}x{}), ignored (use default size)",
+                st.w, st.h
+            );
+        } else {
         // 目标显示器：窗口中心点所在显示器（副屏拼接/拔插后旧坐标仍指向其它
         // 屏也算合法；完全失效时 monitor_from_point 返回 None → 回退上面的默认）。
         let scale = primary.as_ref().map(|p| p.scale_factor()).unwrap_or(1.0);
@@ -317,6 +337,7 @@ fn resolved_initial_bounds(
             out_h = h;
             out_pos = Some((x / mscale, y / mscale));
             out_max = st.maximized;
+        }
         }
     }
 
@@ -954,6 +975,51 @@ fn sanitize_label(s: &str) -> String {
     }
 }
 
+/// Windows 任务栏 Big 图标：tauri 的 set_icon 只走 tao set_window_icon
+/// （IconType::Small —— 标题栏/Alt+Tab），而任务栏读取的是 ICON_BIG；
+/// tao 注册的窗口 class 不带图标（hIcon NULL）且 tauri 未暴露
+/// set_taskbar_icon，任务栏因此显示空白默认图。
+/// 处理：从 exe 内嵌资源加载图标（tauri-build 以资源 ID 32512 嵌入的
+/// bundle .ico，lib.rs set_icon_with_id），SendMessage(WM_SETICON) 同时
+/// 补 Big（任务栏）与 Small（标题栏）。失败仅告警，不阻塞窗口创建。
+#[cfg(windows)]
+fn apply_taskbar_icon_big(win: &tauri::WebviewWindow) {
+    use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetSystemMetrics, LoadImageW, SendMessageW, ICON_BIG, ICON_SMALL, IMAGE_ICON,
+        LR_DEFAULTSIZE, SM_CXSMICON, SM_CYSMICON, WM_SETICON,
+    };
+    let Ok(hwnd) = win.hwnd() else { return };
+    // tauri hwnd() 返回 windows crate 的 HWND(pub *mut c_void)，与 windows-sys 指针同形。
+    let hwnd = hwnd.0;
+    unsafe {
+        let hinstance = GetModuleHandleW(std::ptr::null());
+        if hinstance.is_null() {
+            return;
+        }
+        // MAKEINTRESOURCEW(32512)：资源 ID 按约定即指针值的低 16 位。
+        let icon_name: *const u16 = 32512usize as *const u16;
+        let hicon_big = LoadImageW(hinstance, icon_name, IMAGE_ICON, 0, 0, LR_DEFAULTSIZE);
+        let hicon_small = LoadImageW(
+            hinstance,
+            icon_name,
+            IMAGE_ICON,
+            GetSystemMetrics(SM_CXSMICON),
+            GetSystemMetrics(SM_CYSMICON),
+            0,
+        );
+        if !hicon_big.is_null() {
+            SendMessageW(hwnd, WM_SETICON, ICON_BIG as usize, hicon_big as isize);
+        }
+        if !hicon_small.is_null() {
+            SendMessageW(hwnd, WM_SETICON, ICON_SMALL as usize, hicon_small as isize);
+        }
+        if hicon_big.is_null() && hicon_small.is_null() {
+            eprintln!("[shell] taskbar icon: LoadImage(resource 32512) returned null");
+        }
+    }
+}
+
 /// Windows 任务栏/标题栏图标：tao 注册的窗口 class 不带图标（WNDCLASSEXW
 /// 的 hIcon/hIconSm 为 NULL），动态创建的窗口不显式注入图标时，任务栏按钮
 /// 会显示空白默认图。default_window_icon 与托盘同源（tauri-build 嵌入的
@@ -964,6 +1030,8 @@ fn apply_window_icon(win: &tauri::WebviewWindow, app: &tauri::AppHandle) {
             eprintln!("[shell] window icon set failed: {}", e);
         }
     }
+    #[cfg(windows)]
+    apply_taskbar_icon_big(win);
 }
 
 /// 会话浮窗（硬门槛①）：第二个 WebviewWindow + 独立 data_directory


### PR DESCRIPTION
## 背景

PR #243 合并后构建的 5.1.0 实测仍有两个问题：
1. **任务栏图标仍是白色文件**：上轮 `win.set_icon()` 走 tao `set_window_icon`（IconType::Small —— 仅标题栏/Alt+Tab），而 Windows 任务栏读取的是 ICON_BIG（tao `set_taskbar_icon`）；tauri 2.11.5 未暴露该 API，动态创建的无框窗口 Big/Small 均空 → 任务栏显示 class 默认空白图。tao 0.35.3 源码 window.rs:882-903 实证两套图标分离。
2. **重装后主窗很小**：窗口状态恢复逻辑对历史尺寸无"过小判定"——旧版本异常会话遗留的小尺寸 `window-state.json` 在重装（保留 app_config_dir）后每次都被原样恢复；且首启固定 1400×900 在高分屏上偏保守。

## 改动

### 任务栏图标（tauri-shell/src/main.rs + Cargo.toml）

- 新增 `apply_taskbar_icon_big`：经 `WebviewWindow::hwnd()` 用 `LoadImageW` 从 exe 内嵌资源加载 tauri-build 嵌入的 bundle .ico（`set_icon_with_id(..., "32512")`，tauri-build 2.6.3 lib.rs:669 实证），`SendMessageW(WM_SETICON)` 同时设置 ICON_BIG（任务栏）与 ICON_SMALL（标题栏）。失败仅告警，不阻塞窗口创建。
- 上轮的 `apply_window_icon`（tauri set_icon，Small）保留，四处窗口调用点不变。
- 依赖新增 `windows-sys = "0.61"`（仅 Windows 目标；对齐依赖树既有 0.61.2，复用零新增编译单元）。

### 主窗尺寸（tauri-shell/src/main.rs `resolved_initial_bounds`）

- 首启默认（无状态）：从固定 1400×900 改为 work area（去双边距）×80%，收敛到 [1200×800, 1920×1080] 逻辑区间；`DSH_WINDOW_W/H` 环境变量显式覆盖保留。
- 坏状态防御：恢复历史状态时 <600×400（逻辑）判为异常残留，丢弃并告警，走首启默认 —— 根治「重装后窗口很小」；正常拖小的记忆（≥480×360 下限）不受影响。

### CHANGELOG

- 批次段落更新为「功能包链路修复 + 任务栏图标 + 窗口尺寸 · next」，补充本轮两层根因与修复说明。

## 验证

- `cargo check`：通过，零警告（windows-sys 0.61.2 复用依赖树既有条目）。
- 修复链依据源码实证：tao window.rs:882（Small）/894（Big）分离、tauri-build lib.rs:669（资源 ID 32512）。
- 未验证项：任务栏图标与窗口尺寸的运行时效果需重打包后目视确认（本 PR 提供的机制为 Win32 标准路径）。
