### PR TITLE
feat(locale): 非中文环境自动切换英文界面

### DIFF
--- a/dsh-desktop/assets/onboarding.html
+++ b/dsh-desktop/assets/onboarding.html
@@ -148,6 +148,19 @@
 <script>
 (function () {
   'use strict';
+  var hasChineseLanguage = function () {
+    var languages = Array.from((navigator && navigator.languages) || []);
+    if (navigator && navigator.language) languages.push(navigator.language);
+    return languages.some(function (tag) { return String(tag).toLowerCase().split('-')[0] === 'zh'; });
+  };
+  var english = !hasChineseLanguage();
+  document.documentElement.lang = english ? 'en' : 'zh-CN';
+
+  function englishError(value) {
+    var text = String(value == null ? '' : value);
+    return /[\u3400-\u9fff]/.test(text) ? 'See the desktop log for details.' : text;
+  }
+
   var bridge = window.onboarding;
   var state = { mode: 'first', catalog: [], current: null, selected: new Set(), busy: false };
 
@@ -157,6 +170,26 @@
   var totalCountEl = $('totalCount');
   var goBtn = $('goBtn');
   var skipBtn = $('skipBtn');
+
+  if (english) {
+    document.title = 'Built-in plugin wizard';
+    $('modeTag').textContent = 'First run';
+    $('closeBtn').title = 'Close (skip)';
+    $('closeBtn').setAttribute('aria-label', 'Close');
+    document.querySelector('.hero h1').textContent = 'Built-in plugin wizard';
+    $('intro').textContent = 'Choose the built-in plugins enabled by default. Unselected packages remain installed and can be enabled later under Settings > Plugins > Manage or by reopening this wizard.';
+    var count = document.querySelector('.count');
+    count.childNodes[0].nodeValue = 'Selected ';
+    count.childNodes[count.childNodes.length - 1].nodeValue = ' total';
+    $('pureBtn').textContent = 'Minimal (core only)';
+    $('pureBtn').title = 'Keep only required core plugins';
+    $('fullBtn').textContent = 'Full (select all)';
+    $('fullBtn').title = 'Select every plugin, including optional enhancements';
+    $('noneBtn').textContent = 'Clear optional';
+    $('footerNote').textContent = 'Disabling is not uninstalling: plugin packages remain available in Plugin management and can be enabled anytime.';
+    $('skipBtn').textContent = 'Skip (keep all enabled)';
+    $('goBtn').textContent = 'Install selected plugins';
+  }
 
   function fmtSize(bytes) {
     if (!bytes || bytes <= 0) return '';
@@ -177,12 +210,14 @@
     totalCountEl.textContent = String(state.catalog.length);
     selCountEl.textContent = String(state.selected.size);
     goBtn.disabled = state.busy;
-    goBtn.textContent = state.busy ? '正在应用…' : (state.mode === 'rerun' ? '应用更改' : '安装所选插件');
+    goBtn.textContent = english
+      ? (state.busy ? 'Applying...' : (state.mode === 'rerun' ? 'Apply changes' : 'Install selected plugins'))
+      : (state.busy ? '正在应用…' : (state.mode === 'rerun' ? '应用更改' : '安装所选插件'));
 
     var html = '';
-    html += section('核心必装', 'badge-lock', '始终启用（主界面/设置页底座）', core);
-    html += section('推荐', 'badge-rec', '常用功能增强', rec);
-    html += section('可选增强', 'badge-opt', '按需启用', opt);
+    html += section(english ? 'Required core' : '核心必装', 'badge-lock', english ? 'Always enabled (UI foundation)' : '始终启用（主界面/设置页底座）', core);
+    html += section(english ? 'Recommended' : '推荐', 'badge-rec', english ? 'Common enhancements' : '常用功能增强', rec);
+    html += section(english ? 'Optional' : '可选增强', 'badge-opt', english ? 'Enable as needed' : '按需启用', opt);
     groupsEl.innerHTML = html;
 
     groupsEl.querySelectorAll('input[type=checkbox]').forEach(function (box) {
@@ -200,12 +235,14 @@
     return h + items.map(function (p) {
       var checked = p.core || state.selected.has(p.id);
       var size = fmtSize(p.size);
-      var tag = (p.registryDisabled && !p.core) ? '<span class="tag tag-off">默认停用</span>' : '';
+      var tag = (p.registryDisabled && !p.core) ? '<span class="tag tag-off">' + (english ? 'Disabled by default' : '默认停用') + '</span>' : '';
+      var description = p.description || '';
+      if (english && /[\u3400-\u9fff]/.test(description)) description = 'Built-in extension for Deepseek Harness EAC.';
       return '<div class="row">' +
         '<input type="checkbox" data-id="' + esc(p.id) + '"' + (checked ? ' checked' : '') + (p.core || state.busy ? ' disabled' : '') + ' />' +
         '<div class="main">' +
           '<div class="name">' + esc(p.name.split('/').pop()) + '<span class="pkg">' + esc(p.name) + '</span></div>' +
-          (p.description ? '<div class="desc">' + esc(p.description) + '</div>' : '') +
+          (description ? '<div class="desc">' + esc(description) + '</div>' : '') +
         '</div>' +
         (size ? '<span class="size">' + size + '</span>' : '') +
         tag +
@@ -224,22 +261,22 @@
   function run() {
     bridge.list().then(function (res) {
       if (!res || !Array.isArray(res.catalog)) {
-        $('intro').textContent = '向导数据加载失败，请重试。';
+        $('intro').textContent = english ? 'Could not load wizard data. Try again.' : '向导数据加载失败，请重试。';
         return;
       }
       state.mode = res.mode || 'first';
       state.catalog = res.catalog;
       state.current = res.current || null;
       if (state.mode === 'rerun') {
-        $('modeTag').textContent = '二次调整';
-        $('intro').textContent = '重新打开插件选择向导：勾选 = 启用，取消勾选 = 停用。改动会立即写入并重启 Web 服务生效。';
-        $('footerNote').textContent = '停用不等于卸载：插件包与「插件管理」页保持完整，随时可一键启用或再次调整。';
+        $('modeTag').textContent = english ? 'Adjust selection' : '二次调整';
+        $('intro').textContent = english ? 'Adjust the plugin selection: checked means enabled and unchecked means disabled. Changes are saved immediately and applied after the web service restarts.' : '重新打开插件选择向导：勾选 = 启用，取消勾选 = 停用。改动会立即写入并重启 Web 服务生效。';
+        $('footerNote').textContent = english ? 'Disabling is not uninstalling: packages remain in Plugin management and can be enabled or adjusted anytime.' : '停用不等于卸载：插件包与「插件管理」页保持完整，随时可一键启用或再次调整。';
         skipBtn.hidden = true;
       }
       defaults(state.current);
       render();
     }).catch(function (e) {
-      $('intro').textContent = '向导数据加载失败: ' + String((e && e.message) || e);
+      $('intro').textContent = english ? 'Could not load wizard data: ' + englishError((e && e.message) || e) : '向导数据加载失败: ' + String((e && e.message) || e);
     });
   }
 
@@ -269,16 +306,16 @@
     bridge.submit(ids).then(function (res) {
       if (!res || res.ok !== true) {
         state.busy = false;
-        $('footerNote').textContent = '应用失败：' + (res && res.error) || '未知错误';
+        $('footerNote').textContent = english ? 'Could not apply changes: ' + englishError(res && res.error) : ('应用失败：' + ((res && res.error) || '未知错误'));
         render();
         return;
       }
       if (res.errors && res.errors.length) {
-        $('footerNote').textContent = '部分插件未生效: ' + res.errors.join('；');
+        $('footerNote').textContent = english ? 'Some plugins could not be applied. See the desktop log for details.' : '部分插件未生效: ' + res.errors.join('；');
       }
     }).catch(function (e) {
       state.busy = false;
-      $('footerNote').textContent = '应用失败: ' + String((e && e.message) || e);
+      $('footerNote').textContent = english ? 'Could not apply changes: ' + englishError((e && e.message) || e) : '应用失败: ' + String((e && e.message) || e);
       render();
     });
   });

--- a/dsh-desktop/assets/plugins/dsh-eac-locale-compat/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-eac-locale-compat/lib/client.js
@@ -1,0 +1,644 @@
+window.__ModuleLoader__.load({
+  id: 'dsh-eac-locale-compat',
+  factory: () => {
+    const module = { exports: {} }
+    const exports = module.exports
+    Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
+
+    const ORIGINAL_TEXT = Symbol('dshEacOriginalText')
+    const TRANSLATED_TEXT = Symbol('dshEacTranslatedText')
+    const ORIGINAL_ATTRIBUTES = Symbol('dshEacOriginalAttributes')
+    const TRANSLATED_ATTRIBUTES = Symbol('dshEacTranslatedAttributes')
+    const TRANSLATABLE_ATTRIBUTES = ['aria-label', 'aria-description', 'placeholder', 'title']
+    const EXCLUDED_SELECTOR = [
+      'code', 'pre', 'kbd', 'samp', 'textarea', '[contenteditable="true"]',
+      '[data-language]', '[data-code-block]', '.cm-editor', '.xterm',
+      '[data-chat-flow-kind]', '[data-message-id]', '[data-role="message"]',
+      '.dss-msg', '.dss-chip',
+    ].join(',')
+
+    // Longest phrases win. Short entries at the end also cover status text that
+    // combines a fixed label with a runtime value supplied by an older plugin.
+    const ENGLISH_PHRASES = Object.freeze([
+      ['本轮费用按 token 用量估算；未读取到 DeepSeek API Key，无法显示余额', 'Turn cost is estimated from token usage. Balance is unavailable because no DeepSeek API key was found.'],
+      ['（UTC+8）为高峰价，其余为空闲价（半价）。可在设置 pricing.peakWindows 调整。', '(UTC+8) uses peak pricing; all other hours use half-price off-peak rates. Adjust this under pricing.peakWindows.'],
+      ['自定义价格覆盖官方默认档（仅影响本机费用估算显示，单位：¥/百万 token）。', 'Custom prices override official defaults for local cost estimates only (CNY per million tokens).'],
+      ['价格设置桥接不可用（请确认已更新到最新版 DSH Desktop）', 'Pricing settings bridge unavailable. Update to the latest DSH Desktop.'],
+      ['价格必须是 0~1000 的数字', 'Price must be a number from 0 to 1000.'],
+      ['已保存，费用估算已更新', 'Saved. Cost estimates were updated.'],
+      ['已恢复默认价格', 'Default prices restored.'],
+      ['正在加载模型列表…', 'Loading model list...'],
+      ['本轮 ¥', 'Turn CNY '],
+      ['余额 ¥', 'Balance CNY '],
+      ['高峰时段 ', 'Peak hours '],
+      ['未命中缓存', 'Cache miss'],
+      ['命中缓存', 'Cache hit'],
+      ['高峰价', 'Peak rate'],
+      ['空闲价', 'Off-peak rate'],
+      ['价格设置', 'Pricing settings'],
+      ['恢复默认', 'Restore defaults'],
+      ['处理中…', 'Processing...'],
+      ['读取失败', 'Read failed'],
+      ['恢复失败', 'Restore failed'],
+      ['本会话中 agent 用 write/edit 等文件工具修改过的文件会显示在这里（支持还原）；通过代码执行类工具（run_code/pwsh/bash）改的文件无法生成 diff，不会出现在此。', 'Files changed by agent file tools such as write/edit appear here and can be restored. Changes made through run_code, pwsh, or bash cannot produce a diff and are not listed.'],
+      ['文件已被后续修改，无法自动还原（可手工处理）。', 'The file changed again and cannot be restored automatically. Resolve it manually.'],
+      ['也可以切到「全部文件」浏览项目目录。', 'Switch to All files to browse the project directory.'],
+      ['当前会话没有项目目录。', 'The current session has no project directory.'],
+      ['暂无文件更改记录', 'No file changes recorded'],
+      ['站内预览此文件', 'Preview this file in the app'],
+      ['还原此文件的全部变更', 'Restore all changes to this file'],
+      ['本机回环监听端口（点击预览）', 'Local loopback port (select to preview)'],
+      ['回到项目根目录', 'Return to project root'],
+      ['重新探测端口', 'Detect ports again'],
+      ['本会话修改过', 'Changed in this session'],
+      ['本会话修改', 'Session changes'],
+      ['全部文件', 'All files'],
+      ['站内预览', 'In-app preview'],
+      ['文件已删除', 'File deleted'],
+      ['已还原', 'Restored'],
+      ['还原失败：', 'Restore failed: '],
+      ['还原', 'Restore'],
+      ['新建', 'Created'],
+      ['修改', 'Modified'],
+      ['预览', 'Preview'],
+      ['拖动调整宽度', 'Drag to resize'],
+      ['后退', 'Back'],
+      ['前进', 'Forward'],
+      ['在外部打开', 'Open externally'],
+      ['关闭预览', 'Close preview'],
+      ['未加载', 'Not loaded'],
+      ['在线 · HTTP ', 'Online · HTTP '],
+      ['离线 · ', 'Offline · '],
+      ['连接失败', 'Connection failed'],
+      ['已加载 · ', 'Loaded · '],
+      ['上级目录', 'Parent directory'],
+      ['（已截断）', '(truncated)'],
+      ['投影诊断: ', 'Projection diagnostics: '],
+      ['undefined（投影未返回）', 'undefined (projection returned no value)'],
+      ['文件', 'Files'],
+      ['大肥鱼桌面伴侣', 'Dafeiyu desktop companion'],
+      ['入口和状态属于 DSH，鱼始终显示在 Windows 桌面最上层。', 'DSH owns the controls and status. The companion stays above the Windows desktop.'],
+      ['大肥鱼设置尚未连接到 DSH Host。', 'Dafeiyu settings are not connected to the DSH host.'],
+      ['关闭后立即退出；重新开启无需单独启动程序。', 'The companion exits immediately when disabled and starts automatically when enabled again.'],
+      ['控制空闲时微动作的出现频率。', 'Controls how often idle animations occur.'],
+      ['减少走动、循环帧和程序化晃动。', 'Reduce walking, looping frames, and procedural movement.'],
+      ['默认只跟随顶层任务，避免状态过度跳动。', 'Follow top-level tasks only by default to avoid excessive status changes.'],
+      ['启用大肥鱼', 'Enable Dafeiyu'],
+      ['角色大小', 'Character size'],
+      ['活跃程度', 'Activity level'],
+      ['安静', 'Quiet'],
+      ['标准', 'Standard'],
+      ['活泼', 'Lively'],
+      ['减少动态效果', 'Reduce motion'],
+      ['响应子 Agent', 'React to subagents'],
+      ['正在读取设置…', 'Reading settings...'],
+      ['正在保存…', 'Saving...'],
+      ['默认关闭；开启后写入插件配置，重启应用生效。可随时在此或「插件 → 管理」停用。', 'Disabled by default. Enabling writes the plugin configuration and takes effect after an app restart. Disable it here or under Plugins > Manage.'],
+      ['DSH 界面右下角的 DeepSeek 余额挂件：余额 / 今日已用 / 每轮对话消耗统计（依赖 DEEPSEEK_API_KEY 凭据）。', 'DeepSeek balance widget at the lower right of DSH: balance, daily usage, and per-turn cost (requires DEEPSEEK_API_KEY).'],
+      ['把一个会话变成「队长 + 子代理成员 + 依赖感知任务 DAG + 成员直发消息」的协作团队；启用后在对话里使用 /agent-teams。', 'Turn a session into a team with a lead, subagents, a dependency-aware task DAG, and direct member messages. Use /agent-teams after enabling.'],
+      ['开启并重启后，小鲸鱼余额挂件固定显示在会话页面右下角（图标+余额/今日已用）；随时可回本分区或「插件 → 管理」停用。', 'After enabling and restarting, the balance widget appears at the lower right of sessions. Disable it here or under Plugins > Manage.'],
+      ['启用并重启后，在对话输入框输入 /agent-teams 打开团队面板：安排子代理成员、分配依赖感知的任务 DAG、成员之间直发消息；不需要时同样可以在此停用。', 'After enabling and restarting, enter /agent-teams in the composer to open the team panel, arrange subagents, assign dependency-aware tasks, and message members directly.'],
+      ['插件管理桥不可用（请在 Tauri 桌面壳中使用）', 'Plugin management bridge unavailable. Use the Tauri desktop app.'],
+      ['读取状态失败: ', 'Could not read status: '],
+      ['已启用：重启应用后生效', 'Enabled. Restart the app to apply.'],
+      ['已停用：重启应用后生效', 'Disabled. Restart the app to apply.'],
+      ['重启 Web 服务立即生效', 'Restart the web service to apply now'],
+      ['余额小鲸鱼', 'Balance widget'],
+      ['AgentTeams 多智能体团队', 'AgentTeams multi-agent team'],
+      ['多智能体协作团队', 'Multi-agent team'],
+      ['正在读取状态…', 'Reading status...'],
+      ['余额', 'Balance'],
+      ['该模型不在 V4 Flash/Pro 调价表内，高峰时段价格仍可能偏高。', 'This model is not in the V4 Flash/Pro rate table. Peak-hour pricing may still be higher.'],
+      ['当前模型非 DeepSeek 平台，价格不受峰谷定价影响。', 'The current model is not on the DeepSeek platform, so peak/off-peak pricing does not apply.'],
+      ['关闭（不发送，消息保留在输入框）', 'Close without sending; keep the message in the composer'],
+      ['建议定时到 18:00 后或 0:00–8:00 执行，价格减半。', 'Schedule after 18:00 or between 00:00 and 08:00 for half-price rates.'],
+      ['该模型不在 V4 Flash/Pro 调价表内，高峰时段价格仍可能偏高。', 'This model is not in the V4 Flash/Pro rate table. Peak-hour pricing may still be higher.'],
+      ['本条命令已被拦截，尚未发送。', 'This request was blocked and has not been sent.'],
+      ['无法确定当前会话，定时失败', 'Could not identify the current session. Scheduling failed.'],
+      ['⚡ 高峰时段 · 已拦截发送', 'Peak hours · Send blocked'],
+      ['⚡ 高峰时段 · 价格提醒', 'Peak hours · Pricing notice'],
+      ['输入（缓存未命中）', 'Input (cache miss)'],
+      ['输入（缓存命中）', 'Input (cache hit)'],
+      ['当前模型：', 'Current model: '],
+      ['现在为北京时间 ', 'Beijing time is '],
+      ['，处于高峰时段（', ', currently within peak hours ('],
+      ['），价格较高。', '), when rates are higher.'],
+      ['本条命令：', 'Request: '],
+      ['继续执行', 'Continue now'],
+      ['定时执行', 'Schedule'],
+      ['今日不再提醒', 'Do not remind me again today'],
+      ['确认定时', 'Confirm schedule'],
+      ['无可选时间', 'No available time'],
+      ['✓ 已定时：', 'Scheduled: '],
+      [' 自动执行', ' automatic execution'],
+      ['定时失败：', 'Scheduling failed: '],
+      ['计费项', 'Billing item'],
+      ['闲时价', 'Off-peak rate'],
+      ['/百万', '/million'],
+      ['小时', 'Hours'],
+      ['分钟', 'Minutes'],
+      ['返回', 'Back'],
+      ['（空）', '(empty)'],
+      ['未知', 'Unknown'],
+      ['微信 ClawBot / 网关 → DSH 会话桥接', 'WeChat ClawBot / gateway to DSH session bridge'],
+      ['形如 provider/model（如 deepseek-official/deepseek-v4-pro）；留空 = 使用 DSH 默认模型', 'Use provider/model, for example deepseek-official/deepseek-v4-pro. Leave blank to use the DSH default model.'],
+      ['留空保存 = 保持现状（回环地址访问无需 Token）', 'Save blank to keep the current value. Loopback access does not require a token.'],
+      ['绝对路径，如 C:\\Users\\you\\Desktop\\work；留空 = 隔离的桥接工作区', 'Absolute path, such as C:\\Users\\you\\Desktop\\work. Leave blank for an isolated bridge workspace.'],
+      ['逗号分隔的微信用户 id（xxx@im.wechat）；留空 = 允许所有发消息的人', 'Comma-separated WeChat user IDs (xxx@im.wechat). Leave blank to allow anyone who sends a message.'],
+      ['填了它就改用这个端点（如 https://api.siliconflow.cn/v1）；留空 = 用上面的接收模型', 'Set this to use another endpoint, such as https://api.siliconflow.cn/v1. Leave blank to use the receiving model above.'],
+      ['请用微信扫码绑定（ClawBot 插件里点绑定，扫这个码）：', 'Scan this QR code in WeChat to bind ClawBot:'],
+      ['微信已扫码，请输入微信上显示的配对码：', 'QR code scanned. Enter the pairing code shown in WeChat:'],
+      ['剩余约 X 小时（每 24h 需重扫）', 'About X hours remaining (scan again every 24 hours)'],
+      ['微信工作目录（远程办公）', 'WeChat working directory (remote work)'],
+      ['微信用户白名单', 'WeChat user allowlist'],
+      ['第三方模型端点（OpenAI 兼容）', 'Third-party model endpoint (OpenAI compatible)'],
+      ['该端点上的模型 id（如 deepseek-ai/DeepSeek-V3）', 'Model ID on this endpoint, such as deepseek-ai/DeepSeek-V3'],
+      ['接入端点（OpenAI 兼容）：', 'Access endpoint (OpenAI compatible): '],
+      ['微信连接（iLink 直连，不经 OpenClaw）', 'WeChat connection (direct iLink, without OpenClaw)'],
+      ['会话已过期，请重新扫码', 'Session expired. Scan the QR code again.'],
+      ['也可以点开链接绑定：', 'You can also open the link to bind: '],
+      ['接收模型', 'Receiving model'],
+      ['桥接 Token', 'Bridge token'],
+      ['模型名', 'Model name'],
+      ['未连接', 'Not connected'],
+      ['正在生成二维码…', 'Generating QR code...'],
+      ['已连接', 'Connected'],
+      ['连接微信', 'Connect WeChat'],
+      ['断开', 'Disconnect'],
+      ['提交配对码', 'Submit pairing code'],
+      ['数字配对码', 'Numeric pairing code'],
+      ['（留空保持现状）', '(leave blank to keep current value)'],
+      ['留空 = 隔离工作区', 'Blank = isolated workspace'],
+      ['页面桌宠', 'In-app desktop pet'],
+      ['显示在应用窗口内的桌宠；大小与位置在桌宠上的齿轮面板里调整。', 'A pet shown inside the app window. Adjust its size and position from its settings button.'],
+      ['停用后窗口内不再显示；重启应用后生效。', 'When disabled, it no longer appears in the window. Restart the app to apply.'],
+      ['始终显示在 Windows 桌面最上层，右键可隐藏、减少动态。', 'Always stays above the Windows desktop. Right-click to hide it or reduce motion.'],
+      ['大肥鱼当前未启用。请在“插件 → 管理”启用 dsh-dafeiyu 后重启应用。', 'Dafeiyu is disabled. Enable dsh-dafeiyu under Plugins > Manage, then restart the app.'],
+      ['启用页面桌宠', 'Enable in-app desktop pet'],
+      ['空闲微动作频率', 'Idle animation frequency'],
+      ['减少动态', 'Reduce motion'],
+      ['右下角', 'Bottom right'],
+      ['左下角', 'Bottom left'],
+      ['右上角', 'Top right'],
+      ['左上角', 'Top left'],
+      ['自由位置（拖拽）', 'Free position (drag)'],
+      ['搜索插件、点击分类标签过滤；配套/其他插件可一键关闭，「移除」为卸载语义（不再随启动同步），完全退出并重启 DSH Desktop 后生效。', 'Search plugins or filter by category. Companion and other plugins can be disabled. Remove uninstalls a plugin and stops startup synchronization; fully restart DSH Desktop to apply.'],
+      ['移除后不再随启动同步（下次启动不还原）', 'Stop synchronizing this plugin at startup; it will not be restored next time.'],
+      ['插件管理桥接不可用（请确认已更新到最新版 DSH Desktop）', 'Plugin management bridge unavailable. Update to the latest DSH Desktop.'],
+      ['（清单来自本地文件，实时注册表暂不可用）', '(list loaded from local files; live registry unavailable)'],
+      ['搜索插件（名称 / id / 描述）…', 'Search plugins (name / ID / description)...'],
+      ['插件清单加载失败：', 'Could not load plugin list: '],
+      ['没有匹配的插件', 'No matching plugins'],
+      ['核心组件', 'Core components'],
+      ['配套插件', 'Companion plugins'],
+      ['其他插件', 'Other plugins'],
+      ['不可关闭', 'Cannot be disabled'],
+      ['可开关', 'Can be toggled'],
+      ['（无描述）', '(no description)'],
+      ['已关闭', 'Disabled'],
+      ['已移除', 'Removed'],
+      ['重启后生效', 'Applies after restart'],
+      ['挂载失败', 'Mount failed'],
+      ['加载中', 'Loading'],
+      ['简洁', 'Compact'],
+      ['全部', 'All'],
+      ['管理', 'Manage'],
+      ['自定义提示词', 'Custom prompt'],
+      ['修改官方内核注入的系统提示词（应用到 standard 完整 Agent 基准预设）', 'Modify the system prompt injected by the official core for the standard full Agent baseline preset.'],
+      ['关闭后回落为官方默认提示词', 'Use the official default prompt when disabled.'],
+      ['替换整体（覆盖默认人设）', 'Replace all (override the default persona)'],
+      ['追加到末尾（保留默认人设，在其后追加）', 'Append (keep the default persona and add content after it)'],
+      ['按原样注入；可用 {{model}} 等占位符。建议包含对你的全面要求与项目约定。', 'Injected verbatim. Placeholders such as {{model}} are supported. Include your complete requirements and project conventions.'],
+      ['渲染后的官方默认 system prompt（不含自定义节），供对照编辑。', 'Rendered official default system prompt without the custom section, for reference while editing.'],
+      ['启用自定义提示词', 'Enable custom prompt'],
+      ['注入方式', 'Injection mode'],
+      ['提示词内容', 'Prompt content'],
+      ['预览官方提示词', 'Preview official prompt'],
+      ['预览加载失败', 'Could not load preview'],
+      ['归档对话管理', 'Archived session management'],
+      ['管理已归档的对话：可恢复（回到原工作区与顺序）或彻底删除（会话日志与附件一并移除，不可恢复）。删除运行中的会话会被拒绝。', 'Manage archived sessions. Restore them to their original workspace and order, or permanently delete their logs and attachments. Running sessions cannot be deleted.'],
+      ['确定要彻底删除这个对话吗？会话日志与附件将一并移除，此操作不可恢复。', 'Permanently delete this session? Its logs and attachments will also be removed. This cannot be undone.'],
+      ['该对话正在运行，无法删除：请先停止它再删除', 'This session is running. Stop it before deleting it.'],
+      ['彻底删除该对话及其日志（不可恢复）', 'Permanently delete this session and its logs'],
+      ['把该对话恢复到归档前的位置', 'Restore this session to its position before archiving'],
+      ['暂无已归档的对话', 'No archived sessions'],
+      ['设置不可用（需要在本机浏览器中打开）', 'Settings unavailable. Open this page in a local browser.'],
+      ['删除对话', 'Delete session'],
+      ['未知会话', 'Unknown session'],
+      ['更新时间', 'Updated'],
+      ['项目', 'Project'],
+      ['已操作', 'Completed'],
+      ['语言', 'Language'],
+      ['权限', 'Permissions'],
+      ['开发者', 'Developer'],
+      ['实验', 'Experimental'],
+      ['高级选项', 'Advanced options'],
+      ['高级', 'Advanced'],
+      ['模型', 'Models'],
+      ['视觉', 'Vision'],
+      ['迁移', 'Migration'],
+      ['夺舍', 'Persona migration'],
+      ['压缩', 'Compaction'],
+      ['审核', 'Review'],
+      ['快照', 'Snapshots'],
+      ['提示词', 'Prompts'],
+      ['思考强度', 'Reasoning effort'],
+      ['归档', 'Archive'],
+      ['当前会话没有项目目录，无法启动终端。', 'The current session has no project directory, so the terminal cannot start.'],
+      ['无法建立连接：宿主路由 /dsh-files/term/events 无响应（session: ', 'Could not connect: host route /dsh-files/term/events did not respond (session: '],
+      ['）。 可点右上「重启」重试，或重启桌面端后重试。', '). Select Restart at the upper right, or restart the desktop app.'],
+      ['正在获取项目目录…', 'Getting project directory...'],
+      ['运行中', 'Running'],
+      ['已退出', 'Exited'],
+      ['重连中…', 'Reconnecting...'],
+      ['连接失败（点重启重试）', 'Connection failed (select Restart to retry)'],
+      ['连接中…', 'Connecting...'],
+      ['清屏', 'Clear'],
+      ['重启终端', 'Restart terminal'],
+      ['输入命令，回车执行（PowerShell 语法；非 PTY：vim 等全屏程序不支持）', 'Enter a command and press Enter (PowerShell syntax; full-screen programs such as vim require a PTY and are unsupported)'],
+      ['回车重启终端…', 'Press Enter to restart the terminal...'],
+      ['终端', 'Terminal'],
+      ['请先输入要优化的提示词', 'Enter a prompt to optimize first.'],
+      ['请先选择模型', 'Select a model first.'],
+      ['正在调用模型…', 'Calling model...'],
+      ['优化请求失败（HTTP ', 'Optimization request failed (HTTP '],
+      ['正在优化 · 已生成 ', 'Optimizing · generated '],
+      ['已完成 · 已生成 /goal', 'Done · generated /goal'],
+      ['已完成 · 已附加浏览器验证', 'Done · appended browser verification'],
+      ['响应流意外结束', 'Response stream ended unexpectedly'],
+      ['已停止优化', 'Optimization stopped'],
+      ['第 ', 'Round '],
+      [' 轮 · 正在生成 ', ' · generating '],
+      [' 个候选…', ' candidates...'],
+      ['正在生成候选 ', 'Generating candidate '],
+      ['自动优化提示词', 'Optimize prompt automatically'],
+      ['提示词优化面板', 'Prompt optimization panel'],
+      ['优化提示词', 'Optimize prompt'],
+      [' 优化当前草稿', ' to optimize the current draft'],
+      ['多轮优化', 'Multi-round optimization'],
+      ['设定目标提示词', 'Set target prompt'],
+      ['设定目标', 'Set target'],
+      ['使用 AI 浏览器验证', 'Validate with AI browser'],
+      ['浏览器验证', 'Browser validation'],
+      ['点击生成多个候选', 'Select to generate multiple candidates'],
+      ['点击用当前模型优化', 'Select to optimize with the current model'],
+      ['多轮优化候选', 'Multi-round candidates'],
+      ['点选任意候选即可写入对话框，再点优化进入下一轮；顶部「原话」始终保留你最初写的内容。', 'Select any candidate to put it in the composer, then optimize again for the next round. Original always keeps your initial text.'],
+      ['原话', 'Original'],
+      ['候选 ', 'Candidate '],
+      ['均衡优化', 'Balanced'],
+      ['精简高效', 'Concise'],
+      ['详尽具体', 'Detailed'],
+      ['已完成', 'Done'],
+      ['无响应流', 'No response stream'],
+      ['优化失败', 'Optimization failed'],
+      ['失败：', 'Failed: '],
+      ['未选模型', 'No model selected'],
+      ['会话上下文', 'Session context'],
+      ['向当前会话上下文提问，答案仅存在于此临时会话，不污染主会话。', 'Ask about the current session context. Answers stay in this temporary session and do not affect the main session.'],
+      ['浮窗可自由拖动/缩放；左下角侧栏图标或 Ctrl+Shift+S 唤起。', 'Drag or resize the floating window. Open it from the lower-left sidebar icon or with Ctrl+Shift+S.'],
+      ['三模式互斥、持久化、即时切换，无需重启 DSH。', 'The three exclusive modes persist and switch immediately without restarting DSH.'],
+      ['选择档位后点「确定」生效（控制临时会话能看到的对话条数与文件上限）。', 'Choose a level and select Confirm to control how many messages and files the temporary session can see.'],
+      ['选择档位后点「确定」生效（0ms = 关闭动画）。', 'Choose a duration and select Confirm (0 ms disables animation).'],
+      ['使用 DSH 全局凭据（DEEPSEEK_API_KEY 环境变量或 ~/.dsh/.credentials.yaml）。', 'Use global DSH credentials from DEEPSEEK_API_KEY or ~/.dsh/.credentials.yaml.'],
+      ['已保存插件自带 Key；重新输入会替换旧值。', 'The plugin key is saved. Enter a new value to replace it.'],
+      ['输入后回车 / 失焦即保存（Key 仅存储在本机 settings.yaml，界面不回显明文）。', 'Press Enter or leave the field to save. The key stays in local settings.yaml and is never shown in plain text.'],
+      ['走服务端 ctx.llm.stream，不读任何 key。需宿主 LLM 服务可用。', 'Use server-side ctx.llm.stream without reading any key. The host LLM service must be available.'],
+      ['回答引擎模式', 'Answer engine mode'],
+      ['1 · 复用 DSH 全局 Key', '1 · Reuse global DSH key'],
+      ['2 · 插件自带 Key', '2 · Plugin key'],
+      ['3 · 宿主 LLM（ctx.llm）', '3 · Host LLM (ctx.llm)'],
+      ['上下文长度', 'Context length'],
+      ['1 · 标准（120 条 / 40K 字符，省 token）', '1 · Standard (120 messages / 40K characters, saves tokens)'],
+      ['2 · 加长（600 条 / 200K 字符，推荐）', '2 · Extended (600 messages / 200K characters, recommended)'],
+      ['3 · 完整（5000 条 / 2M 字符，最接近通读全文，token 消耗大）', '3 · Full (5,000 messages / 2M characters, high token use)'],
+      ['应用并保存', 'Apply and save'],
+      ['弹出动画时长', 'Open animation duration'],
+      ['关闭（0ms）', 'Off (0 ms)'],
+      ['快速（300ms）', 'Fast (300 ms)'],
+      ['标准（500ms，默认）', 'Standard (500 ms, default)'],
+      ['舒缓（800ms）', 'Relaxed (800 ms)'],
+      ['缓慢（1200ms）', 'Slow (1200 ms)'],
+      ['●●●●（已保存，输入可替换）', '●●●● (saved; enter a replacement)'],
+      ['API 基址', 'API base URL'],
+      ['基于上下文提问', 'Ask about the context'],
+      ['回答中…', 'Answering...'],
+      ['发送', 'Send'],
+      ['正在加载上下文…', 'Loading context...'],
+      ['未检测到会话', 'No session detected'],
+      ['(未知会话)', '(unknown session)'],
+      [' · 对话 ', ' · messages '],
+      [' 条 · 文件 ', ' · files '],
+      [' · 已截断', ' · truncated'],
+      ['会话：', 'Session: '],
+      ['拖动移动浮窗', 'Drag floating window'],
+      ['临时会话', 'Temporary session'],
+      ['隐藏浮窗', 'Hide floating window'],
+      ['清空临时会话', 'Clear temporary session'],
+      ['拖拽缩放', 'Drag to resize'],
+      ['侧边临时会话', 'Side temporary session'],
+      ['唤起浮窗', 'Open floating window'],
+      ['[进程已退出', '[Process exited'],
+      ['，回车或点「重启」开启新会话]', '. Press Enter or select Restart to start a new session]'],
+      ['[未连接：命令未发送]', '[Not connected: command was not sent]'],
+      ['，目录: ', ', directory: '],
+      [' 可点右上「重启」重试，或重启桌面端后重试。', '. Select Restart at the upper right, or restart the desktop app.'],
+      ['探测 fetch 失败: ', 'Probe fetch failed: '],
+      ['探测 fetch: HTTP ', 'Probe fetch: HTTP '],
+      ['重启', 'Restart'],
+      ['http://127.0.0.1:3000 或项目 HTML 文件', 'http://127.0.0.1:3000 or a project HTML file'],
+      ['共 ', 'Total '],
+      [' 次变更 · ', ' changes · '],
+      [' 次变更', ' changes'],
+      ['端口', 'Port'],
+      ['将于 ', 'Scheduled for '],
+      [' 执行（闲时半价）', ' (half-price off-peak execution)'],
+      [' 时', ':00'],
+      ['输出', 'Output'],
+      [' · 剩 ', ' · remaining '],
+      ['插件管理桥不可用', 'Plugin management bridge unavailable'],
+      ['读取桌宠状态失败: ', 'Could not read desktop pet status: '],
+      ['已启用，重启应用后生效', 'Enabled. Restart the app to apply.'],
+      ['已停用，重启应用后生效', 'Disabled. Restart the app to apply.'],
+      ['留空保存 = 保持现状', 'Save blank to keep the current value'],
+      ['恢复', 'Restore'],
+      ['设', 'S'],
+      ['从这条消息之前分叉出新会话，并以编辑后的内容重新发送；原会话保留不动。', 'Fork a new session before this message and resend the edited content. The original session is preserved.'],
+      ['首条消息不支持回退（前面没有完整回合），请新建会话后重新发送。', 'The first message cannot be rewound because no complete turn precedes it. Start a new session and resend it.'],
+      ['新会话输入框未能就绪，编辑后的内容已复制到剪贴板，请粘贴发送。', 'The new session composer was not ready. The edited content was copied to the clipboard; paste it to send.'],
+      ['开启后隐藏大量工具调用、工具结果与思考过程，只显示每一轮的最终总结输出。', 'Hide tool calls, tool results, and reasoning while keeping the final summary of each turn.'],
+      ['在模型请求前按真实 Token 压力压缩；溢出恢复会先复检实测上下文，防供应商误报误压；瞬态 400 自动重试一次。', 'Compact before model requests based on measured token pressure. Overflow recovery verifies the context first, and transient 400 errors retry once.'],
+      ['关闭后不执行请求前压缩或溢出恢复；手动压缩仍可用。', 'Disable pre-request compaction and overflow recovery. Manual compaction remains available.'],
+      ['收到 CONTEXT_WINDOW_EXCEEDED 且实测 tokens 接近上下文窗口时才压缩并重试；远低于窗口的误报会原样透传 400。', 'Compact and retry only when measured tokens are close to the context window. False overflow reports pass through unchanged.'],
+      ['非溢出的 400（如免费服务商偶发）且本会话此前已有成功回答时，自动原样重试一次，免去「无故 400、继续说一句才好」；彻底失败才提示。', 'Retry a non-overflow 400 once when this session already has a successful response. Report it only after the retry fails.'],
+      ['JSON 数组；每项至少包含 provider 和 model，可覆盖 enabled、thresholdRatio、retainRatio、recoverOnOverflow、maxOverflowRetries。', 'JSON array. Each item needs provider and model and may override enabled, thresholdRatio, retainRatio, recoverOnOverflow, and maxOverflowRetries.'],
+      ['技能按目录扫描：~/.dsh/skills 与 ~/.agents/skills 下的 <名称>/SKILL.md 或平铺 <名称>.md。项目级技能在 <项目>/.dsh/skills。修改即时生效（文件监听）。', 'Skills are scanned by directory: <name>/SKILL.md or <name>.md under ~/.dsh/skills and ~/.agents/skills. Project skills live in <project>/.dsh/skills. Changes are watched live.'],
+      ['MCP 服务通过 profile 的 cordis.patch.yml 中 @deepseek-ai/dsh-mcp-client 行配置。保存后需重启 Web 服务生效。', 'MCP servers are configured by the @deepseek-ai/dsh-mcp-client row in the profile cordis.patch.yml. Restart the web service after saving.'],
+      ['发现本机 Claude Code（~/.claude.json）与 Codex（~/.codex/config.toml）中的 MCP 服务器如下，勾选后导入（同名覆盖现有行）：', 'The following MCP servers were found in Claude Code (~/.claude.json) and Codex (~/.codex/config.toml). Select entries to import; matching names are replaced:'],
+      ['未在本机找到 Claude Code / Codex 的 MCP 配置（~/.claude.json、~/.codex/config.toml）。', 'No Claude Code or Codex MCP configuration was found (~/.claude.json or ~/.codex/config.toml).'],
+      ['还没有 MCP 服务。点击「新增服务」添加。', 'No MCP servers yet. Select Add server to create one.'],
+      ['已保存。重启 Web 服务后生效。', 'Saved. Restart the web service to apply.'],
+      ['参数不是合法的 JSON 数组，已按空格拆分', 'Arguments are not a valid JSON array and were split on spaces.'],
+      ['当前回合仍在进行，等它结束后再回退。', 'The current turn is still running. Wait for it to finish before rewinding.'],
+      ['当前没有可安全压缩的旧历史。', 'There is no older history that can be compacted safely.'],
+      ['模型策略必须是 JSON 数组', 'Model policies must be a JSON array.'],
+      ['为防止循环，只允许 0 或 1。', 'Only 0 or 1 is allowed to prevent retry loops.'],
+      ['必须低于触发阈值。', 'Must be lower than the trigger threshold.'],
+      ['此功能需要 Deepseek Harness EAC 桌面端运行', 'This feature requires the Deepseek Harness EAC desktop app.'],
+      ['插件包不会被卸载', 'Plugin packages are not uninstalled.'],
+      ['修改会立即生效', 'Changes apply immediately.'],
+      ['需要重启 Web 服务后生效', 'Restart the web service to apply.'],
+      ['弹出到独立窗口（分屏）', 'Open in a separate window (split view)'],
+      ['弹出到独立窗口', 'Open in a separate window'],
+      ['立即压缩当前对话', 'Compact current session now'],
+      ['正在压缩…', 'Compacting...'],
+      ['压缩已完成并持久化。', 'Compaction completed and saved.'],
+      ['请先打开一个对话。', 'Open a session first.'],
+      ['上下文自动压缩', 'Automatic context compaction'],
+      ['启用自动压缩', 'Enable automatic compaction'],
+      ['触发阈值', 'Trigger threshold'],
+      ['保留近期上下文', 'Keep recent context'],
+      ['溢出自动恢复', 'Automatic overflow recovery'],
+      ['溢出重试次数', 'Overflow retry count'],
+      ['瞬态错误自动重试', 'Retry transient errors'],
+      ['保存模型策略', 'Save model policies'],
+      ['专属策略', 'specific policy'],
+      ['当前 preset 未启用', 'Current preset is disabled'],
+      ['未选择会话', 'No session selected'],
+      ['Host 不可用', 'Host unavailable'],
+      ['隐藏对话输出', 'Hide conversation output'],
+      ['显示全部', 'Show all'],
+      ['已隐藏', 'Hidden'],
+      ['编辑并回退', 'Edit and rewind'],
+      ['回退并重发', 'Rewind and resend'],
+      ['正在分叉会话…', 'Forking session...'],
+      ['回退失败', 'Rewind failed'],
+      ['已回退并重新发送', 'Rewound and resent'],
+      ['将随消息重新附加', 'Will reattach with the message: '],
+      ['张图片', ' image(s)'],
+      ['Skills 与 MCP', 'Skills & MCP'],
+      ['MCP 服务', 'MCP servers'],
+      ['新增服务', 'Add server'],
+      ['服务名（英文/数字/下划线/中划线）', 'Server name (letters, digits, underscores, or hyphens)'],
+      ['参数（JSON 数组或空格分隔）', 'Arguments (JSON array or space-separated)'],
+      ['环境变量（每行 KEY=VALUE）', 'Environment variables (one KEY=VALUE per line)'],
+      ['请求头（每行 KEY: VALUE）', 'Headers (one KEY: VALUE per line)'],
+      ['从 Claude / Codex 导入', 'Import from Claude / Codex'],
+      ['导入选中项', 'Import selected'],
+      ['立即重启生效', 'Restart now'],
+      ['重启中…', 'Restarting...'],
+      ['加载中…', 'Loading...'],
+      ['保存中…', 'Saving...'],
+      ['已保存', 'Saved'],
+      ['保存失败', 'Save failed'],
+      ['打开目录', 'Open folder'],
+      ['刷新', 'Refresh'],
+      ['启动命令', 'Command'],
+      ['同名将覆盖', 'Matching names will be replaced'],
+      ['取消全选', 'Clear selection'],
+      ['全选', 'Select all'],
+      ['默认停用', 'Disabled by default'],
+      ['桌宠设置', 'Desktop pet settings'],
+      ['点击召唤桌宠', 'Click to summon desktop pet'],
+      ['召唤桌宠', 'Summon desktop pet'],
+      ['关闭桌宠', 'Close desktop pet'],
+      ['桌宠', 'Desktop pet'],
+      ['互动（点击回应 / 随机动作）', 'Interactions (click responses / random actions)'],
+      ['自动挂边隐藏（空闲折叠）', 'Auto-hide at edge when idle'],
+      ['插件管理', 'Plugin management'],
+      ['插件市场', 'Plugin marketplace'],
+      ['增强功能', 'Enhancements'],
+      ['创建配置快照', 'Create configuration snapshot'],
+      ['恢复最后快照', 'Restore latest snapshot'],
+      ['安全模式', 'Safe mode'],
+      ['解除隔离', 'Unquarantine'],
+      ['隔离', 'Quarantine'],
+      ['最近错误', 'Latest error'],
+      ['安装失败', 'Installation failed'],
+      ['更新失败', 'Update failed'],
+      ['操作失败', 'Operation failed'],
+      ['未知错误', 'Unknown error'],
+      ['连接手机', 'Connect phone'],
+      ['语音识别', 'Speech recognition'],
+      ['提示词优化', 'Prompt optimization'],
+      ['自动优化提示词', 'Optimize prompt'],
+      ['停止优化', 'Stop optimization'],
+      ['重新生成', 'Regenerate'],
+      ['应用结果', 'Apply result'],
+      ['文件更改', 'File changes'],
+      ['查看文件', 'View file'],
+      ['恢复文件', 'Restore file'],
+      ['删除对话', 'Delete session'],
+      ['归档对话', 'Archive session'],
+      ['已归档', 'Archived'],
+      ['会话管理', 'Session management'],
+      ['峰谷价格', 'Peak/off-peak pricing'],
+      ['继续发送', 'Send anyway'],
+      ['定时发送', 'Schedule send'],
+      ['取消定时', 'Cancel schedule'],
+      ['启用', 'Enable'],
+      ['已启用', 'Enabled'],
+      ['停用', 'Disable'],
+      ['已停用', 'Disabled'],
+      ['关闭', 'Close'],
+      ['打开', 'Open'],
+      ['重试', 'Retry'],
+      ['取消', 'Cancel'],
+      ['确定', 'Confirm'],
+      ['删除', 'Delete'],
+      ['移除', 'Remove'],
+      ['编辑', 'Edit'],
+      ['保存', 'Save'],
+      ['新增', 'Add'],
+      ['导入', 'Import'],
+      ['导出', 'Export'],
+      ['名称', 'Name'],
+      ['类型', 'Type'],
+      ['详情', 'Details'],
+      ['状态', 'Status'],
+      ['来源', 'Source'],
+      ['操作', 'Actions'],
+      ['大小', 'Size'],
+      ['位置', 'Position'],
+      ['设置', 'Settings'],
+      ['插件', 'Plugins'],
+      ['外观', 'Appearance'],
+      ['推荐', 'Recommended'],
+      ['可选', 'Optional'],
+      ['用户', 'User'],
+      ['内置', 'Built-in'],
+      ['读取中', 'Loading'],
+      ['失败', 'Failed'],
+      ['成功', 'Succeeded'],
+      ['用 ', 'Use '],
+      [' 字', ' characters'],
+      [' 轮', ' rounds'],
+      ['无', 'None'],
+      ['个', ''],
+    ].sort((left, right) => right[0].length - left[0].length))
+
+    function hasChinese(value) {
+      return /[\u3400-\u9fff]/u.test(value)
+    }
+
+    function translateText(value) {
+      if (!hasChinese(value)) return value
+      let translated = value
+      for (const [source, target] of ENGLISH_PHRASES) translated = translated.split(source).join(target)
+      translated = translated.replace(/ {2,}/g, ' ')
+      // Never expose a half-translated sentence. Older plugins are added to the
+      // compatibility dictionary as complete UI phrases; unknown text is safer
+      // left intact until its owning plugin supplies a reviewed translation.
+      return hasChinese(translated) ? value : translated
+    }
+
+    function isExcluded(node) {
+      const parent = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement
+      if (!parent || typeof parent.closest !== 'function') return false
+      return parent.closest(EXCLUDED_SELECTOR) !== null
+    }
+
+    function translateNode(node) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        if (isExcluded(node)) return
+        const value = node.nodeValue || ''
+        if (node[ORIGINAL_TEXT] !== undefined && value !== node[TRANSLATED_TEXT]) {
+          if (hasChinese(value)) node[ORIGINAL_TEXT] = value
+          else {
+            delete node[ORIGINAL_TEXT]
+            delete node[TRANSLATED_TEXT]
+            return
+          }
+        } else if (node[ORIGINAL_TEXT] === undefined && hasChinese(value)) {
+          node[ORIGINAL_TEXT] = value
+        }
+        if (node[ORIGINAL_TEXT] === undefined) return
+        const translated = translateText(node[ORIGINAL_TEXT])
+        node[TRANSLATED_TEXT] = translated
+        if (value !== translated) node.nodeValue = translated
+        return
+      }
+      if (node.nodeType !== Node.ELEMENT_NODE || isExcluded(node)) return
+      const original = node[ORIGINAL_ATTRIBUTES] || (node[ORIGINAL_ATTRIBUTES] = Object.create(null))
+      const rendered = node[TRANSLATED_ATTRIBUTES] || (node[TRANSLATED_ATTRIBUTES] = Object.create(null))
+      for (const name of TRANSLATABLE_ATTRIBUTES) {
+        const value = node.getAttribute(name)
+        if (original[name] !== undefined && value !== rendered[name]) {
+          if (value !== null && hasChinese(value)) original[name] = value
+          else {
+            delete original[name]
+            delete rendered[name]
+            continue
+          }
+        } else if (original[name] === undefined && value !== null && hasChinese(value)) {
+          original[name] = value
+        }
+        if (original[name] === undefined) continue
+        const translated = translateText(original[name])
+        rendered[name] = translated
+        if (value !== translated) node.setAttribute(name, translated)
+      }
+      for (const child of node.childNodes) translateNode(child)
+    }
+
+    function restoreNode(node) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        if (node[ORIGINAL_TEXT] !== undefined && node.nodeValue === node[TRANSLATED_TEXT]) {
+          node.nodeValue = node[ORIGINAL_TEXT]
+        }
+        delete node[ORIGINAL_TEXT]
+        delete node[TRANSLATED_TEXT]
+        return
+      }
+      if (node.nodeType !== Node.ELEMENT_NODE) return
+      const original = node[ORIGINAL_ATTRIBUTES]
+      const rendered = node[TRANSLATED_ATTRIBUTES]
+      if (original) for (const name of TRANSLATABLE_ATTRIBUTES) {
+        if (original[name] !== undefined && node.getAttribute(name) === rendered?.[name]) {
+          node.setAttribute(name, original[name])
+        }
+      }
+      delete node[ORIGINAL_ATTRIBUTES]
+      delete node[TRANSLATED_ATTRIBUTES]
+      for (const child of node.childNodes) restoreNode(child)
+    }
+
+    function createCompatibilityRuntime(root, locale) {
+      let english = locale.getLocale().active === 'en'
+      let queued = false
+      const sync = () => {
+        queued = false
+        if (english) translateNode(root)
+        else restoreNode(root)
+      }
+      const queueSync = () => {
+        if (queued) return
+        queued = true
+        queueMicrotask(sync)
+      }
+      const observer = new MutationObserver(queueSync)
+      observer.observe(root, { attributes: true, attributeFilter: TRANSLATABLE_ATTRIBUTES, characterData: true, childList: true, subtree: true })
+      const unsubscribe = locale.subscribe(() => {
+        english = locale.getLocale().active === 'en'
+        queueSync()
+      })
+      sync()
+      return () => {
+        observer.disconnect()
+        unsubscribe()
+        restoreNode(root)
+      }
+    }
+
+    const inject = ['locale']
+    function apply(ctx) {
+      if (typeof document === 'undefined' || !document.body) return
+      ctx.effect(() => createCompatibilityRuntime(document.body, ctx.locale), 'eac locale compatibility')
+    }
+
+    exports.apply = apply
+    exports.inject = inject
+    exports.__internals = { hasChinese, translateText, translateNode, restoreNode, createCompatibilityRuntime }
+    return module.exports
+  },
+})

--- a/dsh-desktop/assets/plugins/dsh-eac-locale-compat/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-eac-locale-compat/lib/index.js
@@ -1,0 +1,6 @@
+export const name = 'eac-locale-compat'
+export const inject = []
+
+export function apply() {
+  // Client-only compatibility plugin.
+}

--- a/dsh-desktop/assets/plugins/dsh-eac-locale-compat/package.json
+++ b/dsh-desktop/assets/plugins/dsh-eac-locale-compat/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dsh-eac-locale-compat",
+  "description": "English compatibility layer for bundled DSH plugins that do not expose locale dictionaries.",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "client": {
+      "platform": "web",
+      "inject": [
+        "@deepseek-ai/dsh-client-runtime",
+        "@deepseek-ai/dsh-client-locale"
+      ]
+    }
+  },
+  "license": "MIT"
+}

--- a/dsh-desktop/assets/plugins/dsh-file-drop-eac/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-file-drop-eac/lib/client.js
@@ -22,6 +22,10 @@
   var TEXT_MAX_BYTES = 256 * 1024;
   var SNIFF_BYTES = 8192;
 
+  function usesEnglishUi() {
+    return typeof document !== 'undefined' && String(document.documentElement.lang || '').toLowerCase().indexOf('en') === 0;
+  }
+
   var TEXT_EXT = new Set([
     '.txt', '.md', '.markdown', '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx',
     '.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.cfg', '.conf',
@@ -77,7 +81,7 @@
     }
     return {
       kind: 'text',
-      text: '<!-- 拖入文件：' + name + ' -->\n' + text,
+      text: (usesEnglishUi() ? '<!-- Dropped file: ' : '<!-- 拖入文件：') + name + ' -->\n' + text,
     };
   }
 
@@ -85,19 +89,33 @@
   function buildPathHint(_a) {
     var name = _a.name, path = _a.path, size = _a.size;
     var label = name || '（未命名文件）';
-    var sizeText = size != null ? '，大小 ' + formatSize(size) : '';
+    var english = usesEnglishUi();
+    if (english && !name) label = '(unnamed file)';
+    var sizeText = size != null ? (english ? ', size ' : '，大小 ') + formatSize(size) : '';
     if (path) {
-      return '[拖入文件：' + label + sizeText + ']\n完整路径：' + path + '\n请读取该文件内容后继续处理。';
+      return english
+        ? '[Dropped file: ' + label + sizeText + ']\nFull path: ' + path + '\nRead this file before continuing.'
+        : '[拖入文件：' + label + sizeText + ']\n完整路径：' + path + '\n请读取该文件内容后继续处理。';
     }
-    return '[拖入文件：' + label + sizeText + ']\n（无法获取完整路径，请通过文件标签页或项目目录读取该文件。）';
+    return english
+      ? '[Dropped file: ' + label + sizeText + ']\n(The full path is unavailable. Read it from the Files tab or project directory.)'
+      : '[拖入文件：' + label + sizeText + ']\n（无法获取完整路径，请通过文件标签页或项目目录读取该文件。）';
   }
 
   /** 文件夹降级提示：浏览器/Electron 拿不到磁盘绝对路径，给出替代方案。 */
   function buildFolderHint(folders) {
+    var english = usesEnglishUi();
     var list = (folders || []).map(function (f) {
-      var v = f && f.virtualPath && f.virtualPath !== '/' ? '（' + f.virtualPath + '）' : '';
-      return '  · ' + (f && f.name || '（未命名目录）') + v;
+      var v = f && f.virtualPath && f.virtualPath !== '/' ? (english ? ' (' + f.virtualPath + ')' : '（' + f.virtualPath + '）') : '';
+      return '  · ' + (f && f.name || (english ? '(unnamed directory)' : '（未命名目录）')) + v;
     }).join('\n');
+    if (english) return [
+      '[Dropped folders: ' + (folders ? folders.length : 0) + ']', list, '',
+      'Browser security prevents this page from reading absolute folder paths or passing an entire directory to the model.',
+      'Use either option:',
+      '  · Open the directory from the Files / Project directory tab so the agent can read its files;',
+      '  · Drop the relevant files into the composer individually.', ''
+    ].join('\n');
     return [
       '[拖入文件夹：' + (folders ? folders.length : 0) + ' 个]',
       list,

--- a/dsh-desktop/assets/plugins/dsh-image-paste/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-image-paste/lib/client.js
@@ -17,6 +17,10 @@
   // ───────────────────────── 纯逻辑（可测） ─────────────────────────
   var MAX_IMAGE_BYTES = 15 * 1024 * 1024;
 
+  function usesEnglishUi() {
+    return typeof document !== 'undefined' && String(document.documentElement.lang || '').toLowerCase().indexOf('en') === 0;
+  }
+
   var IMAGE_MIME_EXT = {
     'image/png': '.png',
     'image/jpeg': '.jpg',
@@ -60,7 +64,7 @@
   /** 文件名清洗：去路径分隔符与保留字，限长；空名回退默认。 */
   function sanitizeName(name) {
     var s = String(name || '').replace(/[\\/:*?"<>|\u0000-\u001f]/g, '_').trim().slice(0, 40);
-    return s || '粘贴图片';
+    return s || (usesEnglishUi() ? 'pasted-image' : '粘贴图片');
   }
 
   /**
@@ -69,15 +73,16 @@
    */
   function buildPasteHint(_a) {
     var images = _a.images;
-    var lines = ['[粘贴图片]'];
+    var english = usesEnglishUi();
+    var lines = [english ? '[Pasted images]' : '[粘贴图片]'];
     for (var i = 0; i < images.length; i++) {
       var im = images[i] || {};
       var name = sanitizeName(im.name);
       var path = im.path || '';
-      var sizeText = im.size != null ? '，大小 ' + formatSize(im.size) : '';
-      lines.push('- ' + name + sizeText + (path ? '\n  完整路径：' + path : ''));
+      var sizeText = im.size != null ? (english ? ', size ' : '，大小 ') + formatSize(im.size) : '';
+      lines.push('- ' + name + sizeText + (path ? (english ? '\n  Full path: ' : '\n  完整路径：') + path : ''));
     }
-    lines.push('请用 inspect_image 工具逐一分析这些图片后继续。');
+    lines.push(english ? 'Use inspect_image to analyze each image before continuing.' : '请用 inspect_image 工具逐一分析这些图片后继续。');
     return lines.join('\n');
   }
 
@@ -124,9 +129,10 @@
       }
       var reader = new FileReader();
       reader.onload = function () {
-        b.save({ dataUrl: String(reader.result || ''), name: file.name || '粘贴图片' })
+        var fallbackName = usesEnglishUi() ? 'pasted-image' : '粘贴图片';
+        b.save({ dataUrl: String(reader.result || ''), name: file.name || fallbackName })
           .then(function (res) {
-            if (res && res.ok) resolve({ name: file.name || '粘贴图片', path: res.path, size: res.size != null ? res.size : file.size });
+            if (res && res.ok) resolve({ name: file.name || fallbackName, path: res.path, size: res.size != null ? res.size : file.size });
             else reject(new Error((res && res.error) || 'save failed'));
           })
           .catch(reject);

--- a/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-manager/lib/client.js
@@ -293,6 +293,13 @@ window.__ModuleLoader__.load({
 			/** 行显示名：名称（可读 id）+ 包名（moduleName/package）；匿名 id 退化为只显包名。 */
 			const rowName = (row) => (/^[0-9a-f]{8}$/i.test(row.id) ? null : row.id);
 			const rowPkg = (row) => row.title;
+			const usesEnglishUi = () => String(document.documentElement.lang || "").toLowerCase().startsWith("en");
+			const rowDescription = (row) => {
+				const description = row.description || L.descFallback;
+				return usesEnglishUi() && /[\u3400-\u9fff]/u.test(description)
+					? "Plugin package: " + rowPkg(row)
+					: description;
+			};
 
 			/** 简洁视图卡片（官方清单页同款：标题 + 状态圆点 + 开关）。 */
 			const renderCompactCard = (row) => {
@@ -307,7 +314,7 @@ window.__ModuleLoader__.load({
 				const short = rowName(row) ? pkgShort(rowPkg(row)) : null;
 				return jsxs("div", {
 					key: row.id,
-					title: row.description || L.descFallback,
+					title: rowDescription(row),
 					style: {
 						display: "flex",
 						alignItems: "center",
@@ -359,7 +366,7 @@ window.__ModuleLoader__.load({
 								phaseBadge(row),
 								rowDirty(row) ? badge(L.badgePending, "var(--dsw-alias-state-info-primary, #5b9bd5)") : null
 							] }),
-							jsx("span", { style: { fontSize: 12, opacity: 0.65, lineHeight: 1.5 }, children: row.description || L.descFallback })
+							jsx("span", { style: { fontSize: 12, opacity: 0.65, lineHeight: 1.5 }, children: rowDescription(row) })
 						]
 					}),
 					row.removed
@@ -397,7 +404,9 @@ window.__ModuleLoader__.load({
 						jsxs("div", { style: { fontWeight: 600, fontSize: 13, margin: "14px 0 2px" }, children: [
 							jsx("span", { children: title }),
 							jsx("span", { style: { fontSize: 12, opacity: 0.55, marginLeft: 8 }, children: note + " · " + items.length }),
-							jsx("span", { style: { fontSize: 12, opacity: 0.4, marginLeft: 8 }, children: items.filter((r) => rowValue(r)).length + " 启用 / " + items.filter((r) => !rowValue(r)).length + " 关闭" })
+							jsx("span", { style: { fontSize: 12, opacity: 0.4, marginLeft: 8 }, children: usesEnglishUi()
+								? items.filter((r) => rowValue(r)).length + " enabled / " + items.filter((r) => !rowValue(r)).length + " disabled"
+								: items.filter((r) => rowValue(r)).length + " 启用 / " + items.filter((r) => !rowValue(r)).length + " 关闭" })
 						] }),
 						compact
 							? jsx("div", { className: "dshpm-cards", style: { display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10, marginTop: 6 }, children: items.map(renderCompactCard) })

--- a/dsh-desktop/assets/plugins/dsh-side-session/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-side-session/lib/client.js
@@ -195,34 +195,41 @@ window.__ModuleLoader__.load({
     // ------------------------------------------------------------------
     // 系统提示 + 消息组装
     // ------------------------------------------------------------------
+    function usesEnglishUi() {
+      return typeof document !== "undefined" && String(document.documentElement.lang || "").toLowerCase().startsWith("en");
+    }
+
     function buildSystemPrompt(ctx) {
       ctx = ctx || { title: "", files: [], transcript: [] };
       var lines = [];
-      lines.push("你是一个「DSH 临时会话」辅助助手。当前用户正在主会话中工作，你基于下方自动导入的「当前会话上下文」回答用户的临时追问。");
+      var english = usesEnglishUi();
+      lines.push(english
+        ? "You are a DSH temporary-session assistant. Answer the user's temporary questions from the imported current-session context below."
+        : "你是一个「DSH 临时会话」辅助助手。当前用户正在主会话中工作，你基于下方自动导入的「当前会话上下文」回答用户的临时追问。");
       lines.push("");
-      lines.push("硬性规则：");
-      lines.push("1. 你只做解释、分析、答疑，绝不修改任何文件，不要输出任何写文件/编辑/执行命令的操作。");
-      lines.push("2. 回答紧扣上下文；上下文不足以回答时，明确说明「根据当前会话上下文无法确认」。");
-      lines.push("3. 保持简洁，用中文。");
+      lines.push(english ? "Rules:" : "硬性规则：");
+      lines.push(english ? "1. Explain, analyze, and answer questions only. Never modify files or propose write/edit/command operations." : "1. 你只做解释、分析、答疑，绝不修改任何文件，不要输出任何写文件/编辑/执行命令的操作。");
+      lines.push(english ? "2. Stay grounded in the context. If it is insufficient, say that the current session context does not establish the answer." : "2. 回答紧扣上下文；上下文不足以回答时，明确说明「根据当前会话上下文无法确认」。");
+      lines.push(english ? "3. Be concise and answer in English." : "3. 保持简洁，用中文。");
       lines.push("");
-      lines.push("==== 当前会话上下文 ====");
-      lines.push("会话标题：" + (ctx.title || "(未知)"));
+      lines.push(english ? "==== Current session context ====" : "==== 当前会话上下文 ====");
+      lines.push((english ? "Session title: " : "会话标题：") + (ctx.title || (english ? "(unknown)" : "(未知)")));
       lines.push("");
-      lines.push("--- 对话记录（最近部分）---");
+      lines.push(english ? "--- Recent conversation ---" : "--- 对话记录（最近部分）---");
       var trans = ctx.transcript || [];
-      if (trans.length === 0) lines.push("(无)");
+      if (trans.length === 0) lines.push(english ? "(none)" : "(无)");
       else {
         for (var i = 0; i < trans.length; i++) {
           var m = trans[i];
-          var who = m.role === "assistant" ? "助手" : "用户";
+          var who = m.role === "assistant" ? (english ? "assistant" : "助手") : (english ? "user" : "用户");
           var text = (m.text || "").slice(0, 4000);
           lines.push("[" + who + "] " + text);
         }
       }
       lines.push("");
-      lines.push("--- 本会话涉及的文件 ---");
+      lines.push(english ? "--- Files involved in this session ---" : "--- 本会话涉及的文件 ---");
       var files = ctx.files || [];
-      if (files.length === 0) lines.push("(无)");
+      if (files.length === 0) lines.push(english ? "(none)" : "(无)");
       else {
         var shown = 0;
         for (var j = 0; j < files.length; j++) {
@@ -233,7 +240,7 @@ window.__ModuleLoader__.load({
           if (content) lines.push(content);
           shown++;
           if (shown >= 40) {
-            lines.push("…(文件过多，已截断展示)");
+            lines.push(english ? "...(file list truncated)" : "…(文件过多，已截断展示)");
             break;
           }
         }
@@ -315,7 +322,7 @@ window.__ModuleLoader__.load({
       if (mode === "2" && !pluginSettings.apiKey) {
         setState({
           streaming: false,
-          error: "插件 API Key 为空：请在「设置 → 临时会话」填写 API Key，或切换到其他模式。",
+          error: usesEnglishUi() ? "The plugin API key is empty. Enter one under Settings > Temporary session, or switch modes." : "插件 API Key 为空：请在「设置 → 临时会话」填写 API Key，或切换到其他模式。",
         });
         return;
       }

--- a/dsh-desktop/assets/plugins/dsh-webui-prompt-optimizer/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-webui-prompt-optimizer/lib/client.js
@@ -350,7 +350,10 @@ window.__ModuleLoader__.load({
 								inputActions.setDraft(`/goal ${objective}`);
 								finish("done", "已完成 · 已生成 /goal");
 							} else if (verifyWithBrowser) {
-								inputActions.setDraft(`${objective}\n\n请用 AI 浏览器实际验证上面这条提示词能否正常工作，并简要报告验证结论。`);
+								const verification = String(document.documentElement.lang || "").toLowerCase().startsWith("en")
+									? "Use the AI browser to verify that the prompt above works as intended, then report the result briefly."
+									: "请用 AI 浏览器实际验证上面这条提示词能否正常工作，并简要报告验证结论。";
+								inputActions.setDraft(`${objective}\n\n${verification}`);
 								finish("done", "已完成 · 已附加浏览器验证");
 							} else finish("done", formatMs(payload.elapsedMs));
 							return;

--- a/dsh-desktop/assets/recovery-center.html
+++ b/dsh-desktop/assets/recovery-center.html
@@ -88,8 +88,38 @@
 <script>
 'use strict';
 const $ = (id) => document.getElementById(id);
+const hasChineseLanguage = () => {
+  const languages = Array.from((navigator && navigator.languages) || []);
+  if (navigator && navigator.language) languages.push(navigator.language);
+  return languages.some((tag) => String(tag).toLowerCase().split('-')[0] === 'zh');
+};
+const english = !hasChineseLanguage();
+document.documentElement.lang = english ? 'en' : 'zh-CN';
+const safeError = (value) => {
+  const text = String(value == null ? '' : value);
+  return english && /[\u3400-\u9fff]/.test(text) ? 'See the desktop log for details.' : text;
+};
 const esc = (s) => String(s == null ? '' : s)
   .replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+if (english) {
+  document.title = 'Recovery Center - Deepseek Harness EAC';
+  document.querySelector('header h1').textContent = 'Recovery Center';
+  $('meta').textContent = 'Loading...';
+  $('banner').textContent = 'This page runs independently from the Web UI. Disable, remove, restore, or quarantine a faulty plugin here, then retry startup.';
+  $('btn-retry').textContent = 'Retry web service startup';
+  $('btn-safemode').textContent = 'Restart in safe mode';
+  $('btn-safemode').title = 'Restart the app with all non-core external plugins disabled';
+  $('btn-snapshot').textContent = 'Create configuration snapshot';
+  $('btn-rollback').textContent = 'Restore latest good snapshot';
+  $('btn-rollback').title = 'Restore the latest good snapshot and restart the web service';
+  $('btn-export').textContent = 'Export diagnostics';
+  document.querySelectorAll('section h2')[0].textContent = 'Installed plugins';
+  document.querySelectorAll('section h2')[1].textContent = 'Desktop log tail (desktop.log)';
+  const headers = ['Plugin', 'Type', 'Source', 'Status', 'Latest error', 'Actions'];
+  document.querySelectorAll('thead th').forEach((node, index) => { node.textContent = headers[index]; });
+  $('rows').innerHTML = '<tr><td colspan="6" class="empty">Loading...</td></tr>';
+}
 
 async function act(action, value) {
   try { return await window.rc.action(action, value); }
@@ -104,38 +134,38 @@ function banner(text, kind) {
 
 async function refresh() {
   const st = await act('status');
-  if (!st || !st.ok) { banner('状态读取失败：' + (st && st.error), 'err'); return; }
+  if (!st || !st.ok) { banner(english ? 'Could not read status: ' + safeError(st && st.error) : '状态读取失败：' + (st && st.error), 'err'); return; }
   $('meta').textContent = 'v' + st.appVersion + ' · profile: ' + st.profile +
-    ' · 快照 ' + st.snapshots.length + ' · 事故 ' + st.incidents.length;
+    (english ? ' · snapshots ' + st.snapshots.length + ' · incidents ' + st.incidents.length : ' · 快照 ' + st.snapshots.length + ' · 事故 ' + st.incidents.length);
   const tb = $('rows');
   if (!st.plugins.length) {
-    tb.innerHTML = '<tr><td colspan="6" class="empty">注册表为空（尚未登记插件档案）</td></tr>';
+    tb.innerHTML = '<tr><td colspan="6" class="empty">' + (english ? 'The registry is empty. No plugin records exist yet.' : '注册表为空（尚未登记插件档案）') + '</td></tr>';
   } else {
     tb.innerHTML = st.plugins.map((p) => {
       const ops = [];
-      if (p.enabled) ops.push(`<button data-act="disable" data-id="${esc(p.id)}">停用</button>`);
-      else ops.push(`<button data-act="enable" data-id="${esc(p.id)}">启用</button>`);
-      ops.push(`<button data-act="remove" data-id="${esc(p.id)}" class="danger">移除</button>`);
+      if (p.enabled) ops.push(`<button data-act="disable" data-id="${esc(p.id)}">${english ? 'Disable' : '停用'}</button>`);
+      else ops.push(`<button data-act="enable" data-id="${esc(p.id)}">${english ? 'Enable' : '启用'}</button>`);
+      ops.push(`<button data-act="remove" data-id="${esc(p.id)}" class="danger">${english ? 'Remove' : '移除'}</button>`);
       if (p.state === 'failed' || p.state === 'quarantined') {
-        ops.push(`<button data-act="unquarantine" data-id="${esc(p.id)}">解除隔离</button>`);
+        ops.push(`<button data-act="unquarantine" data-id="${esc(p.id)}">${english ? 'Unquarantine' : '解除隔离'}</button>`);
       } else {
-        ops.push(`<button data-act="quarantine" data-id="${esc(p.id)}" class="danger">隔离</button>`);
+        ops.push(`<button data-act="quarantine" data-id="${esc(p.id)}" class="danger">${english ? 'Quarantine' : '隔离'}</button>`);
       }
       const err = p.lastError
-        ? `<span class="err-line" title="${esc(p.lastError)}">${esc(p.lastError)}</span><br><span class="sub">${esc(p.lastErrorAt || '')}</span>`
+        ? `<span class="err-line" title="${esc(safeError(p.lastError))}">${esc(safeError(p.lastError))}</span><br><span class="sub">${esc(p.lastErrorAt || '')}</span>`
         : '—';
       return `<tr>
         <td class="id">${esc(p.id)}${p.version ? '<br><span class="sub">v' + esc(p.version) + '</span>' : ''}</td>
         <td><span class="risk ${esc(p.risk)}">${esc(p.risk)}</span></td>
         <td>${esc(p.source)}</td>
-        <td class="state ${esc(p.state)}">${esc(p.state)}${p.enabled ? '' : '<br>(已停用)'}</td>
+        <td class="state ${esc(p.state)}">${esc(p.state)}${p.enabled ? '' : '<br>' + (english ? '(disabled)' : '(已停用)')}</td>
         <td>${err}</td>
         <td class="btns">${ops.join('')}</td>
       </tr>`;
     }).join('');
   }
   const logs = await act('read-log', 'desktop.log');
-  $('logtail').textContent = logs && logs.ok ? logs.tail : '(日志不可读)';
+  $('logtail').textContent = logs && logs.ok ? logs.tail : (english ? '(log unavailable)' : '(日志不可读)');
 }
 
 $('rows').addEventListener('click', async (ev) => {
@@ -147,36 +177,36 @@ $('rows').addEventListener('click', async (ev) => {
   const r = await act(action, id);
   btn.disabled = false;
   if (r && r.ok) {
-    banner(action + ' 已执行：' + id + (r.restartRequired ? '（重启 Web 服务后生效）' : ''), 'ok');
+    banner(english ? action + ' completed: ' + id + (r.restartRequired ? ' (restart the web service to apply)' : '') : action + ' 已执行：' + id + (r.restartRequired ? '（重启 Web 服务后生效）' : ''), 'ok');
   } else {
-    banner(action + ' 失败：' + ((r && r.error) || '未知错误'), 'err');
+    banner(english ? action + ' failed: ' + safeError((r && r.error) || 'Unknown error') : action + ' 失败：' + ((r && r.error) || '未知错误'), 'err');
   }
   refresh();
 });
 
 $('btn-retry').addEventListener('click', async () => {
-  banner('正在重试启动 Web 服务…');
+  banner(english ? 'Retrying web service startup...' : '正在重试启动 Web 服务…');
   const r = await act('retry-boot');
-  if (r && r.ok) banner('Web 服务已重新拉起。', 'ok');
-  else banner('重试失败：' + ((r && r.error) || '未知错误'), 'err');
+  if (r && r.ok) banner(english ? 'The web service is running again.' : 'Web 服务已重新拉起。', 'ok');
+  else banner(english ? 'Retry failed: ' + safeError((r && r.error) || 'Unknown error') : '重试失败：' + ((r && r.error) || '未知错误'), 'err');
 });
 $('btn-safemode').addEventListener('click', async () => {
   const r = await act('safe-mode');
-  if (!(r && r.ok)) banner('安全模式重启失败：' + ((r && r.error) || ''), 'err');
+  if (!(r && r.ok)) banner(english ? 'Safe-mode restart failed: ' + safeError(r && r.error) : '安全模式重启失败：' + ((r && r.error) || ''), 'err');
 });
 $('btn-snapshot').addEventListener('click', async () => {
   const r = await act('snapshot');
-  banner(r && r.ok ? '快照已创建。' : '快照失败：' + ((r && r.error) || ''), r && r.ok ? 'ok' : 'err');
+  banner(r && r.ok ? (english ? 'Snapshot created.' : '快照已创建。') : (english ? 'Snapshot failed: ' + safeError(r && r.error) : '快照失败：' + ((r && r.error) || '')), r && r.ok ? 'ok' : 'err');
   refresh();
 });
 $('btn-rollback').addEventListener('click', async () => {
   const r = await act('rollback-last-good');
-  if (r && r.ok) banner('已回滚到最后良好快照，可重试启动。', 'ok');
-  else banner('回滚失败：' + ((r && r.error) || '无可回滚快照'), 'err');
+  if (r && r.ok) banner(english ? 'Restored the latest good snapshot. You can retry startup.' : '已回滚到最后良好快照，可重试启动。', 'ok');
+  else banner(english ? 'Restore failed: ' + safeError((r && r.error) || 'No snapshot is available') : '回滚失败：' + ((r && r.error) || '无可回滚快照'), 'err');
 });
 $('btn-export').addEventListener('click', async () => {
   const r = await act('export-logs');
-  banner(r && r.ok ? '诊断包已导出：' + r.zipPath : '导出失败：' + ((r && r.error) || ''), r && r.ok ? 'ok' : 'err');
+  banner(r && r.ok ? (english ? 'Diagnostics exported: ' : '诊断包已导出：') + r.zipPath : (english ? 'Export failed: ' + safeError(r && r.error) : '导出失败：' + ((r && r.error) || '')), r && r.ok ? 'ok' : 'err');
 });
 
 refresh();

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -93,6 +93,9 @@ export const COMPANION_PLUGINS: CompanionPluginDef[] = [
   { id: 'unified-market', name: 'dsh-unified-market', dir: 'dsh-unified-market' },
   { id: 'skin-switch', name: '@deepseek-ai/dsh-skin-switch' },
   { id: 'easy-setup', name: '@deepseek-ai/dsh-easy-setup' },
+  // 旧版/社区客户端插件的英文兼容层：跟随官方 locale 状态翻译固定 UI
+  // 文案，不触碰会话、代码、终端、编辑器或用户输入。作为界面底座始终启用。
+  { id: 'eac-locale-compat', name: 'dsh-eac-locale-compat', dir: 'dsh-eac-locale-compat' },
   // VNext Core Bridge（受信组件，vnext-absorb Phase 2）：把隔离 SDK 插件的
   // 工具/上下文经回环端点桥接进 dsh Agent（DSH_EAC_BRIDGE_URL/TOKEN 由
   // sidecar 在拉起 dsh web 前注入）；必须随包分发并默认启用。

--- a/dsh-desktop/scripts/onboarding.js
+++ b/dsh-desktop/scripts/onboarding.js
@@ -20,6 +20,7 @@ const CORE_PLUGIN_IDS = new Set([
   'plugin-manager',
   'plugin-shield',
   'plugin-wizard',
+  'eac-locale-compat',
   // EAC 内置 agent preset 直接引用 dsh-compact/engine；允许移除会让这些
   // preset 在创建会话时因 MODULE_NOT_FOUND 失效。
   'compact',

--- a/dsh-desktop/test/dsh-file-drop-eac-core.test.ts
+++ b/dsh-desktop/test/dsh-file-drop-eac-core.test.ts
@@ -15,14 +15,15 @@ import vm from 'node:vm';
 const BUNDLE = new URL('../assets/plugins/dsh-file-drop-eac/lib/client.js', import.meta.url);
 
 /** 用 stubbed window 载入真实 client bundle，返回暴露的 core。 */
-function loadCore() {
+function loadCore(language = '') {
   const src = readFileSync(BUNDLE, 'utf8');
   const captured = {};
   const win = {
     __ModuleLoader__: { load: (handoff) => { captured.handoff = handoff; } },
   };
+  const document = { documentElement: { lang: language } };
   vm.runInNewContext(src, {
-    window: win, console, setTimeout, clearTimeout,
+    window: win, document, console, setTimeout, clearTimeout,
     FileReader: class {}, DataTransfer: class {}, InputEvent: class {}, Event: class {},
     HTMLTextAreaElement: { prototype: {} },
   });
@@ -33,6 +34,17 @@ function loadCore() {
 }
 
 const core = loadCore();
+
+test('English UI produces English file and folder instructions for the agent', () => {
+  const englishCore = loadCore('en');
+  const pathHint = englishCore.buildPathHint({ name: 'a.zip', path: 'C:\\a.zip', size: 10 });
+  const folderHint = englishCore.buildFolderHint([{ name: 'project', virtualPath: '/project' }]);
+  assert.match(pathHint, /Dropped file/);
+  assert.match(pathHint, /Full path/);
+  assert.doesNotMatch(pathHint, /[\u3400-\u9fff]/u);
+  assert.match(folderHint, /Dropped folders/);
+  assert.doesNotMatch(folderHint, /[\u3400-\u9fff]/u);
+});
 
 const TEXT_SAMPLES = ['a.txt', 'main.js', 'b.md', 'c.json', 'd.yaml', 'e.log', 'f.csv', 'Makefile', 'LICENSE', 'package.json'];
 const IMAGE_SAMPLES = ['a.png', 'b.jpg', 'c.jpeg', 'd.webp', 'e.gif', 'f.bmp', 'g.svg'];

--- a/dsh-desktop/test/eac-locale-compat.test.ts
+++ b/dsh-desktop/test/eac-locale-compat.test.ts
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const source = readFileSync(join(root, 'assets', 'plugins', 'dsh-eac-locale-compat', 'lib', 'client.js'), 'utf8');
+
+function loadBundle() {
+  const window: Record<string, unknown> = {
+    __ModuleLoader__: {
+      load(definition: { factory: () => unknown }) {
+        window.plugin = definition.factory();
+      },
+    },
+  };
+  vm.runInNewContext(source, {
+    window,
+    console,
+    Symbol,
+    Object,
+    Node: { ELEMENT_NODE: 1, TEXT_NODE: 3 },
+  });
+  return (window.plugin as { __internals: Record<string, (...args: unknown[]) => unknown> }).__internals;
+}
+
+class FakeElement {
+  nodeType = 1;
+  childNodes: Array<FakeElement | FakeText> = [];
+  parentElement: FakeElement | null = null;
+  attributes = new Map<string, string>();
+  excluded = false;
+
+  append(child: FakeElement | FakeText) {
+    child.parentElement = this;
+    this.childNodes.push(child);
+  }
+
+  closest() { return this.excluded ? this : null; }
+  getAttribute(name: string) { return this.attributes.get(name) ?? null; }
+  setAttribute(name: string, value: string) { this.attributes.set(name, value); }
+}
+
+class FakeText {
+  nodeType = 3;
+  parentElement: FakeElement | null = null;
+  nodeValue: string;
+  constructor(nodeValue: string) { this.nodeValue = nodeValue; }
+}
+
+test('compat translator covers fixed plugin copy and dynamic value fragments', () => {
+  const { translateText, hasChinese } = loadBundle();
+  assert.equal(translateText('编辑并回退'), 'Edit and rewind');
+  assert.equal(translateText('正在下载 42%'), '正在下载 42%', 'shell-owned copy is not part of the plugin dictionary');
+  assert.equal(translateText('将随消息重新附加 3 张图片'), 'Will reattach with the message: 3 image(s)');
+  assert.equal(translateText('正在优化 · 已生成 42 字'), 'Optimizing · generated 42 characters');
+  assert.equal(translateText('用 Ctrl+Shift+P 优化当前草稿'), 'Use Ctrl+Shift+P to optimize the current draft');
+  assert.equal(translateText('3 轮'), '3 rounds');
+  assert.equal(hasChinese('English only'), false);
+  assert.equal(hasChinese('连接手机'), true);
+});
+
+test('compat translator restores original text and attributes when switching back to Chinese', () => {
+  const { translateNode, restoreNode } = loadBundle();
+  const rootNode = new FakeElement();
+  rootNode.attributes.set('title', '弹出到独立窗口（分屏）');
+  const label = new FakeText('编辑并回退');
+  rootNode.append(label);
+
+  translateNode(rootNode);
+  assert.equal(rootNode.getAttribute('title'), 'Open in a separate window (split view)');
+  assert.equal(label.nodeValue, 'Edit and rewind');
+
+  restoreNode(rootNode);
+  assert.equal(rootNode.getAttribute('title'), '弹出到独立窗口（分屏）');
+  assert.equal(label.nodeValue, '编辑并回退');
+});
+
+test('compat translator follows dynamic plugin updates without restoring stale copy', () => {
+  const { translateNode, restoreNode } = loadBundle();
+  const rootNode = new FakeElement();
+  rootNode.attributes.set('title', '编辑并回退');
+  const label = new FakeText('正在优化 · 已生成 1 字');
+  rootNode.append(label);
+
+  translateNode(rootNode);
+  label.nodeValue = '正在优化 · 已生成 2 字';
+  rootNode.attributes.set('title', '弹出到独立窗口');
+  translateNode(rootNode);
+  assert.equal(label.nodeValue, 'Optimizing · generated 2 characters');
+  assert.equal(rootNode.getAttribute('title'), 'Open in a separate window');
+
+  label.nodeValue = 'Already provided in English';
+  rootNode.attributes.set('title', 'Already English');
+  translateNode(rootNode);
+  restoreNode(rootNode);
+  assert.equal(label.nodeValue, 'Already provided in English');
+  assert.equal(rootNode.getAttribute('title'), 'Already English');
+});
+
+test('restoring Chinese clears translation state before later plugin updates', () => {
+  const { translateNode, restoreNode } = loadBundle();
+  const rootNode = new FakeElement();
+  const label = new FakeText('编辑并回退');
+  rootNode.append(label);
+
+  translateNode(rootNode);
+  restoreNode(rootNode);
+  label.nodeValue = '正在加载模型列表…';
+  restoreNode(rootNode);
+  assert.equal(label.nodeValue, '正在加载模型列表…');
+});
+
+test('compat translator leaves conversation, code, terminal, editor, and user-input regions untouched', () => {
+  const { translateNode } = loadBundle();
+  const protectedNode = new FakeElement();
+  protectedNode.excluded = true;
+  const content = new FakeText('删除文件');
+  protectedNode.append(content);
+
+  translateNode(protectedNode);
+  assert.equal(content.nodeValue, '删除文件');
+});
+
+test('compat plugin is registered as a required core plugin', () => {
+  const sync = readFileSync(join(root, 'lib', 'desktop', 'companion-sync.ts'), 'utf8');
+  const onboarding = readFileSync(join(root, 'scripts', 'onboarding.js'), 'utf8');
+  assert.match(sync, /id: 'eac-locale-compat'.*name: 'dsh-eac-locale-compat'/);
+  assert.match(onboarding, /CORE_PLUGIN_IDS[\s\S]*'eac-locale-compat'/);
+});
+
+test('shell-owned HTML includes an English branch for non-Chinese browser languages', () => {
+  const onboarding = readFileSync(join(root, 'assets', 'onboarding.html'), 'utf8');
+  const recovery = readFileSync(join(root, 'assets', 'recovery-center.html'), 'utf8');
+  for (const html of [onboarding, recovery]) {
+    assert.match(html, /navigator\.languages/);
+    assert.match(html, /split\('-'\)\[0\] === 'zh'/);
+    assert.match(html, /document\.documentElement\.lang = english \? 'en' : 'zh-CN'/);
+  }
+  assert.match(onboarding, /Built-in plugin wizard/);
+  assert.match(recovery, /Recovery Center/);
+});
+
+test('non-DOM plugin instructions also follow the active English locale', () => {
+  const sideSession = readFileSync(join(root, 'assets', 'plugins', 'dsh-side-session', 'lib', 'client.js'), 'utf8');
+  const optimizer = readFileSync(join(root, 'assets', 'plugins', 'dsh-webui-prompt-optimizer', 'lib', 'client.js'), 'utf8');
+  assert.match(sideSession, /Be concise and answer in English/);
+  assert.match(sideSession, /document\.documentElement\.lang/);
+  assert.match(optimizer, /Use the AI browser to verify/);
+  assert.match(optimizer, /document\.documentElement\.lang/);
+});

--- a/dsh-desktop/test/image-paste-core.test.ts
+++ b/dsh-desktop/test/image-paste-core.test.ts
@@ -12,14 +12,16 @@ import vm from 'node:vm';
 
 const BUNDLE = new URL('../assets/plugins/dsh-image-paste/lib/client.js', import.meta.url);
 
-function loadCore() {
+function loadCore(language = '') {
   const src = readFileSync(BUNDLE, 'utf8');
   const captured = {};
   const win = {
     __ModuleLoader__: { load: (handoff) => { captured.handoff = handoff; } },
   };
+  const document = { documentElement: { lang: language } };
   vm.runInNewContext(src, {
     window: win,
+    document,
     console,
     Promise,
     FileReader: class {},
@@ -34,6 +36,15 @@ function loadCore() {
 }
 
 const core = loadCore();
+
+test('English UI produces English image instructions for the agent', () => {
+  const englishCore = loadCore('en');
+  const output = englishCore.buildPasteHint({ images: [{ name: 'screen.png', path: 'C:\\screen.png', size: 2048 }] });
+  assert.match(output, /Pasted images/);
+  assert.match(output, /Full path/);
+  assert.match(output, /Use inspect_image/);
+  assert.doesNotMatch(output, /[\u3400-\u9fff]/u);
+});
 
 test('isImageItem accepts image files and rejects text/HTML items', () => {
   assert.equal(core.isImageItem({ kind: 'file', type: 'image/png' }), true);

--- a/dsh-desktop/test/recovery-center.test.ts
+++ b/dsh-desktop/test/recovery-center.test.ts
@@ -25,7 +25,7 @@ test('恢复中心三入口（Tauri 版）：托盘菜单 / 启动失败链 / �
   const mainRs = read('..', 'tauri-shell', 'src', 'main.rs');
   const serverTs = read('..', 'tauri-shell', 'sidecar', 'server.ts');
   // 入口 1：Rust 托盘常驻菜单「恢复中心…」→ open_recovery_center_window。
-  assert.ok(/MenuItem::with_id\(app, "recovery", "恢复中心…"/.test(mainRs), 'tray menu entry missing');
+  assert.ok(/MenuItem::with_id\(app, "recovery", ui_text\("恢复中心…", "Recovery Center\.\.\."\)/.test(mainRs), 'localized tray menu entry missing');
   assert.ok(/"recovery" => \{\s*\n\s*open_recovery_center_window\(app\)/.test(mainRs), 'tray item must open RC window');
   // 入口 3：DSH_DESKTOP_RECOVERY=1 直开恢复中心（Rust 侧）并跳过常规 boot（sidecar 侧）。
   assert.ok(/DSH_DESKTOP_RECOVERY/.test(mainRs), 'env entry missing in main.rs');

--- a/tauri-shell/Cargo.toml
+++ b/tauri-shell/Cargo.toml
@@ -21,6 +21,7 @@ http = "1"
 # 经 hwnd() 直呼 USER32。版本对齐依赖树既有 0.61.x（复用，不新增编译单元）。
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
+  "Win32_Globalization",
   "Win32_UI_WindowsAndMessaging",
   "Win32_System_LibraryLoader",
 ] }

--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -48,6 +48,56 @@ use tokio_tungstenite::tungstenite::Message;
 // 窗口桥注入 = WS 回环客户端（单源）+ 桥胶水（build.rs 拼装 bridge-bundle.js）。
 const BRIDGE_JS: &str = include_str!(concat!(env!("OUT_DIR"), "/bridge-bundle.js"));
 const WS_PORT: u16 = 19873;
+static CHINESE_UI: OnceLock<bool> = OnceLock::new();
+
+fn locale_tag_is_chinese(tag: &str) -> bool {
+    tag.trim()
+        .split(['-', '_'])
+        .next()
+        .is_some_and(|primary| primary.eq_ignore_ascii_case("zh"))
+}
+
+#[cfg(windows)]
+fn detect_chinese_ui_language() -> bool {
+    use windows_sys::Win32::Globalization::GetUserDefaultLocaleName;
+    let mut locale = [0u16; 85];
+    let len = unsafe { GetUserDefaultLocaleName(locale.as_mut_ptr(), locale.len() as i32) };
+    if len <= 1 {
+        return false;
+    }
+    locale_tag_is_chinese(&String::from_utf16_lossy(&locale[..len as usize - 1]))
+}
+
+#[cfg(not(windows))]
+fn detect_chinese_ui_language() -> bool {
+    ["LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE"]
+        .iter()
+        .filter_map(|name| std::env::var(name).ok())
+        .flat_map(|value| value.split(':').map(str::to_owned).collect::<Vec<_>>())
+        .any(|tag| locale_tag_is_chinese(tag.split('.').next().unwrap_or(&tag)))
+}
+
+fn use_chinese_ui() -> bool {
+    *CHINESE_UI.get_or_init(detect_chinese_ui_language)
+}
+
+fn ui_text<'a>(zh: &'a str, en: &'a str) -> &'a str {
+    if use_chinese_ui() { zh } else { en }
+}
+
+#[cfg(test)]
+mod ui_language_tests {
+    use super::locale_tag_is_chinese;
+
+    #[test]
+    fn recognizes_chinese_locale_variants_only() {
+        assert!(locale_tag_is_chinese("zh-CN"));
+        assert!(locale_tag_is_chinese("zh_Hant_TW"));
+        assert!(!locale_tag_is_chinese("en-US"));
+        assert!(!locale_tag_is_chinese("ja-JP"));
+        assert!(!locale_tag_is_chinese(""));
+    }
+}
 
 /// 打包态与开发态（CARGO_MANIFEST_DIR 布局）的资源根。
 /// 实测（R6 Stage 1）：Tauri v2 resources map 目标相对安装根，NSIS 装出
@@ -1062,7 +1112,7 @@ fn open_float_window(app: &tauri::AppHandle, session_id: &str) -> Result<bool, S
         .map_err(|e| e.to_string())?
         .join("float-webview");
     let mut builder = tauri::webview::WebviewWindowBuilder::new(app, &label, tauri::WebviewUrl::External(url))
-        .title("DSH 会话")
+        .title(ui_text("DSH 会话", "DSH Session"))
         .inner_size(900.0, 640.0)
         .min_inner_size(480.0, 360.0)
         .decorations(false)
@@ -1110,7 +1160,7 @@ fn open_recovery_center_window(app: &tauri::AppHandle) -> bool {
         .map(|p| p.join("recovery-center-webview"))
         .unwrap_or_default();
     let builder = tauri::webview::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::External(url))
-        .title("恢复中心")
+        .title(ui_text("恢复中心", "Recovery Center"))
         .inner_size(980.0, 720.0)
         .min_inner_size(760.0, 520.0)
         .data_directory(data_dir)
@@ -1228,50 +1278,60 @@ fn loading_page() -> String {
          color:#dfe6ff;font-family:'Segoe UI','Microsoft YaHei',system-ui,sans-serif\">\
          <div style=\"text-align:center\">\
          <div style=\"font-size:20px;font-weight:600;margin-bottom:14px\">Deepseek Harness EAC</div>\
-         <div style=\"font-size:13px;color:#8b9ac4\">正在启动服务…</div>\
+         <div style=\"font-size:13px;color:#8b9ac4\">{}</div>\
          <div style=\"margin-top:18px;width:34px;height:34px;margin-left:auto;margin-right:auto;\
          border:3px solid rgba(255,255,255,.12);border-top-color:#5b8cff;border-radius:50%;\
          animation:dshspin 1s linear infinite\"></div></div>\
          <style>@keyframes dshspin{{to{{transform:rotate(360deg)}}}}</style>\
          <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{}/ws';{}</script>",
-        WS_PORT, BRIDGE_JS
+        ui_text("正在启动服务…", "Starting services..."), WS_PORT, BRIDGE_JS
     )
 }
 
 fn died_page(log_path: &str, code: &str) -> String {
     let esc = |s: &str| s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;");
     format!(
-        "<!doctype html><meta charset=utf-8><title>服务已停止</title>\
+        "<!doctype html><html lang={0}><meta charset=utf-8><title>{1}</title>\
          <body style=\"margin:0;height:100vh;display:grid;place-items:center;background:#0b1220;\
          color:#dfe6ff;font-family:'Segoe UI','Microsoft YaHei',system-ui,sans-serif\">\
          <div style=\"text-align:center;max-width:560px\">\
-         <div style=\"font-size:20px;font-weight:600;margin-bottom:10px\">DSH 服务已停止</div>\
-         <div style=\"font-size:13px;color:#8b9ac4;margin-bottom:6px\">退出码 {}</div>\
-         <div style=\"font-size:12px;color:#5f6f9c;font-family:Consolas,monospace;margin-bottom:20px\">{}</div>\
+         <div style=\"font-size:20px;font-weight:600;margin-bottom:10px\">{2}</div>\
+         <div style=\"font-size:13px;color:#8b9ac4;margin-bottom:6px\">{3} {4}</div>\
+         <div style=\"font-size:12px;color:#5f6f9c;font-family:Consolas,monospace;margin-bottom:20px\">{5}</div>\
          <div style=\"display:flex;gap:10px;justify-content:center\">\
          <button onclick=\"retry()\" style=\"padding:8px 22px;border:1px solid rgba(255,255,255,.18);\
-         border-radius:9px;background:rgba(91,140,255,.15);color:#dfe6ff;font-size:13px;cursor:pointer\">重新启动</button>\
+         border-radius:9px;background:rgba(91,140,255,.15);color:#dfe6ff;font-size:13px;cursor:pointer\">{6}</button>\
          <button onclick=\"safeMode()\" style=\"padding:8px 22px;border:1px solid rgba(255,200,120,.25);\
-         border-radius:9px;background:rgba(255,180,80,.10);color:#ffd9a3;font-size:13px;cursor:pointer\">安全模式重启</button>\
+         border-radius:9px;background:rgba(255,180,80,.10);color:#ffd9a3;font-size:13px;cursor:pointer\">{7}</button>\
          </div>\
          </div>\
-         <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{}/ws';{}\
+         <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{8}/ws';{9}\
          function retry(){{\
-           var b=document.querySelector('button');b.textContent='正在重启…';b.disabled=true;\
+           var b=document.querySelector('button');b.textContent={10:?};b.disabled=true;\
            window.dshDesktop._call('boot.start',{{}}).then(function(){{location.reload();}})\
-             .catch(function(e){{b.textContent='重启失败，请重试';b.disabled=false;}});\
+             .catch(function(e){{b.textContent={11:?};b.disabled=false;}});\
          }}\
          function safeMode(){{\
-           var b=event.target;b.textContent='进入安全模式…';b.disabled=true;\
+           var b=event.target;b.textContent={12:?};b.disabled=true;\
            window.dshDesktop._call('rescue.safe-mode',{{on:true}}).then(function(){{\
              return window.dshDesktop._call('boot.start',{{}});\
            }}).then(function(){{location.reload();}})\
-             .catch(function(e){{b.textContent='失败（服务可能仍在运行）';b.disabled=false;}});\
+             .catch(function(e){{b.textContent={13:?};b.disabled=false;}});\
          }}</script></body>",
+        ui_text("zh-CN", "en"),
+        ui_text("服务已停止", "Service stopped"),
+        ui_text("DSH 服务已停止", "The DSH service has stopped"),
+        ui_text("退出码", "Exit code"),
         esc(code),
         esc(log_path),
+        ui_text("重新启动", "Restart"),
+        ui_text("安全模式重启", "Restart in safe mode"),
         WS_PORT,
-        BRIDGE_JS
+        BRIDGE_JS,
+        ui_text("正在重启…", "Restarting..."),
+        ui_text("重启失败，请重试", "Restart failed. Try again."),
+        ui_text("进入安全模式…", "Entering safe mode..."),
+        ui_text("失败（服务可能仍在运行）", "Failed (the service may still be running)"),
     )
 }
 
@@ -1297,18 +1357,24 @@ fn encode_back(url: &str) -> String {
 /// 更新进度页（client-update.show / agent 更新共用；进度经 _onNotify 渲染）。
 fn update_page(version: &str, kind: &str) -> String {
     let esc = |s: &str| s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;");
+    let product = if kind == "agent" {
+        ui_text("dsh 内核", "dsh core")
+    } else {
+        "Deepseek Harness EAC"
+    };
     format!(
-        "<!doctype html><meta charset=utf-8><title>正在更新</title>\
+        "<!doctype html><html lang={0}><meta charset=utf-8><title>{1}</title>\
          <body style=\"margin:0;height:100vh;display:grid;place-items:center;background:#0b1220;\
          color:#dfe6ff;font-family:'Segoe UI','Microsoft YaHei',system-ui,sans-serif\">\
          <div style=\"text-align:center;max-width:520px;width:82%\">\
-         <div style=\"font-size:19px;font-weight:600;margin-bottom:8px\">正在更新 {0}</div>\
-         <div style=\"font-size:12.5px;color:#8b9ac4;margin-bottom:22px\">v{3} · 更新完成后应用会自动重启；插件、皮肤与会话全部保留。</div>\
+         <div style=\"font-size:19px;font-weight:600;margin-bottom:8px\">{2} {3}</div>\
+         <div style=\"font-size:12.5px;color:#8b9ac4;margin-bottom:22px\">v{4} · {5}</div>\
          <div style=\"height:8px;border-radius:6px;background:rgba(255,255,255,.08);overflow:hidden\">\
          <div id=fill style=\"height:100%;width:0%;border-radius:6px;background:#5b8cff;transition:width .3s\"></div></div>\
-         <div id=status style=\"margin-top:14px;font-size:12.5px;color:#8b9ac4;font-family:Consolas,monospace\">准备中…</div>\
+         <div id=status style=\"margin-top:14px;font-size:12.5px;color:#8b9ac4;font-family:Consolas,monospace\">{6}</div>\
          </div>\
-         <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{1}/ws';{2}\
+         <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{7}/ws';{8}\
+         var EN={9};\
          var BACK=new URLSearchParams(location.search).get('back')||'';\
          window.dshDesktop._onNotify(function(m,p){{\
            if (m==='client-update.progress'){{\
@@ -1317,43 +1383,59 @@ fn update_page(version: &str, kind: &str) -> String {
                document.getElementById('fill').style.width=pct+'%';\
                var extra='';\
                if (p.speedMBps) extra=' · '+p.speedMBps.toFixed(1)+' MB/s';\
-               if (p.etaSec && isFinite(p.etaSec) && p.etaSec>0){{var s=Math.round(p.etaSec);extra+=' · 剩余 '+(s>=60?Math.floor(s/60)+' 分 '+(s%60)+' 秒':s+' 秒');}}\
-               document.getElementById('status').textContent='正在下载 '+pct+'%'+extra;\
+               if (p.etaSec && isFinite(p.etaSec) && p.etaSec>0){{var s=Math.round(p.etaSec);extra+=EN?' · '+(s>=60?Math.floor(s/60)+'m '+(s%60)+'s':s+'s')+' remaining':' · 剩余 '+(s>=60?Math.floor(s/60)+' 分 '+(s%60)+' 秒':s+' 秒');}}\
+               document.getElementById('status').textContent=(EN?'Downloading ':'正在下载 ')+pct+'%'+extra;\
              }} else if (p && p.stage){{\
-               document.getElementById('status').textContent=p.stage;\
+               var stages={{fetch:'Downloading packages...',install:'Installing...',done:'Finishing...',mirror:'Switching download source...'}};\
+               document.getElementById('status').textContent=EN?(stages[p.stage]||'Updating...'):p.stage;\
              }}\
            }} else if (m==='client-update.hide'){{\
              if (BACK) location.replace(BACK);\
            }}\
          }});</script></body>",
-        if kind == "agent" { "dsh 内核" } else { "Deepseek Harness EAC" },
+        ui_text("zh-CN", "en"),
+        ui_text("正在更新", "Updating"),
+        ui_text("正在更新", "Updating"),
+        product,
+        esc(version),
+        ui_text("更新完成后应用会自动重启；插件、皮肤与会话全部保留。", "The app restarts automatically when the update finishes. Plugins, skins, and sessions are preserved."),
+        ui_text("准备中…", "Preparing..."),
         WS_PORT,
         BRIDGE_JS,
-        esc(version),
+        if use_chinese_ui() { "false" } else { "true" },
     )
 }
 
 /// 关于页（menu.action 'about'；版本经 chrome.init 动态读取）。
 fn about_page() -> String {
     format!(
-        "<!doctype html><meta charset=utf-8><title>关于</title>\
+        "<!doctype html><html lang={0}><meta charset=utf-8><title>{1}</title>\
          <body style=\"margin:0;height:100vh;display:grid;place-items:center;background:#0b1220;\
          color:#dfe6ff;font-family:'Segoe UI','Microsoft YaHei',system-ui,sans-serif\">\
          <div style=\"text-align:center;max-width:460px;padding:30px 38px;border:1px solid rgba(255,255,255,.08);\
          border-radius:16px;background:color-mix(in srgb,#0b1220 92%,white)\">\
          <div style=\"font-size:20px;font-weight:600;margin-bottom:6px\">Deepseek Harness EAC</div>\
-         <div id=ver style=\"font-size:13px;color:#8b9ac4;margin-bottom:14px\">读取版本中…</div>\
-         <div style=\"font-size:12px;color:#5f6f9c;line-height:1.8\">Tauri 壳（Rust L1）· Node sidecar（L2）· dsh 内核零改动（L3）<br/>\
-         本项目为社区增强封装，与官方 DeepSeek 无隶属关系。</div>\
+         <div id=ver style=\"font-size:13px;color:#8b9ac4;margin-bottom:14px\">{2}</div>\
+         <div style=\"font-size:12px;color:#5f6f9c;line-height:1.8\">{3}<br/>{4}</div>\
          <button onclick=\"if(BACK)location.replace(BACK)\" style=\"margin-top:20px;padding:8px 26px;border:1px solid rgba(255,255,255,.18);\
-         border-radius:9px;background:rgba(91,140,255,.15);color:#dfe6ff;font-size:13px;cursor:pointer\">返回</button>\
+         border-radius:9px;background:rgba(91,140,255,.15);color:#dfe6ff;font-size:13px;cursor:pointer\">{5}</button>\
          </div>\
-         <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{}/ws';{}\
+         <script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{6}/ws';{7}\
          var BACK=new URLSearchParams(location.search).get('back')||'';\
          window.dshDesktop._call('chrome.init',{{}}).then(function(i){{\
-           document.getElementById('ver').textContent='封装 v'+i.appVersion+' · dsh 内核 '+i.agentVersion+'（'+(i.agentSource||'bundled')+'）';\
-         }}).catch(function(){{document.getElementById('ver').textContent='版本信息暂不可用';}});</script></body>",
-        WS_PORT, BRIDGE_JS
+           document.getElementById('ver').textContent={8:?}+' v'+i.appVersion+' · '+{9:?}+' '+i.agentVersion+' ('+(i.agentSource||'bundled')+')';\
+         }}).catch(function(){{document.getElementById('ver').textContent={10:?};}});</script></body>",
+        ui_text("zh-CN", "en"),
+        ui_text("关于", "About"),
+        ui_text("读取版本中…", "Reading version..."),
+        ui_text("Tauri 壳（Rust L1）· Node sidecar（L2）· dsh 内核零改动（L3）", "Tauri shell (Rust L1) · Node sidecar (L2) · unchanged dsh core (L3)"),
+        ui_text("本项目为社区增强封装，与官方 DeepSeek 无隶属关系。", "This community enhancement is not affiliated with official DeepSeek."),
+        ui_text("返回", "Back"),
+        WS_PORT,
+        BRIDGE_JS,
+        ui_text("封装", "App"),
+        ui_text("dsh 内核", "dsh core"),
+        ui_text("版本信息暂不可用", "Version information is unavailable"),
     )
 }
 
@@ -1363,7 +1445,11 @@ fn about_page() -> String {
 fn wizard_page() -> String {
     let file = resource_root().join("dsh-desktop").join("assets").join("onboarding.html");
     let html = std::fs::read_to_string(&file).unwrap_or_else(|_| {
-        "<!doctype html><meta charset=utf-8><title>向导</title><body style=\"background:#0b1220;color:#dfe6ff;font-family:sans-serif;display:grid;place-items:center;height:100vh\">向导资源缺失（assets/onboarding.html）</body>".to_string()
+        format!(
+            "<!doctype html><meta charset=utf-8><title>{0}</title><body style=\"background:#0b1220;color:#dfe6ff;font-family:sans-serif;display:grid;place-items:center;height:100vh\">{1} (assets/onboarding.html)</body>",
+            ui_text("向导", "Wizard"),
+            ui_text("向导资源缺失", "Wizard resource is missing"),
+        )
     });
     let injection = format!(
         "<script>window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{}/ws';{};\
@@ -1390,7 +1476,11 @@ fn wizard_page() -> String {
 fn recovery_center_page() -> String {
     let file = resource_root().join("dsh-desktop").join("assets").join("recovery-center.html");
     let html = std::fs::read_to_string(&file).unwrap_or_else(|_| {
-        "<!doctype html><meta charset=utf-8><title>恢复中心</title><body style=\"background:#0b1220;color:#dfe6ff;font-family:sans-serif;display:grid;place-items:center;height:100vh\">恢复中心资源缺失（assets/recovery-center.html）</body>".to_string()
+        format!(
+            "<!doctype html><meta charset=utf-8><title>{0}</title><body style=\"background:#0b1220;color:#dfe6ff;font-family:sans-serif;display:grid;place-items:center;height:100vh\">{1} (assets/recovery-center.html)</body>",
+            ui_text("恢复中心", "Recovery Center"),
+            ui_text("恢复中心资源缺失", "Recovery Center resource is missing"),
+        )
     });
     let ws_rpc = std::fs::read_to_string(resource_root().join("dsh-desktop").join("assets").join("ws-jsonrpc-client.js")).unwrap_or_default();
     let preload = std::fs::read_to_string(resource_root().join("dsh-desktop").join("assets").join("recovery-center-preload.js")).unwrap_or_default();
@@ -1890,11 +1980,11 @@ fn main() {
 
             // 托盘（L1）：对齐 Electron 托盘全项（显示/隐藏、恢复中心、重启服务、反馈、退出）。
             let app_handle = app.handle().clone();
-            let show = tauri::menu::MenuItem::with_id(app, "show", "显示 / 隐藏窗口", true, None::<&str>)?;
-            let recovery = tauri::menu::MenuItem::with_id(app, "recovery", "恢复中心…", true, None::<&str>)?;
-            let restart = tauri::menu::MenuItem::with_id(app, "restart", "重启 Web 服务", true, None::<&str>)?;
-            let feedback = tauri::menu::MenuItem::with_id(app, "feedback", "反馈建议", true, None::<&str>)?;
-            let quit = tauri::menu::MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
+            let show = tauri::menu::MenuItem::with_id(app, "show", ui_text("显示 / 隐藏窗口", "Show / Hide Window"), true, None::<&str>)?;
+            let recovery = tauri::menu::MenuItem::with_id(app, "recovery", ui_text("恢复中心…", "Recovery Center..."), true, None::<&str>)?;
+            let restart = tauri::menu::MenuItem::with_id(app, "restart", ui_text("重启 Web 服务", "Restart Web Service"), true, None::<&str>)?;
+            let feedback = tauri::menu::MenuItem::with_id(app, "feedback", ui_text("反馈建议", "Feedback"), true, None::<&str>)?;
+            let quit = tauri::menu::MenuItem::with_id(app, "quit", ui_text("退出", "Quit"), true, None::<&str>)?;
             let sep1 = tauri::menu::PredefinedMenuItem::separator(app)?;
             let sep2 = tauri::menu::PredefinedMenuItem::separator(app)?;
             let menu = tauri::menu::Menu::with_items(app, &[&show, &sep1, &recovery, &restart, &sep2, &feedback, &quit])?;


### PR DESCRIPTION
## 目的
在未检测到中文语言时自动使用英文界面，并同步该分支已有的本地工具与代理文档改动。

## 用户可见变化
- Web UI 使用 DSH locale；非中文浏览器语言默认英文。
- 新增兼容插件，为缺少 locale 字典的内置插件转换固定 UI 文案，支持动态内容和切回中文。
- 会话、代码、终端、编辑器、textarea 与用户内容不参与翻译。
- Tauri 壳页面、窗口标题、托盘、首次向导和恢复中心按系统或浏览器语言显示英文。
- 文件拖放、图片粘贴、侧边临时会话和提示词优化产生的 Agent 指令会使用英文。

## 架构与兼容边界
- L3：`dsh-eac-locale-compat` 客户端兼容插件及 DSH 插件文案。
- L2：插件同步与 onboarding 核心插件注册。
- L1：系统语言检测、壳页面和托盘文本。
- 仅翻译固定 UI 文案；未知中文保持原样，避免半翻译。
- 不修改用户数据、profile 布局、会话内容或桥接 API。

## 验证
- `npm run build` 通过。
- 55 项语言/插件/向导/恢复中心定向测试通过。
- `cargo check` 与 2 项 Rust 测试通过。
- `node boot-smoke.js` 通过，确认插件同步、HTTP 探活和优雅关停。

## 未验证项
- 当前 Linux 环境无 Windows GUI，未执行 Windows GUI smoke。
- `rustfmt` 未安装，未执行 `cargo fmt --check`。
- 全量 Node 测试中既有 `phone-bridge.test.ts` 会因重复响应头和 WebSocket 句柄泄漏阻塞，未计入本改动结果。

## 其他提交
本 PR 也包含先前已提交的本地工具与代理文档改动；其原生二进制模块更新仍需维护者在目标平台复核。

## 工作区边界
未提交的 sidecar 信号关停、平台测试和资源定位改动未包含在本 PR。