### PR TITLE
fix(dsh-settings-scroll-fix): 修复关键词检测误判问题，改用结构化检测

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/lib/client.js
@@ -54,7 +54,7 @@ window.__ModuleLoader__.load({
       if (role !== 'dialog') return false
       const ariaModal = String(element.getAttribute('aria-modal') || '').toLowerCase()
       if (ariaModal !== 'true') return false
-      return element.querySelector(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`) !== null
+      return hasSettingsSlotDescendant(element)
     }
 
     function hasSettingsSlotDescendant(element) {
@@ -111,6 +111,8 @@ window.__ModuleLoader__.load({
       const seen = new Set()
 
       const tryPush = (elements) => {
+        if (!elements) return
+        if (!elements[Symbol.iterator]) elements = [elements]
         for (const el of elements) {
           if (!seen.has(el)) {
             seen.add(el)

--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/lib/client.js
@@ -11,10 +11,7 @@ window.__ModuleLoader__.load({
     const ROOT_ATTR = 'data-dssf-settings-root'
     const SCROLL_ATTR = 'data-dssf-scrollable'
     const FLEX_ATTR = 'data-dssf-flex-min-height'
-    const SETTINGS_LABELS = [
-      '设置', '基础', '通用', '模型', '供应商', '插件', '外观',
-      'settings', 'general', 'models', 'providers', 'plugins', 'appearance',
-    ]
+    const SETTINGS_SLOT_PREFIX = 'settings.'
 
     const STYLE_TEXT = [
       `[${SCROLL_ATTR}="true"] {`,
@@ -51,17 +48,22 @@ window.__ModuleLoader__.load({
       return style.display !== 'none' && style.visibility !== 'hidden'
     }
 
-    function normalizedText(element) {
-      return String(element.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase()
+    function isSettingsDialog(element) {
+      if (!isElement(element)) return false
+      const role = String(element.getAttribute('role') || '').toLowerCase()
+      if (role !== 'dialog') return false
+      const ariaModal = String(element.getAttribute('aria-modal') || '').toLowerCase()
+      if (ariaModal !== 'true') return false
+      return element.querySelector(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`) !== null
     }
 
-    function settingsSignalCount(element) {
-      const text = normalizedText(element)
-      let count = 0
-      for (const label of SETTINGS_LABELS) {
-        if (text.includes(label)) count += 1
+    function hasSettingsSlotDescendant(element) {
+      if (!isElement(element)) return false
+      try {
+        return element.querySelector(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`) !== null
+      } catch {
+        return false
       }
-      return count
     }
 
     // 会话列骨架的稳定契约（内核 data-* 属性，非构建哈希）：设置弹层是
@@ -86,16 +88,9 @@ window.__ModuleLoader__.load({
       let current = seed
       for (let depth = 0; isElement(current) && depth < 9; depth += 1) {
         if (current === document.body || current === document.documentElement) break
+        if (isSettingsDialog(current)) return current
         const rect = rectOf(current)
-        const role = String(current.getAttribute('role') || '').toLowerCase()
-        // dialog 分支同样要求不含会话树：浮层形态的"设置根"绝不含
-        // 会话骨架，含之即为种子失真（与下方 250x180 分支同一判定）。
-        if (role === 'dialog' && rect.width >= 200 && rect.height >= 150 && settingsSignalCount(current) >= 1 && !containsConversationTree(current)) return current
-        if (rect.width >= 250 && rect.height >= 180 && settingsSignalCount(current) >= 2) {
-          // 含会话树的大框（整页框架/中心列）不是设置浮层：hero 首页的
-          // "设置"按钮等词表命中会把公共祖先爬到这里，误标会话区。
-          if (!containsConversationTree(current)) return current
-        }
+        if (rect.width >= 250 && rect.height >= 180 && hasSettingsSlotDescendant(current)) return current
         current = current.parentElement
       }
       return null
@@ -113,32 +108,44 @@ window.__ModuleLoader__.load({
 
     function discoverSettingsRoots() {
       const seeds = []
-      const selectors = [
-        '[data-dsh-settings-root]',
-        '[data-slot^="settings."]',
-        '[aria-label*="设置"]',
-        '[aria-label*="Settings"]',
-        '[role="dialog"]',
-      ]
-      for (const selector of selectors) {
-        try {
-          seeds.push(...document.querySelectorAll(selector))
-        } catch {
-          // Ignore unsupported selectors in older Chromium builds.
+      const seen = new Set()
+
+      const tryPush = (elements) => {
+        for (const el of elements) {
+          if (!seen.has(el)) {
+            seen.add(el)
+            seeds.push(el)
+          }
         }
       }
 
-      const navigationSignals = []
-      for (const element of document.querySelectorAll('button, a, [role="tab"], [role="menuitem"], nav a, nav button')) {
-        const text = normalizedText(element)
-        if (text.length <= 32 && SETTINGS_LABELS.some(label => text.includes(label)) && isVisible(element)) {
-          navigationSignals.push(element)
+      // Layer 1: Plugin custom marks (backward compat)
+      try { tryPush(document.querySelectorAll('[data-dsh-settings-root]')) } catch {}
+
+      // Layer 2: DSH official settings slot containers
+      try { tryPush(document.querySelectorAll(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`)) } catch {}
+
+      // Layer 3: Settings dialog (role + aria-modal + must contain settings slot descendant)
+      try {
+        for (const el of document.querySelectorAll('div[role="dialog"][aria-modal="true"]')) {
+          if (hasSettingsSlotDescendant(el)) tryPush([el])
         }
-      }
-      if (navigationSignals.length >= 1) {
-        const ancestor = commonAncestor(navigationSignals)
-        if (ancestor !== null) seeds.push(ancestor)
-      }
+      } catch {}
+
+      // Layer 4: Settings trigger button region (fallback)
+      try {
+        for (const btn of document.querySelectorAll('button[aria-haspopup="dialog"]')) {
+          try {
+            const slotAncestor = btn.closest(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`)
+              || btn.closest('[data-slot="sidebar.settings"]')
+            if (slotAncestor) tryPush([slotAncestor])
+          } catch {}
+        }
+      } catch {}
+
+      // Layer 5: aria-label fallback
+      try { tryPush(document.querySelectorAll('[aria-label*="设置"]')) } catch {}
+      try { tryPush(document.querySelectorAll('[aria-label*="Settings"]')) } catch {}
 
       const roots = []
       for (const seed of seeds) {

--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/src/client.js
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/src/client.js
@@ -54,7 +54,7 @@ window.__ModuleLoader__.load({
       if (role !== 'dialog') return false
       const ariaModal = String(element.getAttribute('aria-modal') || '').toLowerCase()
       if (ariaModal !== 'true') return false
-      return element.querySelector(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`) !== null
+      return hasSettingsSlotDescendant(element)
     }
 
     function hasSettingsSlotDescendant(element) {
@@ -111,6 +111,8 @@ window.__ModuleLoader__.load({
       const seen = new Set()
 
       const tryPush = (elements) => {
+        if (!elements) return
+        if (!elements[Symbol.iterator]) elements = [elements]
         for (const el of elements) {
           if (!seen.has(el)) {
             seen.add(el)

--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/src/client.js
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/src/client.js
@@ -11,10 +11,7 @@ window.__ModuleLoader__.load({
     const ROOT_ATTR = 'data-dssf-settings-root'
     const SCROLL_ATTR = 'data-dssf-scrollable'
     const FLEX_ATTR = 'data-dssf-flex-min-height'
-    const SETTINGS_LABELS = [
-      '设置', '基础', '通用', '模型', '供应商', '插件', '外观',
-      'settings', 'general', 'models', 'providers', 'plugins', 'appearance',
-    ]
+    const SETTINGS_SLOT_PREFIX = 'settings.'
 
     const STYLE_TEXT = [
       `[${SCROLL_ATTR}="true"] {`,
@@ -51,17 +48,22 @@ window.__ModuleLoader__.load({
       return style.display !== 'none' && style.visibility !== 'hidden'
     }
 
-    function normalizedText(element) {
-      return String(element.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase()
+    function isSettingsDialog(element) {
+      if (!isElement(element)) return false
+      const role = String(element.getAttribute('role') || '').toLowerCase()
+      if (role !== 'dialog') return false
+      const ariaModal = String(element.getAttribute('aria-modal') || '').toLowerCase()
+      if (ariaModal !== 'true') return false
+      return element.querySelector(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`) !== null
     }
 
-    function settingsSignalCount(element) {
-      const text = normalizedText(element)
-      let count = 0
-      for (const label of SETTINGS_LABELS) {
-        if (text.includes(label)) count += 1
+    function hasSettingsSlotDescendant(element) {
+      if (!isElement(element)) return false
+      try {
+        return element.querySelector(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`) !== null
+      } catch {
+        return false
       }
-      return count
     }
 
     // 会话列骨架的稳定契约（内核 data-* 属性，非构建哈希）：设置弹层是
@@ -86,16 +88,9 @@ window.__ModuleLoader__.load({
       let current = seed
       for (let depth = 0; isElement(current) && depth < 9; depth += 1) {
         if (current === document.body || current === document.documentElement) break
+        if (isSettingsDialog(current)) return current
         const rect = rectOf(current)
-        const role = String(current.getAttribute('role') || '').toLowerCase()
-        // dialog 分支同样要求不含会话树：浮层形态的"设置根"绝不含
-        // 会话骨架，含之即为种子失真（与下方 250x180 分支同一判定）。
-        if (role === 'dialog' && rect.width >= 200 && rect.height >= 150 && settingsSignalCount(current) >= 1 && !containsConversationTree(current)) return current
-        if (rect.width >= 250 && rect.height >= 180 && settingsSignalCount(current) >= 2) {
-          // 含会话树的大框（整页框架/中心列）不是设置浮层：hero 首页的
-          // "设置"按钮等词表命中会把公共祖先爬到这里，误标会话区。
-          if (!containsConversationTree(current)) return current
-        }
+        if (rect.width >= 250 && rect.height >= 180 && hasSettingsSlotDescendant(current)) return current
         current = current.parentElement
       }
       return null
@@ -113,32 +108,44 @@ window.__ModuleLoader__.load({
 
     function discoverSettingsRoots() {
       const seeds = []
-      const selectors = [
-        '[data-dsh-settings-root]',
-        '[data-slot^="settings."]',
-        '[aria-label*="设置"]',
-        '[aria-label*="Settings"]',
-        '[role="dialog"]',
-      ]
-      for (const selector of selectors) {
-        try {
-          seeds.push(...document.querySelectorAll(selector))
-        } catch {
-          // Ignore unsupported selectors in older Chromium builds.
+      const seen = new Set()
+
+      const tryPush = (elements) => {
+        for (const el of elements) {
+          if (!seen.has(el)) {
+            seen.add(el)
+            seeds.push(el)
+          }
         }
       }
 
-      const navigationSignals = []
-      for (const element of document.querySelectorAll('button, a, [role="tab"], [role="menuitem"], nav a, nav button')) {
-        const text = normalizedText(element)
-        if (text.length <= 32 && SETTINGS_LABELS.some(label => text.includes(label)) && isVisible(element)) {
-          navigationSignals.push(element)
+      // Layer 1: Plugin custom marks (backward compat)
+      try { tryPush(document.querySelectorAll('[data-dsh-settings-root]')) } catch {}
+
+      // Layer 2: DSH official settings slot containers
+      try { tryPush(document.querySelectorAll(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`)) } catch {}
+
+      // Layer 3: Settings dialog (role + aria-modal + must contain settings slot descendant)
+      try {
+        for (const el of document.querySelectorAll('div[role="dialog"][aria-modal="true"]')) {
+          if (hasSettingsSlotDescendant(el)) tryPush([el])
         }
-      }
-      if (navigationSignals.length >= 1) {
-        const ancestor = commonAncestor(navigationSignals)
-        if (ancestor !== null) seeds.push(ancestor)
-      }
+      } catch {}
+
+      // Layer 4: Settings trigger button region (fallback)
+      try {
+        for (const btn of document.querySelectorAll('button[aria-haspopup="dialog"]')) {
+          try {
+            const slotAncestor = btn.closest(`[data-slot^="${SETTINGS_SLOT_PREFIX}"]`)
+              || btn.closest('[data-slot="sidebar.settings"]')
+            if (slotAncestor) tryPush([slotAncestor])
+          } catch {}
+        }
+      } catch {}
+
+      // Layer 5: aria-label fallback
+      try { tryPush(document.querySelectorAll('[aria-label*="设置"]')) } catch {}
+      try { tryPush(document.querySelectorAll('[aria-label*="Settings"]')) } catch {}
 
       const roots = []
       for (const seed of seeds) {

--- a/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/tests/smoke.mjs
+++ b/dsh-desktop/assets/plugins/dsh-settings-scroll-fix/tests/smoke.mjs
@@ -4,12 +4,15 @@ import { resolve } from 'node:path'
 import vm from 'node:vm'
 
 class FakeElement {
-  constructor({ text = '', role = '', width = 640, height = 480, clientHeight = height, scrollHeight = height } = {}) {
+  constructor({ text = '', role = '', width = 640, height = 480, clientHeight = height, scrollHeight = height, ariaModal = '', dataSlot = '' } = {}) {
     this.nodeType = 1
     this.textContent = text
     this.parentElement = null
     this.children = []
-    this.attributes = new Map(role === '' ? [] : [['role', role]])
+    this.attributes = new Map()
+    if (role !== '') this.attributes.set('role', role)
+    if (ariaModal !== '') this.attributes.set('aria-modal', ariaModal)
+    if (dataSlot !== '') this.attributes.set('data-slot', dataSlot)
     this.dataset = {}
     this.clientHeight = clientHeight
     this.scrollHeight = scrollHeight
@@ -36,13 +39,26 @@ class FakeElement {
     if (selector === '[role="dialog"]') return this.getAttribute('role') === 'dialog'
     return /input|textarea|select|pre|code|contenteditable/.test(selector) ? false : false
   }
-  querySelectorAll() { return this.children.flatMap(child => [child, ...child.querySelectorAll('*')]) }
+  querySelector(selector) {
+    if (selector.startsWith('[data-slot^="settings."]')) {
+      if (this.getAttribute('data-slot')?.startsWith('settings.')) return this
+      for (const child of this.children) {
+        const found = child.querySelector(selector)
+        if (found) return found
+      }
+      return null
+    }
+    return null
+  }
+  querySelectorAll(selector) { return this.children.flatMap(child => [child, ...child.querySelectorAll('*')]) }
   remove() { this.removed = true }
 }
 
-const root = new FakeElement({ text: '设置 通用 模型 插件', role: 'dialog', width: 900, height: 620 })
+const root = new FakeElement({ text: '设置 通用 模型 插件', role: 'dialog', ariaModal: 'true', width: 900, height: 620 })
+const settingsChild = new FakeElement({ dataSlot: 'settings.section' })
+root.append(settingsChild)
 const scrollable = new FakeElement({ width: 620, height: 320, clientHeight: 320, scrollHeight: 900 })
-root.append(scrollable)
+settingsChild.append(scrollable)
 const styleElement = new FakeElement()
 const listeners = new Map()
 
@@ -53,6 +69,16 @@ const document = {
   querySelector(selector) { return selector.startsWith('style[') && !styleElement.removed ? null : null },
   querySelectorAll(selector) {
     if (selector.includes('data-dsh-settings-root')) return [root]
+    if (selector.includes('[role="dialog"][aria-modal="true"]')) return [root]
+    if (selector.startsWith('[data-slot^="settings."]')) {
+      const results = []
+      const walk = (el) => {
+        if (el.getAttribute('data-slot')?.startsWith('settings.')) results.push(el)
+        for (const child of el.children) walk(child)
+      }
+      walk(root)
+      return results
+    }
     return []
   },
   createElement(name) { assert.equal(name, 'style'); return styleElement },


### PR DESCRIPTION
## 概述

本 PR 修复了 `dsh-settings-scroll-fix` 插件的误判问题，将关键词检测替换为基于 DOM 结构属性的结构化检测。

## 问题

之前的实现使用 `SETTINGS_LABELS`（包含"模型"、"通用"、"插件"等关键词）来识别设置页面。这导致非设置页面（如对话框、侧边栏）中包含这些常见关键词时被错误识别为设置页面，从而错误地修改滚动行为。

## 解决方案

用 5 层结构化检测策略替代关键词方案：

1. **插件自定义标记**（`[data-dsh-settings-root]`）- 向后兼容
2. **DSH 官方 slot 容器**（`[data-slot^="settings."]`）- 主要检测
3. **设置对话框**（`div[role='dialog'][aria-modal='true']` + 必须包含设置 slot）- 精确对话框匹配
4. **设置触发按钮区域**（`button[aria-haspopup='dialog']` + slot 祖先）- 触发区域检测
5. **aria-label 降级**（`[aria-label*='设置']`/`[aria-label*='Settings']`）- 降级路径

## 修改内容

- **删除**：`SETTINGS_LABELS` 关键词数组
- **删除**：`normalizedText()` 文本处理函数
- **删除**：`settingsSignalCount()` 关键词计数函数
- **新增**：`isSettingsDialog()` - 检查 role + aria-modal + 设置 slot 后代
- **新增**：`hasSettingsSlotDescendant()` - 检查是否包含设置 slot 子元素
- **重写**：`promoteToSettingsRoot()` - 使用结构化信号替代关键词计数
- **重写**：`discoverSettingsRoots()` - 5 层结构化检测策略
- **更新**：冒烟测试以适配新的检测逻辑

## 优势

- **消除误判**：非设置对话框、侧边栏等包含常见关键词的元素不再被错误识别
- **更可靠**：结构化属性（`data-slot`、ARIA）比文本内容更可靠
- **性能更好**：无需读取 textContent 或进行字符串匹配，使用原生 querySelector 和 getAttribute
- **向后兼容**：`[data-slot^='settings.']` 前缀匹配自动兼容新增的设置 slot

## 测试

- ✅ `node scripts/build.mjs` - 插件构建成功
- ✅ `node tests/smoke.mjs` - 冒烟测试通过
- ✅ 完整 Tauri 构建成功
- ✅ NSIS 安装包和便携包已生成
