### PR TITLE
fix(ws-bridge): 完整读取请求头后再判断升级,修复部分环境下窗口无法拖拽与导航栏按钮失效的问题

### DIFF
--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -1177,16 +1177,82 @@ fn open_recovery_center_window(app: &tauri::AppHandle) -> bool {
     true
 }
 
-async fn handle_conn(stream: TcpStream, state: BridgeState, app: tauri::AppHandle) -> std::io::Result<()> {
-    // 先窥探请求头：决定 WS 升级还是极简 HTTP。（peek 取 &self，不消耗流）
-    let (req_path, wants_upgrade) = {
-        let mut buf = [0u8; 2048];
-        let n = stream.peek(&mut buf).await?;
-        let head = String::from_utf8_lossy(&buf[..n]).to_string();
+/// 已读请求头回放流：handle_conn 先循环读完整请求头做升级判断，读走的字节
+/// 经此流原样喂回 accept_async / http_serve，避免字节丢失。
+struct PrefixedIo {
+    prefix: Vec<u8>,
+    pos: usize,
+    inner: TcpStream,
+}
+
+impl tokio::io::AsyncRead for PrefixedIo {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        if self.pos < self.prefix.len() {
+            let n = std::cmp::min(buf.remaining(), self.prefix.len() - self.pos);
+            buf.put_slice(&self.prefix[self.pos..self.pos + n]);
+            self.pos += n;
+            return std::task::Poll::Ready(Ok(()));
+        }
+        std::pin::Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncWrite for PrefixedIo {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+async fn handle_conn(mut stream: TcpStream, state: BridgeState, app: tauri::AppHandle) -> std::io::Result<()> {
+    // 完整读取请求头（读到空行）再判断 WS 升级：单次 peek 只拿"当下可读"的
+    // 字节，浏览器内核的 WS 握手头分段到达时会漏掉 Upgrade 头 → 误判为普通
+    // HTTP 回 200（浏览器报 Unexpected response code: 200 / close 1006，窗口
+    // 四按钮的 win.* 桥调用随之 30s 超时无响应）——G3 握手检测修复。
+    let (req_path, wants_upgrade, head_bytes) = {
+        use tokio::io::AsyncReadExt;
+        let mut consumed: Vec<u8> = Vec::with_capacity(1024);
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut chunk).await?;
+            if n == 0 {
+                break;
+            }
+            consumed.extend_from_slice(&chunk[..n]);
+            if consumed.len() > 64 * 1024 {
+                break; // 头部异常超长，防御性放行
+            }
+            if consumed.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let head = String::from_utf8_lossy(&consumed).to_string();
         let first = head.lines().next().unwrap_or("");
         let path = first.split_whitespace().nth(1).unwrap_or("/").to_string();
-        (path, head.to_lowercase().contains("upgrade: websocket"))
+        (path, head.to_lowercase().contains("upgrade: websocket"), consumed)
     };
+
+    // 已读头部回放给后续消费者（WS 升级握手 / http_serve 的头消费循环）。
+    let stream = PrefixedIo { prefix: head_bytes, pos: 0, inner: stream };
 
     if !wants_upgrade {
         return http_serve(stream, &req_path).await;
@@ -1497,7 +1563,10 @@ fn recovery_center_page() -> String {
     }
 }
 
-async fn http_serve(mut stream: TcpStream, path: &str) -> std::io::Result<()> {
+async fn http_serve<S>(mut stream: S, path: &str) -> std::io::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
     eprintln!("[http] serve {}", path);
     // 真正消费请求头（读到空行）：未读数据残留会让连接以 RST 而非 FIN 收尾，
     // WebView2 视为响应中断并反复重试。


### PR DESCRIPTION
## 目的

修复窗口标题栏「缩小/最大化/关闭/杂项」四按钮无响应（`win.*` 桥调用 30s 超时），与窗口无法拖动（`win.start-dragging` 同样走桥）的问题。
用户可见变化：四按钮恢复响应、窗口可正常拖动，不再依赖皮肤侧 `-webkit-app-region` 注入。

触发环境条件（本机复现，新内核+请求头较长环境）：
- WebView2/Edge 运行时内核较新（本机 Chrome 151）：WS 握手请求头分段发送；旧内核一次性发送，不受影响
- 请求头较长更易触发：dsh web（127.0.0.1 随机端口）与桥（127.0.0.1:19873）同 host 不同端口，同域 Cookie 会随 WS 握手发送，加上系统语言/扩展头，头部长度差异可达数百字节

## 架构与范围

- 仅 L1（`tauri-shell` Rust 壳层）：`tauri-shell/src/main.rs`
- 不涉及 L2/L3（sidecar / dsh 核心）、插件、配置、更新、安装或发布
- `handle_conn` 的 WS 升级判断：单次 `peek` → 循环读取完整请求头（至 `\r\n\r\n`，64KB 上限/EOF）
- 新增 `PrefixedIo`（AsyncRead/AsyncWrite）回放已读字节；`http_serve` 签名泛型化（函数体不变）

## 风险与兼容

- 行为等价：对一次性发送握手头的客户端（旧内核）结果不变（新旧均 101）；普通 HTTP 请求路径字节级一致（已读字节原样回放）
- 无公开接口变化；无新增依赖（复用 tokio 既有 AsyncRead/AsyncWrite）
- 仅改变"请求头分段到达"这一此前失效的路径（200 → 101）
- 已知限制：macOS/Linux 未实机测试（共用同一段代码，由 CI Linux 任务编译验证）

## 验证

- 协议对照（Node 模拟器，旧逻辑 vs 新逻辑）：
  - 一次性发送握手头：旧 101 / 新 101（无回归）
  - 分两段发送（间隔 300ms）：旧 200（复现 bug）/ 新 101（修复）
- 真机（Windows x64）：`cargo build --release` 通过；替换便携版 exe 后四按钮恢复正常、窗口可拖动（以无 hack 皮肤验证，不再依赖 `-webkit-app-region` 注入）
- `git diff --check`：通过（exit 0）
- 无无关文件：`git status` 仅 `tauri-shell/src/main.rs` 一个文件（+77/-8 行）
- Skill 验证：`validate-skill.ps1` 通过（`scriptTests: passed`，`errors: []`，`ready: true`）

- [x] Skill 推荐的最低验证级别已完成
- [x] `git diff --check` 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] 未验证项已明确列出

## 配置与迁移

无

## 回退方式

- 代码：还原 `handle_conn` / `http_serve` 原实现（`git revert` 或直接改回）
- 构建验证现场：本地留有原始 `main.rs` 备份（`main.rs.bak-20260828-201225`），可无损恢复