### PR TITLE
fix(release): 补齐内核依赖准备步骤

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -86,6 +86,14 @@ jobs:
           restore-keys: |
             dsh-tauri-win-x64-
 
+      - name: 准备内核依赖缓存
+        run: |
+          npm install --global pnpm@11.7.0
+          node scripts/fetch-kernel.js
+          node scripts/pack-kernel-dependency.js
+          node -e "const fs=require('fs'); if (!fs.existsSync('vendor/kernel/0.1.2-alpha.1/deepseek-ai-schemastery-3.18.1.tgz')) throw new Error('schemastery tarball missing after staging')"
+          node scripts/refresh-kernel-lock.js
+
       - name: 安装依赖
         working-directory: dsh-desktop
         run: npm ci
@@ -174,6 +182,14 @@ jobs:
 
       - name: 安装 Rust 工具链（stable）
         uses: dtolnay/rust-toolchain@stable
+
+      - name: 准备内核依赖缓存
+        run: |
+          npm install --global pnpm@11.7.0
+          node scripts/fetch-kernel.js
+          node scripts/pack-kernel-dependency.js
+          node -e "const fs=require('fs'); if (!fs.existsSync('vendor/kernel/0.1.2-alpha.1/deepseek-ai-schemastery-3.18.1.tgz')) throw new Error('schemastery tarball missing after staging')"
+          node scripts/refresh-kernel-lock.js
 
       - name: 安装依赖并获取 Linux runtime
         run: npm ci && npm run fetch-runtime


### PR DESCRIPTION
## 目的

修复 Release Tauri 在 Windows 与 Ubuntu 22.04 job 的依赖安装失败。最新内核依赖改为 vendor/kernel 本地 tarball 后，发布工作流未执行普通 CI 已具备的内核准备步骤，导致 npm ci 找不到 deepseek-ai-schemastery-3.18.1.tgz。

## 架构与范围

仅修改 .github/workflows/release-tauri.yml。在两个发布 job 的 npm ci 前加入与 ci.yml 一致的内核获取、依赖打包、关键 tarball 校验和 lock 刷新步骤。不涉及 L1/L2/L3 业务代码、插件配置或用户数据。

## 风险与兼容

风险集中在发布任务耗时和上游内核下载可用性。命令已经由 main 的普通 CI Windows/Linux job 验证。公开接口、用户数据、升级路径和第三方兼容无变化。

## 验证

- 失败复现：Release Tauri run 33302028653 的 Windows/Linux job 均在 npm ci 阶段因缺少 vendor/kernel/0.1.2-alpha.1/deepseek-ai-schemastery-3.18.1.tgz 失败。
- repo-preflight.ps1 -RequiredLevel targeted：ready。
- classify-change.ps1：release-git，minimumValidation=package。
- git diff --check：通过。
- 完整 Windows/Linux 构建由本 PR CI 验证；合并后重新执行 Release Tauri 作为 V5 分发验证。

- [ ] Skill 推荐的最低验证级别已完成
- [x] git diff --check 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] UI 无变化，无需截图或录屏
- [x] 未验证项已明确列出

## 配置与迁移

无。

## 回退方式

回退本提交即可恢复原发布工作流；本修改不迁移配置或用户数据。