### PR TITLE
feat(dsh-easy-setup): add OrcaRouter as a named vision provider preset

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js
@@ -143,6 +143,9 @@ window.__ModuleLoader__.load({
       { id: "openai", label: "OpenAI", baseURL: "https://api.openai.com/v1", keyEnv: "OPENAI_API_KEY", models: ["gpt-4o-mini", "gpt-4o"] },
       { id: "siliconflow", label: "硅基流动 SiliconFlow", baseURL: "https://api.siliconflow.cn/v1", keyEnv: "SILICONFLOW_API_KEY", models: ["Qwen/Qwen2.5-VL-32B-Instruct", "Pro/Qwen/Qwen2.5-VL-7B-Instruct"] },
       { id: "moonshot", label: "月之暗面 Kimi", baseURL: "https://api.moonshot.cn/v1", keyEnv: "MOONSHOT_API_KEY", models: ["moonshot-v1-8k-vision-preview"] },
+      // OrcaRouter: OpenAI-compatible gateway that exposes many vision-capable
+      // models through a single endpoint (routing/failover included).
+      { id: "orcarouter", label: "OrcaRouter 智能网关", baseURL: "https://api.orcarouter.ai/v1", keyEnv: "ORCAROUTER_API_KEY", models: ["orcarouter/fusion-flash", "orcarouter/fusion", "openai/gpt-4o-mini", "deepseek/deepseek-v4-flash-vision-exp"] },
       { id: "custom", label: "自定义（手动填写）", baseURL: "", keyEnv: "VISION_API_KEY", models: [] }
     ];
 

--- a/dsh-desktop/logger.ts
+++ b/dsh-desktop/logger.ts
@@ -66,6 +66,7 @@ const PII_PREFIXES_RULES_UNSORTED: PrefixRule[] = [
   { prefix: 'ASIA', head: 4, tail: 4 }, // AWS STS
   { prefix: 'sk-ant-', head: 5, tail: 4 }, // Anthropic (tests expected head=5: "sk-an")
   { prefix: 'sk-or-',  head: 5, tail: 4 }, // OpenRouter (head=5 → "sk-or")
+  { prefix: 'sk-orca-', head: 7, tail: 4 }, // OrcaRouter (head=7 → "sk-orca")
   { prefix: 'ds-',     head: 5, tail: 4 }, // Deepseek
   { prefix: 'sk-',     head: 4, tail: 4 }, // OpenAI (fallback)
   { prefix: 'pk-',     head: 4, tail: 4 }, // Stripe public

--- a/dsh-desktop/test/logger-redact.test.ts
+++ b/dsh-desktop/test/logger-redact.test.ts
@@ -79,6 +79,7 @@ if (logger && logger._testExports?.deepRedact) {
     ['ASIAIOSFODNN7EXAMPLE',      'ASIA***MPLE',        'AWS ASIA STS 前缀保留前 6 后 4'],
     ['sk-ant-1234567890abcdef',   'sk-an***cdef',       'sk-ant 前缀'],
     ['sk-or-abcdefghijklmnopqrs', 'sk-or***pqrs',       'sk-or OpenRouter'],
+    ['sk-orca-abcdefghijklmnopqrs', 'sk-orca***pqrs',   'sk-orca OrcaRouter'],
     ['ds-abcdefghijklmnopqrstuvw','ds-ab***tuvw',       'ds- Deepseek'],
     ['ghp_abcdefghijklmnopqrstuvwxyz1234567890', 'ghp_ab***7890', 'GitHub ghp_ 令牌'],
     ['SECxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', 'SECxxx***xxxx', '钉钉 webhook sign=SEC... 前缀'],


### PR DESCRIPTION
## Purpose

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This PR wires OrcaRouter into the **vision quick-setup** page the project already ships for selecting a vision model (the "**visual configuration for vision models**" entry point from the README). Instead of pasting a base URL into the "custom" field, users pick **OrcaRouter 智能网关** from the provider dropdown, exactly like the existing OpenRouter-style providers.

## Architecture & scope

`dsh-easy-setup` (L2-side companion plugin, `dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js`) keeps a `PROVIDERS` registry for the vision quick-setup dropdown. Each entry mirrors the OpenRouter-style wiring already used by the `openai`, `zhipu`, `dashscope`, `siliconflow` and `moonshot` presets:

- `id: "orcarouter"`, label **OrcaRouter 智能网关**
- `baseURL: "https://api.orcarouter.ai/v1"` — the OpenAI-compatible endpoint `picturereader`'s `sendVisionRequest` already calls as `${base}/v1/chat/completions`
- `keyEnv: "ORCAROUTER_API_KEY"` — written to the `apiKeyEnv` setting, resolved from the environment at request time (same pattern as `GLM_API_KEY` / `OPENAI_API_KEY`)
- `models: ["orcarouter/fusion-flash", "orcarouter/fusion", "openai/gpt-4o-mini", "deepseek/deepseek-v4-flash-vision-exp"]` — vision-capable models exposed through the gateway

File-by-file:

| File | Change |
| --- | --- |
| `dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js` | Adds the `orcarouter` entry to the `PROVIDERS` registry (3 lines, two of which are a comment) |
| `dsh-desktop/logger.ts` | Adds an `sk-orca-` prefix rule to the PII redactor, mirroring the existing `sk-or-` OpenRouter rule so OrcaRouter keys never leak into logs |
| `dsh-desktop/test/logger-redact.test.ts` | Adds the matching redaction case |

No changes to the dsh kernel, no schema changes, no config migrations.

## Risk & compatibility

None — the change is purely additive inside a UI-side constant and a redaction rule. Existing providers and stored `tool-vision` settings are untouched; a user who never selects the new provider sees no behavior change. OrcaRouter is OpenAI-compatible, so the existing `picturereader` request path applies unchanged.

## Verification

- `git diff --check` passes.
- `node --check` on the modified `client.js` passes.
- Redaction algorithm verified locally: `sk-orca-…` masks to `sk-orca***…`, the OpenRouter `sk-or-` and generic `sk-` rules are unaffected (longest-prefix ordering confirmed).
- **Live test (L3)**: exercised `picturereader`'s `sendVisionRequest` against `https://api.orcarouter.ai/v1/chat/completions` with `ORCAROUTER_API_KEY` from the environment — all four preset models returned HTTP 200 with real vision content (`orcarouter/fusion-flash` → "Red", `orcarouter/fusion` → "Pink", `openai/gpt-4o-mini` → "Red", `deepseek/deepseek-v4-flash-vision-exp` → "Pink"). The key is never echoed into logs or this PR.

**Not run in this environment:** the full `npm test` suite (and its `tsc` pretest) cannot execute here because this clone has no `node_modules`/vendored runtime — CI (`dsh-desktop` on `windows-latest`) will run it on the PR. The `logger.ts` change is one array entry matching the existing adjacent rules.

## Configuration & migration

None.

## Rollback

Revert the single `PROVIDERS` entry and the two redaction lines; the UI returns to the previous provider list and stored settings are unchanged.

---

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
