### PR TITLE
fix(boot): 修复 Linux 发布包启动链

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -175,8 +175,16 @@ jobs:
       - name: 安装 Rust 工具链（stable）
         uses: dtolnay/rust-toolchain@stable
 
+      - name: 准备内核依赖缓存
+        run: |
+          corepack disable
+          npm install --global pnpm@11.7.0
+          node scripts/fetch-kernel.js
+
       - name: 安装依赖并获取 Linux runtime
-        run: npm ci && npm run fetch-runtime
+        run: |
+          npm ci
+          npm run fetch-runtime
 
       - name: 写入发布版本号
         run: npm version ${{ steps.tag.outputs.version }} --no-git-tag-version --allow-same-version

--- a/dsh-desktop/scripts/patch-deps.ts
+++ b/dsh-desktop/scripts/patch-deps.ts
@@ -400,29 +400,36 @@ function patchMenuSubmenuScroll(file?: string): boolean {
   return true;
 }
 
-// 内核 client-modules v2 解析签名补丁：Node ≥24.11 的内部 ESM 解析器
-// resolveSync 实际签名是 (specifier, parentURL)（位置参数），而内核 0.1.2
-// 的 v2 分支按 (parentURL, {specifier, attributes}) 调用——TypeError 被
-// locatePkgJson 的 catch 吞掉后所有包都判为 located-undefined，boot graph
-// 静默清零（官方 UI 走 vite dist 不受影响，故官方 CI 未发现）。修复：v2
-// 分支同样用位置参数调用。锚点带换行缩进（tsdown 产物形态）。
+// client-modules 解析签名恢复：上游 0.1.2 已正确区分 Node 24 v2
+// (parentURL, { specifier, attributes }) 与 Node 22 v1 的位置参数。旧版
+// patch-deps 误把两者统一成位置参数，导致 Node 24 把包名当 URL 后静默清空
+// boot graph。这里只修复已经被旧补丁改坏的安装树；上游原始实现保持不动。
 const CLIENT_MODULES_RESOLVE_TARGET = path.join(root, 'node_modules', '@deepseek-ai', 'dsh-client-modules', 'lib', 'index.js');
-const CLIENT_MODULES_RESOLVE_OLD = 'internal.version === "v2" ? internal.resolveSync(baseUrl, {\n\t\t\t\tspecifier: loaderName,\n\t\t\t\tattributes: {}\n\t\t\t}).url : internal.resolveSync(loaderName, baseUrl, {}).url';
-const CLIENT_MODULES_RESOLVE_NEW = 'internal.resolveSync(loaderName, baseUrl, {}).url';
+const CLIENT_MODULES_RESOLVE_EXPECTED = 'internal.version === "v2" ? internal.resolveSync(baseUrl, {\n\t\t\t\tspecifier: loaderName,\n\t\t\t\tattributes: {}\n\t\t\t}).url : internal.resolveSync(loaderName, baseUrl, {}).url';
+const CLIENT_MODULES_RESOLVE_REVERSED = 'internal.resolveSync(loaderName, baseUrl, {}).url';
+const CLIENT_MODULES_RESOLVE_PARENT_FIRST = 'internal.resolveSync(baseUrl, loaderName, {}).url';
 
-function patchClientModulesResolve(): void {
-  if (!fs.existsSync(CLIENT_MODULES_RESOLVE_TARGET)) {
+function patchClientModulesResolve(targetFile = CLIENT_MODULES_RESOLVE_TARGET): boolean {
+  if (!fs.existsSync(targetFile)) {
     console.log('[patch-deps] dsh-client-modules 不存在，跳过');
-    return;
+    return false;
   }
-  let src = fs.readFileSync(CLIENT_MODULES_RESOLVE_TARGET, 'utf8');
-  if (!src.includes(CLIENT_MODULES_RESOLVE_OLD)) {
-    console.log('[patch-deps] client-modules v2 签名锚点未命中（已应用或上游已修），跳过');
-    return;
+  let src = fs.readFileSync(targetFile, 'utf8');
+  if (src.includes(CLIENT_MODULES_RESOLVE_EXPECTED)) {
+    console.log('[patch-deps] client-modules Node 22/24 解析签名正确，跳过');
+    return false;
   }
-  src = src.replace(CLIENT_MODULES_RESOLVE_OLD, CLIENT_MODULES_RESOLVE_NEW);
-  writeFileAtomic(CLIENT_MODULES_RESOLVE_TARGET, src);
-  console.log('[patch-deps] 已补丁 client-modules：v2 resolveSync 位置参数（boot graph 清零修复）');
+  if (src.includes(CLIENT_MODULES_RESOLVE_REVERSED)) {
+    src = src.replace(CLIENT_MODULES_RESOLVE_REVERSED, CLIENT_MODULES_RESOLVE_EXPECTED);
+  } else if (src.includes(CLIENT_MODULES_RESOLVE_PARENT_FIRST)) {
+    src = src.replace(CLIENT_MODULES_RESOLVE_PARENT_FIRST, CLIENT_MODULES_RESOLVE_EXPECTED);
+  } else {
+    console.log('[patch-deps] client-modules 解析签名锚点未命中（上游可能已更新），跳过');
+    return false;
+  }
+  writeFileAtomic(targetFile, src);
+  console.log('[patch-deps] 已恢复 client-modules Node 22/24 分支解析签名（boot graph 清零修复）');
+  return true;
 }
 
 function main(): void {
@@ -440,4 +447,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { patchAgentPresetMenu, patchMenuSubmenuScroll };
+module.exports = { patchAgentPresetMenu, patchMenuSubmenuScroll, patchClientModulesResolve };

--- a/dsh-desktop/test/linux-release-boot.test.ts
+++ b/dsh-desktop/test/linux-release-boot.test.ts
@@ -53,6 +53,7 @@ test('Linux staging excludes the kernel build tree and removes client build path
     writeFileSync(client, [
       '//#region \\0dsh-css:/home/runner/work/repo/dsh-desktop/vendor/kernel/.build/deepseek-harness-dsh-v0.1.2-alpha.1/packages/example/src/client.css.mjs',
       '//#region \\0dsh-css:D:\\build\\dsh-desktop\\vendor\\kernel\\.build\\deepseek-harness-dsh-v0.1.2-alpha.1\\packages\\example\\src\\client.css.mjs',
+      '//#region \\0dsh-inline-css:/home/runner/work/repo/dsh-desktop/vendor/kernel/.build/deepseek-harness-dsh-v0.1.2-alpha.1/packages/example/src/base.css.mjs',
       'const value = 1;',
     ].join('\n'));
     assert.equal(sanitizeLinuxClientBuildPaths(join(temp, 'node_modules')), 1);
@@ -60,6 +61,7 @@ test('Linux staging excludes the kernel build tree and removes client build path
     assert.doesNotMatch(sanitized, /\/home\/runner/);
     assert.doesNotMatch(sanitized, /D:\\build/);
     assert.match(sanitized, /\\0dsh-css:deepseek-harness-dsh-v0\.1\.2-alpha\.1\/packages\/example/);
+    assert.match(sanitized, /\\0dsh-inline-css:deepseek-harness-dsh-v0\.1\.2-alpha\.1\/packages\/example/);
     assert.equal(sanitizeLinuxClientBuildPaths(join(temp, 'node_modules')), 0);
   } finally {
     rmSync(temp, { recursive: true, force: true });

--- a/dsh-desktop/test/linux-release-boot.test.ts
+++ b/dsh-desktop/test/linux-release-boot.test.ts
@@ -1,8 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  copyKernelCacheForTarget,
+  sanitizeLinuxClientBuildPaths,
+} from '../../tauri-shell/stage-linux-sanitize.mjs';
 
 const root = fileURLToPath(new URL('../..', import.meta.url));
 const shell = readFileSync(join(root, 'tauri-shell', 'src', 'main.rs'), 'utf8');
@@ -28,6 +33,37 @@ test('rescue integration resolves both source and packaged sidecar layouts', () 
 
 test('Linux releases rebuild the kernel cache from a clean checkout', () => {
   assert.match(linuxRelease, /准备内核依赖缓存[\s\S]*pnpm@11\.7\.0[\s\S]*fetch-kernel\.js/);
+});
+
+test('Linux staging excludes the kernel build tree and removes client build paths', () => {
+  const temp = mkdtempSync(join(tmpdir(), 'dsh-linux-stage-'));
+  try {
+    const kernel = join(temp, 'kernel');
+    const stagedKernel = join(temp, 'staged-kernel');
+    mkdirSync(join(kernel, '.build'), { recursive: true });
+    mkdirSync(join(kernel, '0.1.2-alpha.1'), { recursive: true });
+    writeFileSync(join(kernel, '.build', 'source.txt'), 'must not ship');
+    writeFileSync(join(kernel, '0.1.2-alpha.1', 'package.tgz'), 'tarball');
+    copyKernelCacheForTarget(kernel, stagedKernel, 'linux');
+    assert.equal(existsSync(join(stagedKernel, '.build')), false);
+    assert.equal(existsSync(join(stagedKernel, '0.1.2-alpha.1', 'package.tgz')), true);
+
+    const client = join(temp, 'node_modules', '@deepseek-ai', 'example', 'lib', 'client.js');
+    mkdirSync(join(temp, 'node_modules', '@deepseek-ai', 'example', 'lib'), { recursive: true });
+    writeFileSync(client, [
+      '//#region \\0dsh-css:/home/runner/work/repo/dsh-desktop/vendor/kernel/.build/deepseek-harness-dsh-v0.1.2-alpha.1/packages/example/src/client.css.mjs',
+      '//#region \\0dsh-css:D:\\build\\dsh-desktop\\vendor\\kernel\\.build\\deepseek-harness-dsh-v0.1.2-alpha.1\\packages\\example\\src\\client.css.mjs',
+      'const value = 1;',
+    ].join('\n'));
+    assert.equal(sanitizeLinuxClientBuildPaths(join(temp, 'node_modules')), 1);
+    const sanitized = readFileSync(client, 'utf8');
+    assert.doesNotMatch(sanitized, /\/home\/runner/);
+    assert.doesNotMatch(sanitized, /D:\\build/);
+    assert.match(sanitized, /\\0dsh-css:deepseek-harness-dsh-v0\.1\.2-alpha\.1\/packages\/example/);
+    assert.equal(sanitizeLinuxClientBuildPaths(join(temp, 'node_modules')), 0);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
 });
 
 test('client modules preserve the distinct Node 22 and Node 24 resolver signatures', async () => {

--- a/dsh-desktop/test/linux-release-boot.test.ts
+++ b/dsh-desktop/test/linux-release-boot.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+const shell = readFileSync(join(root, 'tauri-shell', 'src', 'main.rs'), 'utf8');
+const rescue = readFileSync(join(root, 'tauri-shell', 'sidecar', 'rescue-integration.ts'), 'utf8');
+const patchDeps = readFileSync(join(root, 'dsh-desktop', 'scripts', 'patch-deps.ts'), 'utf8');
+const release = readFileSync(join(root, '.github', 'workflows', 'release-tauri.yml'), 'utf8');
+const linuxRelease = release.split('release-tauri-linux:')[1] || '';
+
+test('Tauri setup initializes the packaged resource root before spawning the sidecar', () => {
+  assert.match(shell, /app\.path\(\)\.resource_dir\(\)/);
+  const setup = shell.indexOf('.setup(move |app|');
+  const initialize = shell.indexOf('initialize_packaged_resource_root(app)', setup);
+  const spawn = shell.indexOf('Sidecar::spawn().await', setup);
+  assert.ok(setup >= 0 && initialize > setup && spawn > initialize,
+    'resource_dir must be initialized before the packaged sidecar starts');
+});
+
+test('rescue integration resolves both source and packaged sidecar layouts', () => {
+  assert.match(rescue, /path\.resolve\(sidecarDir, '\.\.', '\.\.', 'dsh-desktop'\)/);
+  assert.match(rescue, /path\.resolve\(sidecarDir, '\.\.', 'dsh-desktop'\)/);
+  assert.match(rescue, /resolveDesktopRoot\(\)/);
+});
+
+test('Linux releases rebuild the kernel cache from a clean checkout', () => {
+  assert.match(linuxRelease, /准备内核依赖缓存[\s\S]*pnpm@11\.7\.0[\s\S]*fetch-kernel\.js/);
+});
+
+test('client modules preserve the distinct Node 22 and Node 24 resolver signatures', async () => {
+  assert.match(patchDeps, /internal\.version === "v2" \? internal\.resolveSync\(baseUrl, \{/);
+  const installed = readFileSync(
+    join(root, 'dsh-desktop', 'node_modules', '@deepseek-ai', 'dsh-client-modules', 'lib', 'index.js'),
+    'utf8',
+  );
+  assert.match(installed, /internal\.version === "v2" \? internal\.resolveSync\(baseUrl, \{/);
+  assert.match(installed, /specifier: loaderName/);
+
+  const loaderPackage = await import('@deepseek-ai/cordis-plugin-loader') as unknown as {
+    ModuleLoader: {
+      fromInternal(): {
+        version: 'v1' | 'v2';
+        resolveSync(...args: unknown[]): { url: string };
+      } | undefined;
+    };
+  };
+  const loader = loaderPackage.ModuleLoader.fromInternal();
+  assert.ok(loader, `Node ${process.version} must expose the internal module resolver`);
+  const parentUrl = pathToFileURL(join(root, 'dsh-desktop', 'package.json')).href;
+  const specifier = '@deepseek-ai/dsh-client-modules';
+  const resolved = loader.version === 'v2'
+    ? loader.resolveSync(parentUrl, { specifier, attributes: {} })
+    : loader.resolveSync(specifier, parentUrl, {});
+  assert.match(resolved.url, /dsh-client-modules/);
+});

--- a/tauri-shell/sidecar/rescue-integration.ts
+++ b/tauri-shell/sidecar/rescue-integration.ts
@@ -27,9 +27,16 @@ type RescueFn = (...a: unknown[]) => unknown;
 const ra = (): Record<string, RescueFn> => rescueAgent as Record<string, RescueFn>;
 
 let H!: RescueHost;
+export function resolveDesktopRoot(sidecarDir = __dirname): string {
+  const upTwo = path.resolve(sidecarDir, '..', '..', 'dsh-desktop');
+  if (fs.existsSync(path.join(upTwo, 'package.json'))) return upTwo;
+  const upOne = path.resolve(sidecarDir, '..', 'dsh-desktop');
+  if (fs.existsSync(path.join(upOne, 'package.json'))) return upOne;
+  return upTwo;
+}
 const DSH_DESKTOP_ROOT = process.env.DSH_RESOURCE_ROOT
   ? path.join(process.env.DSH_RESOURCE_ROOT, 'dsh-desktop')
-  : path.resolve(__dirname, '..', '..', 'dsh-desktop');
+  : resolveDesktopRoot();
 const rescueAgent: Record<string, unknown> = require(path.join(DSH_DESKTOP_ROOT, 'rescue-agent.js')) as Record<string, unknown>;
 const atomicJson = require(path.join(DSH_DESKTOP_ROOT, 'lib', 'atomic-json.js')) as {
   writeJsonAtomic(file: string, value: unknown): void;

--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -33,7 +33,7 @@
 //   其余 → sidecar（chrome.init / service.restart / boot.* / P3 渐进收编面）。
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
@@ -57,6 +57,7 @@ static CHINESE_UI: OnceLock<bool> = OnceLock::new();
 // 页面侧注入的 __DSH_BRIDGE_WS__ 恒为 ws_port()；ws-jsonrpc-client.js 里的
 // 19873 仅为无注入环境的兜底默认值，不与本机制耦合。
 static WS_PORT_EFFECTIVE: AtomicU16 = AtomicU16::new(WS_PORT);
+static PACKAGED_RESOURCE_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
 fn ws_port() -> u16 {
     WS_PORT_EFFECTIVE.load(Ordering::SeqCst)
@@ -111,11 +112,29 @@ mod ui_language_tests {
     }
 }
 
+fn is_resource_root(path: &Path) -> bool {
+    path.join("sidecar").join("server.js").is_file() && path.join("dsh-desktop").is_dir()
+}
+
+fn initialize_packaged_resource_root(app: &tauri::App) {
+    use tauri::Manager;
+    if let Ok(root) = app.path().resource_dir() {
+        if is_resource_root(&root) {
+            let _ = PACKAGED_RESOURCE_ROOT.set(root);
+        }
+    }
+}
+
 /// 打包态与开发态（CARGO_MANIFEST_DIR 布局）的资源根。
 /// 实测（R6 Stage 1）：Tauri v2 resources map 目标相对安装根，NSIS 装出
 /// exe 同级 sidecar/ + dsh-desktop/ 兄弟目录；exe 同级直认优先，
 /// 兼容保留 resources/ 子目录布局探测，最后回退开发布局。
 fn resource_root() -> std::path::PathBuf {
+    // Linux deb/AppImage 把资源放在 usr/lib/<product>/，不与 usr/bin 下的
+    // 可执行文件同级。setup 阶段由 Tauri path resolver 注入真实目录。
+    if let Some(root) = PACKAGED_RESOURCE_ROOT.get() {
+        return root.clone();
+    }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent().map(|p| p.to_path_buf()) {
             if dir.join("sidecar").join("server.js").exists() {
@@ -2289,6 +2308,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![shell_ping, sidecar_call])
         .setup(move |app| {
             use tauri::Manager;
+
+            initialize_packaged_resource_root(app);
 
             BRIDGE_ONCE.call_once(|| {
                 let st = BridgeState {

--- a/tauri-shell/stage-linux-sanitize.mjs
+++ b/tauri-shell/stage-linux-sanitize.mjs
@@ -1,0 +1,34 @@
+import { cpSync, existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const CLIENT_CSS_REGION_BUILD_PATH =
+  /(^[ \t]*\/\/#region \\0dsh-css:)(?:[A-Za-z]:)?[^\r\n]*?[\\/](deepseek-harness-[^\\/\r\n]+)[\\/](.+)$/gm;
+
+export function copyKernelCacheForTarget(source, destination, targetPlatform) {
+  const buildTree = path.resolve(source, '.build');
+  cpSync(source, destination, {
+    recursive: true,
+    filter: (entry) => targetPlatform !== 'linux' || path.resolve(entry) !== buildTree,
+  });
+}
+
+export function sanitizeLinuxClientBuildPaths(nodeModules) {
+  const scope = path.join(nodeModules, '@deepseek-ai');
+  if (!existsSync(scope)) return 0;
+
+  let changed = 0;
+  for (const packageName of readdirSync(scope)) {
+    const file = path.join(scope, packageName, 'lib', 'client.js');
+    if (!existsSync(file) || !statSync(file).isFile()) continue;
+    const source = readFileSync(file, 'utf8');
+    const sanitized = source.replace(
+      CLIENT_CSS_REGION_BUILD_PATH,
+      (_match, prefix, kernelPackage, relativePath) =>
+        `${prefix}${kernelPackage}/${relativePath.replaceAll('\\', '/')}`,
+    );
+    if (sanitized === source) continue;
+    writeFileSync(file, sanitized);
+    changed += 1;
+  }
+  return changed;
+}

--- a/tauri-shell/stage-linux-sanitize.mjs
+++ b/tauri-shell/stage-linux-sanitize.mjs
@@ -2,7 +2,7 @@ import { cpSync, existsSync, readFileSync, readdirSync, statSync, writeFileSync 
 import path from 'node:path';
 
 const CLIENT_CSS_REGION_BUILD_PATH =
-  /(^[ \t]*\/\/#region \\0dsh-css:)(?:[A-Za-z]:)?[^\r\n]*?[\\/](deepseek-harness-[^\\/\r\n]+)[\\/](.+)$/gm;
+  /(^[ \t]*\/\/#region \\0dsh-(?:inline-)?css:)(?:[A-Za-z]:)?[^\r\n]*?[\\/](deepseek-harness-[^\\/\r\n]+)[\\/](.+)$/gm;
 
 export function copyKernelCacheForTarget(source, destination, targetPlatform) {
   const buildTree = path.resolve(source, '.build');

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -14,6 +14,7 @@ import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { canReuseStagedNodeModules, writeStagedPlatformStamp } from './stage-platform-cache.mjs';
+import { copyKernelCacheForTarget, sanitizeLinuxClientBuildPaths } from './stage-linux-sanitize.mjs';
 import { pruneDarwinPayloads, pruneNonDarwinPrebuilds } from './stage-platform-prune.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -306,7 +307,11 @@ if (existsSync(npmCache)) {
 // npm ci 需要这些 tarball 就位才能解析；8MB 级，直接整目录拷贝。
 const kernelCache = path.join(dd, 'vendor', 'kernel');
 if (existsSync(kernelCache)) {
-  cpSync(kernelCache, path.join(staged, 'dsh-desktop', 'vendor', 'kernel'), { recursive: true });
+  copyKernelCacheForTarget(
+    kernelCache,
+    path.join(staged, 'dsh-desktop', 'vendor', 'kernel'),
+    targetPlatform,
+  );
   console.log('[stage] vendor/kernel 内核 tarball 缓存已拷贝（package.json file: 依赖解析用）');
 } else {
   throw new Error('[stage] vendor/kernel 缺失：先运行 npm run fetch-kernel 重建内核缓存');
@@ -331,6 +336,8 @@ if (targetPlatform === 'linux') {
     path.join(nmDest, '@koromix', 'koffi-linux-x64', 'musl_x64'),
     { recursive: true, force: true },
   );
+  const sanitizedClients = sanitizeLinuxClientBuildPaths(nmDest);
+  console.log(`[stage] 已清理 ${sanitizedClients} 个内核 client bundle 的构建机路径`);
 }
 if (targetPlatform === 'darwin') {
   console.log('[stage] 移除 Darwin 不可达的 Windows/Linux payload');

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -336,8 +336,6 @@ if (targetPlatform === 'linux') {
     path.join(nmDest, '@koromix', 'koffi-linux-x64', 'musl_x64'),
     { recursive: true, force: true },
   );
-  const sanitizedClients = sanitizeLinuxClientBuildPaths(nmDest);
-  console.log(`[stage] 已清理 ${sanitizedClients} 个内核 client bundle 的构建机路径`);
 }
 if (targetPlatform === 'darwin') {
   console.log('[stage] 移除 Darwin 不可达的 Windows/Linux payload');
@@ -372,6 +370,11 @@ const vendoredBashFix = path.join(dd, 'node_modules', '@deepseek-ai', 'dsh-tool-
 if (existsSync(vendoredBashFix)) {
   cpSync(vendoredBashFix, path.join(nmDest, '@deepseek-ai', 'dsh-tool-bash', 'lib', 'index.js'));
   console.log('[stage] 已回填 dsh-tool-bash 的 vendored 修复');
+}
+
+if (targetPlatform === 'linux') {
+  const sanitizedClients = sanitizeLinuxClientBuildPaths(nmDest);
+  console.log(`[stage] 已清理 ${sanitizedClients} 个内核 client bundle 的构建机路径`);
 }
 
 // 捆绑依赖完整性清单（issue #7）：对**最终载荷**（npm ci + 补丁 + vendored


### PR DESCRIPTION
## 目的

修复 Issue #266 中 v5.3.1 Linux `.deb` / AppImage 无法正常启动的问题，并修复首次 PR CI 暴露的 Linux bundle 构建机路径泄漏。合并后，Linux 发布包可以从 Tauri 实际资源目录启动 sidecar，正确加载 packaged rescue 模块和 Node 24 客户端模块图，且不再携带内核 `.build` 源树或本地构建根。

启动失败的根因不是 Node 24 本身，而是旧版 `patch-deps` 把上游针对 Node 22/v1 与 Node 24/v2 的两套 `resolveSync` 调用错误合并，导致 Node 24 解析包名失败，异常被上层吞掉后生成空 boot graph。

首次 PR CI 的 bundle audit 失败则来自两个装配问题：`vendor/kernel` 被整目录复制，导致 `.build` 源树进入发行包；部分 `@deepseek-ai/*/lib/client.js` 的 `//#region` 调试注释保留了构建机绝对路径。

Closes #266

## 架构与范围

- L1 / Tauri 壳：在 `.setup()` 阶段通过 `app.path().resource_dir()` 初始化打包资源根，并保证早于 `Sidecar::spawn()`。
- L2 / sidecar rescue：同时解析源码布局 `../../dsh-desktop` 与 Linux 打包布局 `../dsh-desktop`。
- 受控依赖补丁：恢复 `dsh-client-modules` 上游正确的 Node 22/v1、Node 24/v2 分支；正确安装树保持不变，旧错误补丁产生的两种形态可幂等修复。
- Linux 发布链：仅在 `release-tauri-linux` job 中于 `npm ci` 前复用主线现有 pnpm + `fetch-kernel.js` 流程。
- Linux 资源装配：复制内核 tarball 缓存时排除仅供构建使用的 `.build`；对 staged `client.js` 只移除 CSS region 注释中的构建机根并统一路径分隔符，不修改运行时代码，也不放宽 bundle audit。
- 测试：增加 Linux 发布启动与装配回归，覆盖资源初始化顺序、双布局、干净 checkout 内核准备、Node 24 真实解析器调用、`.build` 排除、POSIX/Windows 构建路径清理和幂等性。

不修改 Windows release job、产品版本号、用户 profile、凭据格式或公开 bridge API。

## 风险与兼容

- `PACKAGED_RESOURCE_ROOT` 仅在 Tauri 返回的目录同时包含 `sidecar/server.js` 与 `dsh-desktop/` 时设置；Windows 和开发态原有 exe 同级、`resources/`、源码布局回退保持不变。
- rescue 的原源码布局优先级保持不变，只在其不存在时尝试 Linux packaged 布局。
- 依赖补丁只匹配已知错误签名；上游正确签名直接跳过，未知上游变化不会被盲目改写。
- `.build` 排除仅在 Linux target 生效；非 Linux 复制行为保持不变。路径清理仅匹配 `//#region \\0dsh-css:` / `dsh-inline-css:` 的已知绝对路径形态，且可重复执行。
- 不涉及用户数据或配置迁移。
- 正式发布 workflow 仍需在发布时人工观察，不由本 PR 自动触发发布。

## 验证

实际执行：

- `npm --prefix dsh-desktop test`
  - 748 passed，0 failed，5 skipped（753 tests）。
- `node dsh-desktop/scripts/test-runner.js test/linux-release-boot.test.ts --test-timeout=120000 --test-force-exit`
  - 5 passed，0 failed；使用包内 Node 24，真实调用内部 v2 resolver，并覆盖 Linux staging 清理。
- `node --check tauri-shell/stage-linux-sanitize.mjs`
  - 通过。
- `cargo test --manifest-path tauri-shell/Cargo.toml`
  - 3 passed，0 failed。
- `npx -y @tauri-apps/cli@2 build --bundles deb,appimage --ci`（Ubuntu 22.04 WSL）
  - 成功生成 `.deb` 与 AppImage。
- 对最终解包树运行 `audit-linux-bundle.mjs`
  - `.deb`：33,925 files，6 native，glibc <= 2.35。
  - AppImage：34,157 files，6 native，glibc <= 2.35。
- AppImage 隔离 HOME/DSH_HOME 启动 smoke
  - 观察到 `sidecar ready`、`boot.start ok`、`web-ready`；结束后确认无残留进程。
- `git diff --check`
  - 通过。
- PR CI run [`33401623396`](https://github.com/zouyuxuan122/DSH-Desktop-EAC/actions/runs/33401623396)
  - Ubuntu 22.04 x64：通过（13m6s），包含 Linux 运行树装配、严格 bundle audit、Tauri 构建和最终产物审计。
  - Windows x64：通过（4m49s）。

- [x] Skill 推荐的最低验证级别已完成
- [x] `git diff --check` 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] UI 无变化，无需截图或录屏
- [x] 未验证项已明确列出

未验证项：真实 `.deb` 未执行系统级安装，仅完成最终安装树解包审计和 AppImage 隔离环境启动 smoke。

## 配置与迁移

无。不会修改 `DSH_HOME`、profile、credentials、preset 或现有安装数据。

## 回退方式

若合并后出现回归，可 revert 本 PR，恢复原有资源定位、rescue 路径、依赖补丁和资源装配行为。回退不需要处理用户数据或配置。
