### PR TITLE
fix(sidebar): better-sidebar 默认不自动展开，恢复时保留宿主侧栏宽度

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client-registry.js
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client-registry.js
@@ -10,7 +10,7 @@ window.__ModuleLoader__.load({
 		let react_jsx_runtime = require("react/jsx-runtime");
 		/** Fallback prefs used whenever the settings document is unreachable or malformed. */
 		const SIDEBAR_PREFS_DEFAULTS = {
-			openByDefault: true,
+			openByDefault: false,
 			defaultWidthPercent: 30,
 			autoOpenSubagent: true,
 			autoOpenJobs: true,
@@ -694,6 +694,11 @@ window.__ModuleLoader__.load({
 		function defaultWidthFor(viewport, percent) {
 			return Math.min(viewport, Math.max(280, Math.round(viewport * percent / 100)));
 		}
+		const HOST_SIDEBAR_AUTO_COLLAPSE = 1024;
+		/** Keep automatic restores from shrinking the host below its sidebar breakpoint. */
+		function canRestorePanel(viewport, panelWidth) {
+			return viewport - panelWidth >= HOST_SIDEBAR_AUTO_COLLAPSE;
+		}
 		function loadState(sessionId, prefs) {
 			try {
 				const raw = localStorage.getItem(`${STORAGE_PREFIX}:${sessionId}`);
@@ -705,7 +710,9 @@ window.__ModuleLoader__.load({
 				}
 			} catch {}
 			const viewport = typeof window !== "undefined" ? window.innerWidth : void 0;
-			return makeDefaultState(viewport === void 0 ? 400 : defaultWidthFor(viewport, prefs.defaultWidthPercent), prefs.openByDefault && (viewport === void 0 || !isNarrowWidth(viewport)), prefs.tabsEnabled["explorer"] !== false);
+			const width = viewport === void 0 ? 400 : defaultWidthFor(viewport, prefs.defaultWidthPercent);
+			const panelOpen = prefs.openByDefault && (viewport === void 0 || !isNarrowWidth(viewport) && canRestorePanel(viewport, width));
+			return makeDefaultState(width, panelOpen, prefs.tabsEnabled["explorer"] !== false);
 		}
 		/**
 		* Structural validation of one persisted state. A malformed or stale shape
@@ -740,9 +747,11 @@ window.__ModuleLoader__.load({
 				active: null
 			};
 			const maxWidth = typeof window !== "undefined" ? window.innerWidth : Infinity;
+			const width = Math.max(280, Math.min(record.width, maxWidth));
+			const viewport = typeof window !== "undefined" ? window.innerWidth : void 0;
 			return {
-				panelOpen: record.panelOpen,
-				width: Math.max(280, Math.min(record.width, maxWidth)),
+				panelOpen: record.panelOpen && (viewport === void 0 || canRestorePanel(viewport, width)),
+				width,
 				activePane: typeof record.activePane === "string" ? reid.get(record.activePane) ?? record.activePane : null,
 				nextTerminal: record.nextTerminal,
 				nextBrowser,

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/client.js
@@ -10,7 +10,7 @@ window.__ModuleLoader__.load({
 		let react_jsx_runtime = require("react/jsx-runtime");
 		/** Fallback prefs used whenever the settings document is unreachable or malformed. */
 		const SIDEBAR_PREFS_DEFAULTS = {
-			openByDefault: true,
+			openByDefault: false,
 			defaultWidthPercent: 30,
 			autoOpenSubagent: true,
 			autoOpenJobs: true,
@@ -694,6 +694,11 @@ window.__ModuleLoader__.load({
 		function defaultWidthFor(viewport, percent) {
 			return Math.min(viewport, Math.max(280, Math.round(viewport * percent / 100)));
 		}
+		const HOST_SIDEBAR_AUTO_COLLAPSE = 1024;
+		/** Keep automatic restores from shrinking the host below its sidebar breakpoint. */
+		function canRestorePanel(viewport, panelWidth) {
+			return viewport - panelWidth >= HOST_SIDEBAR_AUTO_COLLAPSE;
+		}
 		function loadState(sessionId, prefs) {
 			try {
 				const raw = localStorage.getItem(`${STORAGE_PREFIX}:${sessionId}`);
@@ -705,7 +710,9 @@ window.__ModuleLoader__.load({
 				}
 			} catch {}
 			const viewport = typeof window !== "undefined" ? window.innerWidth : void 0;
-			return makeDefaultState(viewport === void 0 ? 400 : defaultWidthFor(viewport, prefs.defaultWidthPercent), prefs.openByDefault && (viewport === void 0 || !isNarrowWidth(viewport)), prefs.tabsEnabled["explorer"] !== false);
+			const width = viewport === void 0 ? 400 : defaultWidthFor(viewport, prefs.defaultWidthPercent);
+			const panelOpen = prefs.openByDefault && (viewport === void 0 || !isNarrowWidth(viewport) && canRestorePanel(viewport, width));
+			return makeDefaultState(width, panelOpen, prefs.tabsEnabled["explorer"] !== false);
 		}
 		/**
 		* Structural validation of one persisted state. A malformed or stale shape
@@ -740,9 +747,11 @@ window.__ModuleLoader__.load({
 				active: null
 			};
 			const maxWidth = typeof window !== "undefined" ? window.innerWidth : Infinity;
+			const width = Math.max(280, Math.min(record.width, maxWidth));
+			const viewport = typeof window !== "undefined" ? window.innerWidth : void 0;
 			return {
-				panelOpen: record.panelOpen,
-				width: Math.max(280, Math.min(record.width, maxWidth)),
+				panelOpen: record.panelOpen && (viewport === void 0 || canRestorePanel(viewport, width)),
+				width,
 				activePane: typeof record.activePane === "string" ? reid.get(record.activePane) ?? record.activePane : null,
 				nextTerminal: record.nextTerminal,
 				nextBrowser,

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/index.js
@@ -54,7 +54,7 @@ function resolveSidebarConfig(config) {
 }
 /** Schemastery schema for the user-facing preferences (validated by the settings service). */
 const PrefsSchema = z.object({
-	openByDefault: z.boolean().default(true),
+	openByDefault: z.boolean().default(false),
 	defaultWidthPercent: z.number().step(1).min(20).max(60).default(30),
 	autoOpenSubagent: z.boolean().default(true),
 	autoOpenJobs: z.boolean().default(true),

--- a/dsh-desktop/test/better-sidebar-bundle.test.ts
+++ b/dsh-desktop/test/better-sidebar-bundle.test.ts
@@ -84,6 +84,24 @@ test('vendored plugin ships without TypeScript sources (installer size)', () => 
   assert.equal(existsSync(join(PLUGIN, 'src')), false, 'src/ must not ship in the installer');
 });
 
+test('automatic better-sidebar restores do not collapse the host sidebar', () => {
+  const serverSrc = readFileSync(join(PLUGIN, 'lib', 'index.js'), 'utf8');
+  assert.match(serverSrc, /openByDefault:\s*z\.boolean\(\)\.default\(false\)/,
+    'server preference schema must default openByDefault to false');
+
+  for (const entry of ['client.js', 'client-registry.js']) {
+    const src = readFileSync(join(PLUGIN, 'lib', entry), 'utf8');
+    assert.match(src, /const SIDEBAR_PREFS_DEFAULTS = \{\s*openByDefault:\s*false,/,
+      `${entry} fallback preferences must keep the sidebar closed`);
+    assert.match(src, /const HOST_SIDEBAR_AUTO_COLLAPSE = 1024;/,
+      `${entry} must track the host sidebar auto-collapse breakpoint`);
+    assert.match(src, /return viewport - panelWidth >= HOST_SIDEBAR_AUTO_COLLAPSE;/,
+      `${entry} must preserve enough width for the host layout`);
+    assert.match(src, /panelOpen: record\.panelOpen && \(viewport === void 0 \|\| canRestorePanel\(viewport, width\)\)/,
+      `${entry} must guard persisted open states during session switches`);
+  }
+});
+
 test('lazy client chunks fall back to the plugin resolver when the legacy module global is absent', () => {
   for (const entry of ['client.js', 'client-registry.js']) {
     const src = readFileSync(join(PLUGIN, 'lib', entry), 'utf8');


### PR DESCRIPTION
## 问题

better-sidebar 在切换会话/自动恢复时会把宿主左侧栏挤掉（窄屏下尤其明显）。

## 改动

- \openByDefault\ 默认改为 \alse\，侧栏不再默认自动展开
- 恢复持久化状态时校验宿主宽度：\iewport - panelWidth >= 1024\ 才恢复展开，否则保持收起
- 新增测试覆盖默认关闭与恢复宽度守卫

## 验证

- \
pm run typecheck\ 通过
- better-sidebar 9 个测试全过
- 开发壳冒烟正常