### PR TITLE
feat(plugin): 将 Archify 加入 EAC 推荐目录

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-unified-market/data/eac-recommended.json
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/data/eac-recommended.json
@@ -1,0 +1,19 @@
+{
+  "updated": "2026-09-01",
+  "plugins": [
+    {
+      "category": "skill",
+      "name": "Archify",
+      "url": "https://github.com/tt-a1i/archify",
+      "owner": "tt-a1i",
+      "description": {
+        "zh": "把代码仓库或系统描述生成经过校验的可交互架构图、工作流图、时序图、数据流图和生命周期图，并导出独立 HTML/SVG/PNG。",
+        "en": "Generate validated, interactive architecture, workflow, sequence, data-flow, and lifecycle diagrams from repositories or system descriptions, with standalone HTML/SVG/PNG export."
+      },
+      "install": "dsh plugin --profile web-desktop add @tt-a1i/archify-dsh@0.1.0",
+      "stars": null,
+      "added": "2026-09-01",
+      "eacRecommended": true
+    }
+  ]
+}

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/client.js
@@ -130,6 +130,7 @@ window.__ModuleLoader__.load({ id: 'dsh-unified-market', factory: (require) => {
       builtin: '已内置', builtinHint: '该插件已随客户端内置分发，每次启动自动同步，无需安装', stBuiltin: '内置插件',
       scanTitle: '安装前冲突预检', scanRun: '预检中…', scanWarn: '注意', scanRefuse: '已拒绝',
       scanForce: '勾选"跳过安全检查"可强制安装（风险自负）。',
+      eacRecommended: 'EAC 推荐',
       marketBanner: '统一插件市场（DSH Desktop 内置）：精选目录（awesome-dsh-plugin.com）+ GitHub dsh-plugin 生态 + npm 检索三源合一。安装走双保险（来源白名单 + 试装验证，可在「详情」查看说明）；「统一管理」提供 检查更新 / 自动更新开关（仅提示或自动升级）；市场自身随官方「内置插件更新」自更新。',
     },
     en: {
@@ -157,6 +158,7 @@ window.__ModuleLoader__.load({ id: 'dsh-unified-market', factory: (require) => {
       builtin: 'Built-in', builtinHint: 'Shipped with the client and re-synced on every launch — no install needed', stBuiltin: 'Built-in plugin',
       scanTitle: 'Pre-install conflict check', scanRun: 'Checking…', scanWarn: 'Note', scanRefuse: 'Refused',
       scanForce: 'Tick "skip safety checks" to force-install (at your own risk).',
+      eacRecommended: 'EAC recommended',
       marketBanner: 'Unified plugin market (bundled with DSH Desktop): curated catalog (awesome-dsh-plugin.com) + GitHub dsh-plugin ecosystem + npm registry in one place. Installs are double-gated (source whitelist + trial boot, see Details). The tool bar provides check updates / auto-update (notify or auto) / health scan / one-click repair. The market itself updates through the official built-in plugin updater.',
     },
   }
@@ -201,6 +203,7 @@ window.__ModuleLoader__.load({ id: 'dsh-unified-market', factory: (require) => {
 .mkts-main h3 a:hover{color:var(--dsw-static-deepseek-500)}
 .mkts-by{font-family:ui-monospace,monospace;font-size:11px;color:var(--dsw-alias-label-tertiary);margin-left:6px}
 .mkts-stars{font-family:ui-monospace,monospace;font-size:11px;color:var(--dsw-alias-label-tertiary);margin-left:6px}
+.mkts-rec{font-size:10px;color:var(--dsw-static-deepseek-500);border:1px solid color-mix(in srgb,var(--dsw-static-deepseek-500) 45%,transparent);border-radius:999px;padding:0 6px;margin-left:6px;white-space:nowrap}
 .mkts-gh{margin-left:8px;font-size:11px;color:var(--dsw-static-deepseek-500);text-decoration:none}
 .mkts-gh:hover{text-decoration:underline}
 .mkts-desc{margin:2px 0 0;color:var(--dsw-alias-label-secondary);font-size:12.5px;max-width:52em;overflow-wrap:break-word;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
@@ -829,6 +832,7 @@ window.__ModuleLoader__.load({ id: 'dsh-unified-market', factory: (require) => {
             h('div', { className: 'mkts-main' },
               h('h3', null,
                 h('a', { href: p.url, target: '_blank', rel: 'noopener noreferrer' }, p.name),
+                p.eacRecommended ? h('span', { className: 'mkts-rec' }, t('eacRecommended')) : null,
                 typeof p.stars === 'number' ? h('span', { className: 'mkts-stars' }, '★ ' + p.stars) : null,
                 p.by ? h('span', { className: 'mkts-by' }, '@' + p.by) : null,
                 h('a', { className: 'mkts-gh', href: p.url, target: '_blank', rel: 'noopener noreferrer' }, t('gh')),

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
@@ -753,6 +753,8 @@ function matchInstalledPackage(plugin, installedState) {
 const REGISTRY_URL = 'https://awesome-dsh-plugin.com/plugins.json'
 /** Static page fallback when the JSON API is unreachable. */
 const CATALOG_PAGE_URL = 'https://awesome-dsh-plugin.com/zh/'
+/** EAC-owned recommendations merged into every catalog source. */
+const EAC_RECOMMENDED_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'eac-recommended.json')
 
 function pickLang(lang) {
   return lang === 'en' ? 'en' : 'zh'
@@ -776,7 +778,80 @@ function fromRegistryPlugin(p, lang) {
     source: cc ? cc.source : null,
     stars: typeof p.stars === 'number' ? p.stars : null,
     added: p.added || null,
+    eacRecommended: p.eacRecommended === true,
   }
+}
+
+function pluginIdentityKeys(plugin) {
+  const keys = []
+  const repo = normalizeRepoUrl(plugin && plugin.url)
+  if (repo) keys.push('repo:' + repo)
+  const source = String((plugin && plugin.source) || '').trim().toLowerCase()
+  if (source) keys.push('source:' + source)
+  const name = String((plugin && plugin.name) || '').trim().toLowerCase()
+  if (name) keys.push('name:' + name)
+  return keys
+}
+
+function loadEacRecommendations(lang) {
+  try {
+    const data = JSON.parse(readFileSync(EAC_RECOMMENDED_PATH, 'utf8'))
+    const locale = pickLang(lang)
+    return Array.isArray(data.plugins) ? data.plugins.map((plugin) => fromRegistryPlugin(plugin, locale)) : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Put EAC recommendations first while retaining live metadata for duplicates.
+ * URL, install source, and display name are all treated as stable identities.
+ */
+function mergeRecommendedCatalog(catalog, lang) {
+  const recommended = loadEacRecommendations(lang)
+  if (recommended.length === 0) return catalog
+  const plugins = []
+  const identities = new Map()
+  const append = (plugin, preferred) => {
+    const keys = pluginIdentityKeys(plugin)
+    const duplicate = keys.map((key) => identities.get(key)).find((index) => index !== undefined)
+    if (duplicate !== undefined) {
+      const current = plugins[duplicate]
+      const winner = preferred ? plugin : current
+      const other = preferred ? current : plugin
+      plugins[duplicate] = {
+        ...other,
+        ...winner,
+        stars: winner.stars ?? other.stars ?? null,
+        added: winner.added ?? other.added ?? null,
+        eacRecommended: current.eacRecommended === true || plugin.eacRecommended === true,
+      }
+      for (const key of keys) identities.set(key, duplicate)
+      return
+    }
+    const index = plugins.length
+    plugins.push(plugin)
+    for (const key of keys) identities.set(key, index)
+  }
+  for (const plugin of recommended) append(plugin, true)
+  for (const plugin of Array.isArray(catalog.plugins) ? catalog.plugins : []) append(plugin, false)
+
+  const labels = new Map((catalog.cats || []).filter((cat) => cat.id !== 'all').map((cat) => [cat.id, cat.label]))
+  const categoryOrder = [...labels.keys()]
+  for (const plugin of plugins) {
+    if (labels.has(plugin.cat)) continue
+    labels.set(plugin.cat, plugin.cat === 'skill' ? (pickLang(lang) === 'en' ? 'Skills' : '技能包') : plugin.cat)
+    categoryOrder.push(plugin.cat)
+  }
+  const cats = [
+    { id: 'all', label: pickLang(lang) === 'en' ? 'All' : '全部', count: plugins.length },
+    ...categoryOrder.map((id) => ({
+      id,
+      label: labels.get(id),
+      count: plugins.filter((plugin) => plugin.cat === id).length,
+    })),
+  ]
+  return { plugins, cats }
 }
 
 /** Derive the category chips (incl. the leading "all" chip) from the registry. */
@@ -819,7 +894,7 @@ async function loadCatalog(lang) {
     const r = await fetch(REGISTRY_URL, { redirect: 'follow', signal: AbortSignal.timeout(10000) })
     if (!r.ok) throw new Error('HTTP ' + r.status)
     const data = await r.json()
-    const parsed = registryToCatalog(data, locale)
+    const parsed = mergeRecommendedCatalog(registryToCatalog(data, locale), locale)
     if (parsed.plugins.length === 0) throw new Error('empty registry')
     catalogCache = { at: now, lang: locale, data: parsed }
     return { ...parsed, source: 'live' }
@@ -828,7 +903,7 @@ async function loadCatalog(lang) {
     try {
       const r = await fetch(CATALOG_PAGE_URL, { redirect: 'follow', signal: AbortSignal.timeout(10000) })
       if (!r.ok) throw new Error('HTTP ' + r.status)
-      const parsed = parseSite(await r.text())
+      const parsed = mergeRecommendedCatalog(parseSite(await r.text()), locale)
       if (parsed.plugins.length === 0) throw new Error('empty catalog')
       catalogCache = { at: now, lang: locale, data: parsed }
       return { ...parsed, source: 'live' }
@@ -836,8 +911,12 @@ async function loadCatalog(lang) {
       // 3) Bundled offline snapshot.
       try {
         const snap = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'catalog-snapshot.json'), 'utf8'))
-        if (Array.isArray(snap.plugins) && snap.plugins.length > 0) return { ...snap, source: 'snapshot' }
+        if (Array.isArray(snap.plugins) && snap.plugins.length > 0) {
+          return { ...mergeRecommendedCatalog(snap, locale), source: 'snapshot' }
+        }
       } catch {}
+      const local = mergeRecommendedCatalog({ plugins: [], cats: [] }, locale)
+      if (local.plugins.length > 0) return { ...local, source: 'recommended' }
       return { plugins: [], cats: [], source: 'none' }
     }
   }
@@ -1784,7 +1863,7 @@ async function loadPacksIndex() {
   return { packs: [], source: 'none' }
 }
 
-export { classifyPlugin, runProbe, whitelistSource, loadCatalog, parseSimplePatch, checkUpdates, parseSite, registryToCatalog, normalizeRepoUrl, readInstalledProvenance, matchInstalledPackage, resolveProfile, githubList, npmSearch, readZhIntro, selfUpdateCheck, autoUpdateState, setAutoUpdate, desktopProfile, resolveLinkedUpstream, fetchUpstreamVersion, findUpstreamByName, npmLatestInfo, linkedUpdateTarget } // test hooks; cordis only reads name/inject/apply
+export { classifyPlugin, runProbe, whitelistSource, loadCatalog, loadEacRecommendations, mergeRecommendedCatalog, parseSimplePatch, checkUpdates, parseSite, registryToCatalog, normalizeRepoUrl, readInstalledProvenance, matchInstalledPackage, resolveProfile, githubList, npmSearch, readZhIntro, selfUpdateCheck, autoUpdateState, setAutoUpdate, desktopProfile, resolveLinkedUpstream, fetchUpstreamVersion, findUpstreamByName, npmLatestInfo, linkedUpdateTarget } // test hooks; cordis only reads name/inject/apply
 
 export function apply(ctx) {
   const webServer = ctx.get('webServer')

--- a/dsh-desktop/test/market-recommended.test.ts
+++ b/dsh-desktop/test/market-recommended.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const host = await import('../assets/plugins/dsh-unified-market/lib/host.js');
+const { loadEacRecommendations, mergeRecommendedCatalog } = host;
+
+test('EAC recommended catalog exposes Archify for web-desktop with an exact version', () => {
+  const plugins = loadEacRecommendations('zh');
+  const archify = plugins.find((plugin) => plugin.name === 'Archify');
+
+  assert.ok(archify, 'Archify must be present in the EAC recommendation catalog');
+  assert.equal(archify.cat, 'skill');
+  assert.equal(archify.profile, 'web-desktop');
+  assert.equal(archify.source, '@tt-a1i/archify-dsh@0.1.0');
+  assert.equal(archify.eacRecommended, true);
+  assert.match(archify.desc, /架构图/);
+});
+
+test('EAC recommendations merge before remote entries and deduplicate by repository', () => {
+  const merged = mergeRecommendedCatalog({
+    plugins: [{
+      cat: 'skill',
+      name: 'archify-dsh',
+      url: 'https://github.com/tt-a1i/archify',
+      by: 'remote',
+      desc: 'remote copy',
+      cmd: 'dsh plugin --profile web add @tt-a1i/archify-dsh',
+      profile: 'web',
+      source: '@tt-a1i/archify-dsh',
+      stars: 123,
+      added: '2026-08-14',
+    }],
+    cats: [
+      { id: 'all', label: '全部', count: 1 },
+      { id: 'skill', label: '技能包', count: 1 },
+    ],
+  }, 'zh');
+
+  const archify = merged.plugins.filter((plugin) => plugin.url === 'https://github.com/tt-a1i/archify');
+  assert.equal(archify.length, 1, 'remote duplicates must not create a second Archify card');
+  assert.equal(archify[0].name, 'Archify', 'the EAC recommendation owns display and install metadata');
+  assert.equal(archify[0].profile, 'web-desktop');
+  assert.equal(archify[0].stars, 123, 'live metadata should be retained when available');
+  assert.equal(merged.cats.find((cat) => cat.id === 'skill')?.count, 1);
+  assert.equal(merged.cats[0].count, 1);
+});
+
+test('EAC recommendation descriptions follow the requested catalog locale', () => {
+  const archify = loadEacRecommendations('en').find((plugin) => plugin.name === 'Archify');
+  assert.ok(archify);
+  assert.match(archify.desc, /validated, interactive architecture/);
+});


### PR DESCRIPTION
## 目的

将 Archify 放入 `dsh-unified-market` 的 EAC 精选/推荐列表，方便用户发现并按需安装，但不默认安装或启用。

## 主要改动

- 新增 EAC 自有推荐目录 `data/eac-recommended.json`，登记 `Archify`。
- 安装命令固定为 `dsh plugin --profile web-desktop add @tt-a1i/archify-dsh@0.1.0`。
- 在线 JSON 目录、网页回退、离线快照和纯本地回退统一合并 EAC 推荐项。
- 按仓库 URL、安装 source 和名称去重；EAC 元数据优先，同时保留在线 `stars` 和 `added`。
- 市场卡片增加中英文 `EAC 推荐` 标签。
- 增加推荐目录、去重、实时元数据和语言回归测试。

## 兼容与风险

- 不修改默认插件集合、onboarding 选择或 profile 配置。
- 不会自动安装或启用 Archify。
- 在线目录不可用时仍可从本地推荐目录展示 Archify。
- 改动限于统一市场插件及其测试，不涉及 Rust、sidecar 或 bridge。

## 验证

- `npm run typecheck`：通过。
- `node --check assets/plugins/dsh-unified-market/lib/host.js`：通过。
- `node --check assets/plugins/dsh-unified-market/lib/client.js`：通过。
- 市场定向测试：8 项通过，0 失败。
- companion 复制与注册表测试：4 项通过，0 失败。
- `npm test`：757 项，753 通过，4 项按平台跳过，0 失败。
- `npm pack --dry-run --json`：确认包含 `data/eac-recommended.json`。

## 未验证项

- 未附运行时 UI 截图。
- `stage-resources.mjs` 装配冒烟因开发机 Windows 会话资源不足被中断；全量测试与 npm 打包文件清单均已通过。

## 回退

回退本 PR 提交即可移除 EAC 推荐覆盖层，不影响用户已安装插件和 profile 数据。