### PR TITLE
fix(plugin): 修复人设卡组合与卡片管理

### DIFF
--- a/dsh-desktop/.gitignore
+++ b/dsh-desktop/.gitignore
@@ -87,6 +87,7 @@ build/*
 /plugin-manager-state.js
 /profile-module-heal.js
 /compact-preset-migrate.js
+/router-persona-preset-migrate.js
 /session-watcher.js
 /patch-row-heal.js
 /shortcut-maintenance.js

--- a/dsh-desktop/assets/agent-presets/router-standard/router-core.mjs
+++ b/dsh-desktop/assets/agent-presets/router-standard/router-core.mjs
@@ -160,14 +160,20 @@ export function clamp01(v) {
   return Math.min(1, Math.max(0, Number(v) || 0))
 }
 
+const ROUTER_PERSONA_SECTIONS = new Set([
+  'persona',
+  'deployment:persona',
+  'router-persona',
+])
+
 /**
- * Replace only the persona section of an assembled section list, keeping
- * everything else — the plan-mode section above all, which is toggled per
- * plan state and carries the plan-boundary instructions.
+ * Replace only the preset-owned persona section of an assembled section
+ * list. Global contributors such as dsh-soul-md's `soul:persona` must remain
+ * so a user persona card can compose with the router guidance.
  */
 export function applyPersona(sections, personaText) {
   const rest = (sections || []).filter(
-    (section) => section.name !== 'persona' && !/persona/i.test(section.name),
+    (section) => !ROUTER_PERSONA_SECTIONS.has(section.name),
   )
   return [...rest, { name: 'router-persona', text: personaText, order: 0 }]
 }

--- a/dsh-desktop/assets/agent-presets/v4-flash-godmode-opencode-go/router-core.mjs
+++ b/dsh-desktop/assets/agent-presets/v4-flash-godmode-opencode-go/router-core.mjs
@@ -108,10 +108,19 @@ export function sessionMode(session) {
   return classifyTask(extractText(userMsg?.data))
 }
 
-/** Replace only the persona section, keeping everything else（plan-mode 等）。 */
+const ROUTER_PERSONA_SECTIONS = new Set([
+  'persona',
+  'deployment:persona',
+  'router-persona',
+])
+
+/**
+ * Replace only the preset-owned persona section. Global contributors such as
+ * dsh-soul-md's `soul:persona` stay in the assembled prompt.
+ */
 export function applyPersona(sections, personaText) {
   const rest = (sections || []).filter(
-    (section) => section.name !== 'persona' && !/persona/i.test(section.name),
+    (section) => !ROUTER_PERSONA_SECTIONS.has(section.name),
   )
   return [...rest, { name: 'router-persona', text: personaText, order: 0 }]
 }

--- a/dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-easy-setup/lib/client.js
@@ -46,6 +46,8 @@ window.__ModuleLoader__.load({
       ".__es_details summary{cursor:pointer;color:var(--dsw-alias-label-secondary)}" +
       ".__es_prompt{white-space:pre-wrap;font-family:var(--dsw-alias-font-mono,monospace);font-size:11px;line-height:1.5;max-height:240px;overflow:auto;border:1px solid var(--dsw-alias-border-l2);border-radius:8px;padding:8px 10px;background:var(--dsw-alias-bg-layer-2)}" +
       ".__es_cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:8px}" +
+      ".__es_cardLibrary{display:flex;flex-direction:column;gap:8px;margin:4px 0 8px}" +
+      ".__es_cardLibrary .__es_cards{gap:10px}" +
       ".__es_card{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:8px 10px;background:var(--dsw-alias-bg-layer-3);display:flex;flex-direction:column;gap:4px}" +
       ".__es_cardMine{border-style:dashed}" +
       ".__es_cardname{font-size:13px;font-weight:600}" +
@@ -166,7 +168,10 @@ window.__ModuleLoader__.load({
       descriptors: [
         descriptor("readPersona", []),
         descriptor("writePersona", ["content"]),
-        descriptor("migrationPrompt", [])
+        descriptor("migrationPrompt", []),
+        descriptor("listCards", []),
+        descriptor("saveCard", ["name", "content"]),
+        descriptor("deleteCard", ["name"])
       ]
     };
 
@@ -445,7 +450,7 @@ window.__ModuleLoader__.load({
             );
           })
         ),
-        cards.length ? h("div", null,
+        cards.length ? h("div", { className: "__es_cardLibrary" },
           h("div", { className: "__es_label" }, t("myCards")),
           h("div", { className: "__es_cards" }, cards.map(function (c) {
             return h("div", { className: "__es_card __es_cardMine", key: c.file },
@@ -477,7 +482,7 @@ window.__ModuleLoader__.load({
           h("button", { className: "__es_btn __es_btnPrimary", disabled: busy === "saving" || braces || draft === data.content, onClick: onSave }, busy === "saving" ? t("saving") : t("save")),
           braces ? h("span", { className: "__es_error" }, t("personaBraceWarn")) : null,
           busy === "saved" ? h("span", { className: "__es_ok" }, t("saved")) : null,
-          typeof busy === "string" && busy.indexOf("saved:") === 0 ? h("span", { className: "__es_ok" }, t("cardApplied") + "：" + busy.slice(7)) : null,
+          typeof busy === "string" && busy.indexOf("saved:") === 0 ? h("span", { className: "__es_ok" }, t("cardApplied") + "：" + busy.slice("saved:".length)) : null,
           typeof busy === "string" && busy.indexOf("error:") === 0 ? h("span", { className: "__es_error" }, t("saveFail") + ": " + busy.slice(6)) : null
         ),
         h("div", { className: "__es_actions" },

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -46,6 +46,13 @@ const { syncBundledPresets, ensureDefaultAgentPreset } = require('../../preset-s
 const { migrateManagedCompactPresets } = require('../../compact-preset-migrate') as {
   migrateManagedCompactPresets(dir: string, log: (m: string) => void): { status: string; file: string }[];
 };
+const { migrateManagedRouterPersonaPresets } = require('../../router-persona-preset-migrate') as {
+  migrateManagedRouterPersonaPresets(
+    assetsDir: string,
+    presetsDir: string,
+    log: (m: string) => void,
+  ): { status: string; file: string }[];
+};
 const { hasEntryId, removePluginFromPatch } = require('../../scripts/plugin-manager-patch') as {
   hasEntryId(patch: string, id: string): boolean;
   removePluginFromPatch(text: string, id: string): string;
@@ -550,14 +557,16 @@ export function syncCompanionPlugins(): void {
     // preset 不进插件树，坏 preset 不会拖垮启动；已存在则跳过（用户手装
     // 或改过的版本优先），见 preset-sync.js。
     if (platform === 'win32') {
+      const bundledPresetsDir = path.join(APP_ROOT, 'assets', 'agent-presets');
+      const installedPresetsDir = path.join(home, '.agent-presets');
       const presetsSynced = syncBundledPresets(
-        path.join(APP_ROOT, 'assets', 'agent-presets'),
-        path.join(home, '.agent-presets'),
+        bundledPresetsDir,
+        installedPresetsDir,
         (m) => ctx.log('boot', m)
       );
       if (presetsSynced.installed.length) ctx.log('boot', '已安装内置 agent preset: ' + presetsSynced.installed.join(', '));
       const compactPresetResults = migrateManagedCompactPresets(
-        path.join(home, '.agent-presets'),
+        installedPresetsDir,
         (m) => ctx.log('boot', m)
       );
       const compactPresetMigrated = compactPresetResults
@@ -565,6 +574,17 @@ export function syncCompanionPlugins(): void {
         .map((result) => path.basename(path.dirname(result.file)));
       if (compactPresetMigrated.length) {
         ctx.log('boot', '已将内置 agent preset 迁移到 dsh-compact: ' + compactPresetMigrated.join(', '));
+      }
+      const routerPersonaResults = migrateManagedRouterPersonaPresets(
+        bundledPresetsDir,
+        installedPresetsDir,
+        (m) => ctx.log('boot', m)
+      );
+      const routerPersonaMigrated = routerPersonaResults
+        .filter((result) => result.status === 'migrated')
+        .map((result) => path.basename(path.dirname(result.file)));
+      if (routerPersonaMigrated.length) {
+        ctx.log('boot', '已修复内置 Router preset 的人设卡组合: ' + routerPersonaMigrated.join(', '));
       }
       // 默认 preset 指到内置的 anchored-standard（用户已在 settings.yaml 写过
       // default 则一律保留）。失败只降级为官方默认 preset，不影响启动。

--- a/dsh-desktop/router-persona-preset-migrate.ts
+++ b/dsh-desktop/router-persona-preset-migrate.ts
@@ -1,0 +1,82 @@
+'use strict';
+
+import crypto = require('node:crypto');
+import fs = require('node:fs');
+import path = require('node:path');
+import { writeFileAtomic } from './lib/atomic-json';
+
+const MANAGED_ROUTER_PRESETS = Object.freeze([
+  'router-standard',
+  'v4-flash-godmode-opencode-go',
+]);
+
+const BUGGY_ROUTER_CORE_HASHES = Object.freeze<Record<string, string>>({
+  'router-standard': '6f91e7aaa6f43179adff43db86e4648fc89197fab1517c7d74f64dbc29b091a1',
+  'v4-flash-godmode-opencode-go': '0d03a662f3f52608ae1fe55baf183fdf1926fcc45b472d8f169de9b3b90388bd',
+});
+
+interface MigrationResult {
+  status: 'missing' | 'kept' | 'customized' | 'migrated' | 'failed';
+  file: string;
+  backup?: string;
+  error?: string;
+}
+
+function normalizedSha256(text: string): string {
+  return crypto.createHash('sha256').update(text.replace(/\r\n/g, '\n')).digest('hex');
+}
+
+function migrateRouterCoreFile(
+  sourceFile: string,
+  installedFile: string,
+  buggyHash: string,
+  log: (message: string) => void = () => {},
+): MigrationResult {
+  let sourceText: string;
+  let installedText: string;
+  try {
+    sourceText = fs.readFileSync(sourceFile, 'utf8');
+    installedText = fs.readFileSync(installedFile, 'utf8');
+  } catch {
+    return { status: 'missing', file: installedFile };
+  }
+
+  if (normalizedSha256(installedText) === normalizedSha256(sourceText)) {
+    return { status: 'kept', file: installedFile };
+  }
+  if (normalizedSha256(installedText) !== buggyHash) {
+    return { status: 'customized', file: installedFile };
+  }
+
+  const backup = installedFile + '.persona-card-fix.bak';
+  try {
+    if (!fs.existsSync(backup)) fs.copyFileSync(installedFile, backup);
+    writeFileAtomic(installedFile, sourceText);
+    return { status: 'migrated', file: installedFile, backup };
+  } catch (error) {
+    const message = String(((error as Error) && (error as Error).message) || error);
+    log(`failed to migrate router persona preset: ${installedFile}: ${message}`);
+    return { status: 'failed', file: installedFile, error: message };
+  }
+}
+
+function migrateManagedRouterPersonaPresets(
+  assetsRoot: string,
+  presetsRoot: string,
+  log: (message: string) => void = () => {},
+): MigrationResult[] {
+  return MANAGED_ROUTER_PRESETS.map((name) => migrateRouterCoreFile(
+    path.join(assetsRoot, name, 'router-core.mjs'),
+    path.join(presetsRoot, name, 'router-core.mjs'),
+    BUGGY_ROUTER_CORE_HASHES[name]!,
+    log,
+  ));
+}
+
+export = {
+  BUGGY_ROUTER_CORE_HASHES,
+  MANAGED_ROUTER_PRESETS,
+  migrateManagedRouterPersonaPresets,
+  migrateRouterCoreFile,
+  normalizedSha256,
+};

--- a/dsh-desktop/test/easy-setup.test.ts
+++ b/dsh-desktop/test/easy-setup.test.ts
@@ -12,9 +12,39 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { resolvePersonaPath, buildMigrationPrompt } from '../assets/plugins/dsh-easy-setup/lib/logic.js';
 
 const HOME = 'C:/Users/tester/.dsh';
+const PLUGIN_DIR = join(import.meta.dirname, '..', 'assets', 'plugins', 'dsh-easy-setup', 'lib');
+
+test('persona card remote methods are declared by both host and client', () => {
+  const host = readFileSync(join(PLUGIN_DIR, 'index.js'), 'utf8');
+  const client = readFileSync(join(PLUGIN_DIR, 'client.js'), 'utf8');
+  const methods = [
+    ['readPersona', '[]'],
+    ['writePersona', '["content"]'],
+    ['migrationPrompt', '[]'],
+    ['listCards', '[]'],
+    ['saveCard', '["name", "content"]'],
+    ['deleteCard', '["name"]'],
+  ];
+
+  for (const [method, parameters] of methods) {
+    const declaration = `descriptor("${method}", ${parameters})`;
+    assert.ok(host.includes(declaration), `host missing ${method}`);
+    assert.ok(client.includes(declaration), `client missing ${method}`);
+  }
+});
+
+test('persona card apply feedback keeps the full card name and library spacing', () => {
+  const client = readFileSync(join(PLUGIN_DIR, 'client.js'), 'utf8');
+  assert.ok(client.includes('busy.slice("saved:".length)'), 'card name must not lose its first character');
+  assert.ok(client.includes('className: "__es_cardLibrary"'), 'custom cards need a dedicated layout group');
+  assert.match(client, /\.__es_cardLibrary\{[^}]*gap:8px[^}]*margin:4px 0 8px/);
+  assert.match(client, /\.__es_cardLibrary \.__es_cards\{gap:10px\}/);
+});
 
 // ── persona path resolution ─────────────────────────────────────────────
 

--- a/dsh-desktop/test/preset-sync.test.ts
+++ b/dsh-desktop/test/preset-sync.test.ts
@@ -239,7 +239,9 @@ test('内置 preset 仅携带 Windows shell 配置', () => {
   }
 });
 
-test('stage-resources ROOT_FILES 包含 preset-sync.js（否则新模块不进安装包）', () => {
+test('stage-resources ROOT_FILES 包含 preset 同步与迁移模块', () => {
   const stage = readFileSync(join(root, '..', 'tauri-shell', 'stage-resources.mjs'), 'utf8');
   assert.match(stage, /'preset-sync\.js'/);
+  assert.match(stage, /'compact-preset-migrate\.js'/);
+  assert.match(stage, /'router-persona-preset-migrate\.js'/);
 });

--- a/dsh-desktop/test/router-persona-preservation.test.ts
+++ b/dsh-desktop/test/router-persona-preservation.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const presets = [
+  'router-standard',
+  'v4-flash-godmode-opencode-go',
+];
+
+for (const preset of presets) {
+  test(`${preset} replaces its own persona without removing the user persona card`, async () => {
+    const moduleUrl = pathToFileURL(
+      join(root, 'assets', 'agent-presets', preset, 'router-core.mjs'),
+    ).href;
+    const { applyPersona } = await import(moduleUrl);
+    const soul = { name: 'soul:persona', text: 'Mocha persona', order: 0 };
+    const custom = { name: 'third-party:persona-notes', text: 'keep me', order: 1 };
+    const plan = { name: 'plan-mode', text: 'plan rules', order: 2 };
+
+    const result = applyPersona([
+      { name: 'persona', text: 'legacy persona', order: 0 },
+      { name: 'deployment:persona', text: 'deployment persona', order: 0 },
+      { name: 'router-persona', text: 'stale router persona', order: 0 },
+      soul,
+      custom,
+      plan,
+    ], 'fresh router persona');
+
+    assert.deepEqual(result, [
+      soul,
+      custom,
+      plan,
+      { name: 'router-persona', text: 'fresh router persona', order: 0 },
+    ]);
+  });
+}

--- a/dsh-desktop/test/router-persona-preset-migrate.test.ts
+++ b/dsh-desktop/test/router-persona-preset-migrate.test.ts
@@ -1,0 +1,76 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const {
+  migrateRouterCoreFile,
+  normalizedSha256,
+} = require(join(root, 'router-persona-preset-migrate.js'));
+
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-router-persona-migrate-'));
+  const source = join(dir, 'assets', 'router-core.mjs');
+  const installed = join(dir, 'installed', 'router-core.mjs');
+  mkdirSync(dirname(source), { recursive: true });
+  mkdirSync(dirname(installed), { recursive: true });
+  return { dir, source, installed };
+}
+
+test('router persona migration updates an untouched buggy preset and keeps a backup', () => {
+  const { dir, source, installed } = fixture();
+  try {
+    const buggy = "const keep = sections.filter((section) => !/persona/i.test(section.name))\n";
+    const fixed = "const keep = sections.filter((section) => section.name !== 'router-persona')\n";
+    writeFileSync(source, fixed);
+    writeFileSync(installed, buggy);
+
+    const result = migrateRouterCoreFile(source, installed, normalizedSha256(buggy));
+    assert.equal(result.status, 'migrated');
+    assert.equal(readFileSync(installed, 'utf8'), fixed);
+    assert.equal(readFileSync(installed + '.persona-card-fix.bak', 'utf8'), buggy);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('router persona migration never overwrites a customized preset', () => {
+  const { dir, source, installed } = fixture();
+  try {
+    writeFileSync(source, 'fixed official source\n');
+    writeFileSync(installed, 'user customized source\n');
+
+    const result = migrateRouterCoreFile(source, installed, normalizedSha256('old official source\n'));
+    assert.equal(result.status, 'customized');
+    assert.equal(readFileSync(installed, 'utf8'), 'user customized source\n');
+    assert.equal(existsSync(installed + '.persona-card-fix.bak'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('router persona migration is idempotent after the fixed source is installed', () => {
+  const { dir, source, installed } = fixture();
+  try {
+    writeFileSync(source, 'fixed source\n');
+    writeFileSync(installed, 'fixed source\r\n');
+
+    const result = migrateRouterCoreFile(source, installed, normalizedSha256('old source\n'));
+    assert.equal(result.status, 'kept');
+    assert.equal(existsSync(installed + '.persona-card-fix.bak'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -43,6 +43,7 @@ const ROOT_FILES = [
   'balance.js', 'session-watcher.js', 'profile-module-heal.js',
   'patch-row-heal.js', 'builtin-collision.js', 'plugin-manager-state.js', 'plugin-guard.js',
   'rescue-agent.js', 'preset-sync.js', 'compact-preset-migrate.js',
+  'router-persona-preset-migrate.js',
   'bundle-integrity.js', 'stable-port.js', 'stream-write-guard.js',
   'shortcut-maintenance.js',
   'host-bootstrap.js',


### PR DESCRIPTION
## 目的

修复人设卡与 Router preset 组合时配置被覆盖、卡片保存不可用，以及人设卡界面的名称截断和布局过密问题。

## 主要改动

- Router preset 不再删除 `dsh-soul-md` 的 `soul:persona` 配置。
- 为受影响的官方 Router preset 增加基于已知哈希的幂等迁移，只修复官方旧版本；用户自定义内容保持不变。
- 迁移前生成 `.persona-card-fix.bak` 备份，并把迁移模块加入 Tauri 资源清单。
- 补齐客户端远程服务的 `listCards`、`saveCard`、`deleteCard` 契约，修复“存为卡片”时报 `svc.saveCard is not a function`。
- 修复已应用人设卡名称少首字母的问题，例如 `uika` 不再显示为 `ika`。
- 调整“我的卡片库”标题、卡片列表和下方编辑区间距。

## 架构与兼容边界

- 改动位于内置插件、preset 同步/迁移和桌面资源清单。
- 迁移仅匹配已知官方旧文件哈希，不覆盖用户自建或已修改的 preset。
- 不改变现有 persona 文件目录和插件契约。

## 验证

- `npm run build`：通过。
- 人设卡相关定向测试：17/17 通过。
- 完整测试此前通过 769 项、跳过 4 项；一次 `session-manager-client.test.ts` 文件级瞬时失败，单独重跑后 4/4 通过。
- EAC 5.3.5 开发运行时验证：保存 `uika`、应用卡片、完整名称显示及卡片库间距均正常。

## 资源装配

按本轮要求未重复执行资源装配，避免再次生成约 1.5 GB 内容；现有装配产物未改动，也未纳入提交。

## 回退

回退本 PR 提交即可恢复代码行为；已迁移的官方 preset 可由 `.persona-card-fix.bak` 备份恢复。
