### PR TITLE
fix(plugin): 修复电脑操作设置保存与会话批准

### DIFF
--- a/dsh-desktop/assets/plugins/computer-user/src/index.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/index.js
@@ -79,14 +79,17 @@ export function toggleApproval(approvedSessions, targets) {
 export function apply(ctx, config) {
   // ── register tools ──
   ctx.effect(() => {
-    for (const tool of createComputerTools({ runPs, getConfig, approvedSessions, sessionId: undefined, setMode })) {
+    for (const tool of createComputerTools({ runPs, getConfig, approvedSessions, sessionIds: [], setMode })) {
       ctx.tools.register({
         ...tool,
-        // Wrap execute to inject the current session ID at call time
+        // Wrap execute to inject every session identity visible at call time.
         async execute(args, exec) {
-          const sid = exec?.agent?.session?.header?.sessionId ?? exec?.sessionId ?? '';
-          // Rebuild gate closure with the real session ID
-          const tools = createComputerTools({ runPs, getConfig, approvedSessions, sessionId: sid, setMode });
+          const sessionIds = [...new Set([
+            exec?.agent?.id,
+            exec?.agent?.session?.header?.sessionId,
+            exec?.sessionId,
+          ].filter(Boolean).map(String))];
+          const tools = createComputerTools({ runPs, getConfig, approvedSessions, sessionIds, setMode });
           const realTool = tools.find((t) => t.name === tool.name);
           return realTool.execute(args, exec);
         },
@@ -100,7 +103,7 @@ export function apply(ctx, config) {
       const settingsNs = settingsNamespace(NS);
       const scope = sctx.settings.register(settingsNs, Config, { base: config });
       sourceGetter = () => scope.get();
-      sourceSetter = (key, value) => scope.set(key, value);
+      sourceSetter = (key, value) => scope.update({ [key]: value });
       scope.watch(() => { /* trigger hot reload */ });
     });
   } catch (error) {

--- a/dsh-desktop/assets/plugins/computer-user/src/tools.js
+++ b/dsh-desktop/assets/plugins/computer-user/src/tools.js
@@ -8,7 +8,7 @@ import { randomBytes } from 'node:crypto';
  * `virtual_offset`). All screen-reading/automation is delegated to bundled
  * PowerShell scripts (capture.ps1 / input.ps1) with zero native dependencies.
  *
- * @param {{runPs:(script:string,payload:object,opts?:object)=>Promise<object>, getConfig:()=>object, approvedSessions?:Set<string>, sessionId?:string, setMode?:(mode:string)=>Promise<void>}} deps
+ * @param {{runPs:(script:string,payload:object,opts?:object)=>Promise<object>, getConfig:()=>object, approvedSessions?:Set<string>, sessionId?:string, sessionIds?:string[], setMode?:(mode:string)=>Promise<void>}} deps
  * @returns {Array<object>} tool definitions ready for ctx.tools.register
  */
 
@@ -39,7 +39,7 @@ const MODES = ['disabled', 'readonly', 'manual', 'auto'];
  * Returns void if allowed, or throws with `awaitingApproval=true` if
  * the user needs to approve via /computer first.
  */
-function modeGate(cfg, toolName, approvedSessions, sessionId) {
+function modeGate(cfg, toolName, approvedSessions, sessionIds) {
   const mode = cfg.mode ?? 'manual';
   if (mode === 'disabled') {
     throw new Error('computer-user 已禁用：请在「设置 → 电脑操作」切换模式后再使用');
@@ -48,7 +48,8 @@ function modeGate(cfg, toolName, approvedSessions, sessionId) {
     throw new Error(`computer-user 只读模式：${toolName} 不允许执行，仅截图/读光标/等待可用`);
   }
   if (mode === 'manual' && !READONLY_TOOLS.has(toolName)) {
-    const approved = sessionId && approvedSessions && approvedSessions.has(sessionId);
+    const ids = Array.isArray(sessionIds) ? sessionIds : sessionIds ? [sessionIds] : [];
+    const approved = approvedSessions && ids.some((id) => id && approvedSessions.has(id));
     if (!approved) {
       const e = new Error(
         '需要批准：当前为手动批准模式。请在对话框输入 /computer 批准后重试（批准后本轮及后续轮次均可使用）。'
@@ -91,11 +92,16 @@ function textOut(schema, prefixLines) {
   };
 }
 
-export function createComputerTools({ runPs, getConfig, approvedSessions, sessionId, setMode }) {
+export function createComputerTools({ runPs, getConfig, approvedSessions, sessionId, sessionIds, setMode }) {
   if (typeof runPs !== 'function') throw new Error('computer-user: runPs is required');
   if (typeof getConfig !== 'function') throw new Error('computer-user: getConfig is required');
 
-  const gate = (toolName) => modeGate(getConfig(), toolName, approvedSessions, sessionId);
+  const approvalIds = Array.isArray(sessionIds)
+    ? sessionIds
+    : sessionId
+      ? [sessionId]
+      : [];
+  const gate = (toolName) => modeGate(getConfig(), toolName, approvedSessions, approvalIds);
 
   // -- computer_screenshot ---------------------------------------------------
   const computerScreenshot = {

--- a/dsh-desktop/scripts/patch-deps.ts
+++ b/dsh-desktop/scripts/patch-deps.ts
@@ -116,6 +116,118 @@ function patchSettingsPanelResize(): void {
   console.log('[patch-deps] 已补丁 settings-general：弹窗宽度跟随主窗（≤1280px）+ 可拖拽拉伸');
 }
 
+// 设置写入失败传播补丁：上游 SettingsScopeController.mutate() 会把 Remote
+// 拒绝和传输异常恢复后直接 return，导致调用方 Promise resolve 并误报“已保存”。
+// 普通表单写入遇到 settings-conflict 时刷新镜像并重试一次；显式 revision fence
+// 不自动越过。最终失败必须 reject，让设置界面进入自己的错误提示分支。
+const SETTINGS_WRITE_MARKER = 'dsh-desktop-settings-write-retry';
+const SETTINGS_WRITE_TARGET = path.join(
+  root,
+  'node_modules',
+  '@deepseek-ai',
+  'dsh-client-ui-settings',
+  'lib',
+  'client.js',
+);
+const SETTINGS_WRITE_OLD = [
+  '\t\t\tmutate(ops, expectedRevision) {',
+  '\t\t\t\tconst ownedOps = structuredClone(ops);',
+  '\t\t\t\tconst generation = ++this.writeGeneration;',
+  '\t\t\t\treturn this.enqueue(async () => {',
+  '\t\t\t\t\tconst revision = expectedRevision ?? this.pendingRevision ?? this.getSnapshot().revision;',
+  '\t\t\t\t\tlet response;',
+  '\t\t\t\t\ttry {',
+  '\t\t\t\t\t\tresponse = await this.api.settings.mutate(this.spec.namespace, ownedOps, revision);',
+  '\t\t\t\t\t} catch (_settingsWriteFailure) {',
+  '\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\treturn;',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tif (!response.ok) {',
+  '\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\treturn;',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tif (this.disposed) return;',
+  '\t\t\t\t\tif (generation === this.writeGeneration) {',
+  '\t\t\t\t\t\tthis.pendingRevision = void 0;',
+  '\t\t\t\t\t\tthis.mirror.acceptView(response.value);',
+  '\t\t\t\t\t} else this.pendingRevision = response.value.revision;',
+  '\t\t\t\t});',
+  '\t\t\t}',
+].join('\n');
+const SETTINGS_WRITE_NEW = [
+  '\t\t\tmutate(ops, expectedRevision) {',
+  '\t\t\t\tconst ownedOps = structuredClone(ops);',
+  '\t\t\t\tconst generation = ++this.writeGeneration;',
+  '\t\t\t\treturn this.enqueue(async () => {',
+  `\t\t\t\t\t// ${SETTINGS_WRITE_MARKER}`,
+  '\t\t\t\t\tconst toFailure = (error) => {',
+  '\t\t\t\t\t\tconst failure = new Error(error?.message ?? "settings write failed");',
+  '\t\t\t\t\t\tif (error?.code !== void 0) failure.code = error.code;',
+  '\t\t\t\t\t\tif (error?.details !== void 0) failure.details = error.details;',
+  '\t\t\t\t\t\treturn failure;',
+  '\t\t\t\t\t};',
+  '\t\t\t\t\tconst settle = (response) => {',
+  '\t\t\t\t\t\tif (this.disposed) return;',
+  '\t\t\t\t\t\tif (generation === this.writeGeneration) {',
+  '\t\t\t\t\t\t\tthis.pendingRevision = void 0;',
+  '\t\t\t\t\t\t\tthis.mirror.acceptView(response.value);',
+  '\t\t\t\t\t\t} else this.pendingRevision = response.value.revision;',
+  '\t\t\t\t\t};',
+  '\t\t\t\t\tconst call = (revision) => this.api.settings.mutate(this.spec.namespace, ownedOps, revision);',
+  '\t\t\t\t\tlet response;',
+  '\t\t\t\t\ttry {',
+  '\t\t\t\t\t\tresponse = await call(expectedRevision ?? this.pendingRevision ?? this.getSnapshot().revision);',
+  '\t\t\t\t\t} catch (error) {',
+  '\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\tthrow error;',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tif (!response.ok && response.error.code === "settings-conflict" && expectedRevision === void 0) {',
+  '\t\t\t\t\t\tthis.pendingRevision = void 0;',
+  '\t\t\t\t\t\tawait this.mirror.load();',
+  '\t\t\t\t\t\tif (this.disposed) return;',
+  '\t\t\t\t\t\ttry {',
+  '\t\t\t\t\t\t\tresponse = await call(this.getSnapshot().revision);',
+  '\t\t\t\t\t\t} catch (error) {',
+  '\t\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\t\tthrow error;',
+  '\t\t\t\t\t\t}',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tif (!response.ok) {',
+  '\t\t\t\t\t\tconst failure = toFailure(response.error);',
+  '\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\tthrow failure;',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tsettle(response);',
+  '\t\t\t\t});',
+  '\t\t\t}',
+].join('\n');
+
+function patchSettingsWriteFailureSource(source: string): string | undefined {
+  if (source.includes(SETTINGS_WRITE_MARKER)) return source;
+  if (!source.includes(SETTINGS_WRITE_OLD)) return undefined;
+  return source.replace(SETTINGS_WRITE_OLD, SETTINGS_WRITE_NEW);
+}
+
+function patchSettingsWriteFailure(targetFile = SETTINGS_WRITE_TARGET): boolean {
+  if (!fs.existsSync(targetFile)) {
+    console.log('[patch-deps] dsh-client-ui-settings 不存在，跳过');
+    return false;
+  }
+  const source = fs.readFileSync(targetFile, 'utf8');
+  const patched = patchSettingsWriteFailureSource(source);
+  if (patched === source) {
+    console.log('[patch-deps] 设置写入失败传播补丁已应用，跳过');
+    return true;
+  }
+  if (patched === undefined) {
+    console.log('[patch-deps] 设置写入目标代码未匹配（上游版本可能已修复/更新），跳过');
+    return false;
+  }
+  writeFileAtomic(targetFile, patched);
+  console.log('[patch-deps] 已补丁 client-ui-settings：冲突刷新重试，最终失败不再误报成功');
+  return true;
+}
+
 // 模型目录图片输入开关：llm-pi-ai 已支持模型级 `input: [text, image]`，
 // 但 settings-models 只渲染 id/name/capacity，用户只能手改 YAML。给直接
 // DeepSeek 与通用 pi-ai 两套模型表格都增加行内 switch。关闭时传 undefined，
@@ -670,6 +782,7 @@ function main(): void {
   patchPickerWorker();
   patchSettingsNavScroll();
   patchSettingsPanelResize();
+  patchSettingsWriteFailure();
   patchModelImageInputToggle();
   patchOptionalEscalationFields();
   patchAgentPresetMenu();
@@ -688,4 +801,6 @@ module.exports = {
   patchClientModulesResolve,
   patchModelImageInputSource,
   patchModelImageInputToggle,
+  patchSettingsWriteFailureSource,
+  patchSettingsWriteFailure,
 };

--- a/dsh-desktop/test/computer-user-approval.test.ts
+++ b/dsh-desktop/test/computer-user-approval.test.ts
@@ -10,21 +10,20 @@ import { createComputerTools } from '../assets/plugins/computer-user/src/tools.j
 //   4) 只读工具在 manual 模式不要求批准
 //   5) disabled / readonly 模式拒绝副作用工具（readonly 下截图类放行）
 //
-// 兼容说明：历史版本（main 上的 tools.js）通过 exec.agent.session.header.sessionId
-// 判定已批准会话；0.3.6 之后改为构造入参 sessionId。为同时覆盖两种接线方式，
-// 本测试既在构造时传入 sessionId，也在 execute 时携带会话头 —— 两者任一命中
-// approvedSessions 均视为已批准。测试不再依赖 5.1.1 的 requestApproval 问答
-// （0.3.6 已移除该流程，manual 模式统一由 /computer 命令批准）。
+// 兼容说明：历史调用方仍可传单个 sessionId；Host 接线传 sessionIds 候选，
+// 覆盖 agent.id、session.header.sessionId 与 exec.sessionId。候选中任一身份命中
+// approvedSessions 即视为已批准。测试不再依赖 5.1.1 的 requestApproval 问答，
+// manual 模式统一由 /computer 命令批准。
 // ---------------------------------------------------------------------------
 
-function makeTools({ mode = 'manual', approvedSessions, sessionId } = {}) {
+function makeTools({ mode = 'manual', approvedSessions, sessionId, sessionIds } = {}) {
   const calls = []
   const runPs = async (script, payload) => {
     calls.push({ script, payload })
     return { ok: true, cursor: [1, 2] }
   }
   const getConfig = () => ({ mode, screenshot_dir: '', default_scale: 1, typing_interval_ms: 0, scroll_units: 120, debug: false })
-  const tools = createComputerTools({ runPs, getConfig, approvedSessions, sessionId, setMode: async () => {} })
+  const tools = createComputerTools({ runPs, getConfig, approvedSessions, sessionId, sessionIds, setMode: async () => {} })
   const byName = (name) => tools.find((t) => t.name === name)
   return { calls, byName, runPs }
 }
@@ -54,6 +53,19 @@ test('manual + 已批准会话 → 直接放行执行', async () => {
   assert.ok(t.calls.some((c) => c.script === 'input.ps1'))
 })
 
+test('manual + agent.id 已批准但会话头不同 → 候选身份任一命中即放行', async () => {
+  const t = makeTools({
+    approvedSessions: new Set(['agent-1']),
+    sessionIds: ['agent-1', 'session-header-1'],
+  })
+  const res = await t.byName('computer_click').execute(
+    { coordinate: [10, 20] },
+    execFor('session-header-1'),
+  )
+  assert.equal(res.clicked !== undefined, true)
+  assert.ok(t.calls.some((c) => c.script === 'input.ps1'))
+})
+
 test('manual + 其他会话已批准 → 本会话仍要求批准', async () => {
   const t = makeTools({ approvedSessions: new Set(['s-other']), sessionId: 's1' })
   await assert.rejects(
@@ -77,4 +89,25 @@ test('disabled 与 readonly 模式拒绝副作用工具', async () => {
   // 但截图类只读工具在 readonly 下放行
   await readonly.byName('computer_screenshot').execute({}, execFor('s1'))
   assert.ok(readonly.calls.some((c) => c.script === 'capture.ps1'))
+})
+
+test('host 设置写入使用 SettingsScope.update，不调用不存在的 set', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const source = await readFile(
+    new URL('../assets/plugins/computer-user/src/index.js', import.meta.url),
+    'utf8',
+  )
+  assert.match(source, /scope\.update\(\{\s*\[key\]: value\s*\}\)/)
+  assert.doesNotMatch(source, /scope\.set\(/)
+})
+
+test('host 工具接线把 agent.id 与会话头都传入批准候选', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const source = await readFile(
+    new URL('../assets/plugins/computer-user/src/index.js', import.meta.url),
+    'utf8',
+  )
+  assert.match(source, /exec\?\.agent\?\.id/)
+  assert.match(source, /exec\?\.agent\?\.session\?\.header\?\.sessionId/)
+  assert.match(source, /createComputerTools\(\{[^}]*sessionIds[^}]*\}\)/)
 })

--- a/dsh-desktop/test/settings-write-recovery.test.ts
+++ b/dsh-desktop/test/settings-write-recovery.test.ts
@@ -1,0 +1,184 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const require = createRequire(import.meta.url);
+const {
+  patchSettingsWriteFailureSource,
+  patchSettingsWriteFailure,
+} = require('../scripts/patch-deps.js') as {
+  patchSettingsWriteFailureSource(source: string): string | undefined;
+  patchSettingsWriteFailure(targetFile: string): boolean;
+};
+
+const oldMutate = [
+  '\t\t\tmutate(ops, expectedRevision) {',
+  '\t\t\t\tconst ownedOps = structuredClone(ops);',
+  '\t\t\t\tconst generation = ++this.writeGeneration;',
+  '\t\t\t\treturn this.enqueue(async () => {',
+  '\t\t\t\t\tconst revision = expectedRevision ?? this.pendingRevision ?? this.getSnapshot().revision;',
+  '\t\t\t\t\tlet response;',
+  '\t\t\t\t\ttry {',
+  '\t\t\t\t\t\tresponse = await this.api.settings.mutate(this.spec.namespace, ownedOps, revision);',
+  '\t\t\t\t\t} catch (_settingsWriteFailure) {',
+  '\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\treturn;',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tif (!response.ok) {',
+  '\t\t\t\t\t\tawait this.recover(generation);',
+  '\t\t\t\t\t\treturn;',
+  '\t\t\t\t\t}',
+  '\t\t\t\t\tif (this.disposed) return;',
+  '\t\t\t\t\tif (generation === this.writeGeneration) {',
+  '\t\t\t\t\t\tthis.pendingRevision = void 0;',
+  '\t\t\t\t\t\tthis.mirror.acceptView(response.value);',
+  '\t\t\t\t\t} else this.pendingRevision = response.value.revision;',
+  '\t\t\t\t});',
+  '\t\t\t}',
+].join('\n');
+
+function patchedController() {
+  const method = patchSettingsWriteFailureSource(oldMutate);
+  assert.ok(method);
+  return new Function(`
+    return class SettingsScopeControllerFixture {
+      ${method}
+      enqueue(operation) {
+        return operation();
+      }
+      async recover(generation) {
+        if (this.disposed || generation !== this.writeGeneration) return;
+        this.pendingRevision = undefined;
+        await this.mirror.load();
+      }
+      getSnapshot() {
+        return this.snapshot;
+      }
+    };
+  `)();
+}
+
+test('settings write patch retries only an implicit-revision conflict and exposes final failure', () => {
+  const patched = patchSettingsWriteFailureSource(`before\n${oldMutate}\nafter`);
+  assert.ok(patched);
+  assert.match(patched, /dsh-desktop-settings-write-retry/);
+  assert.match(patched, /response\.error\.code === "settings-conflict"/);
+  assert.match(patched, /expectedRevision === void 0/);
+  assert.match(patched, /await this\.mirror\.load\(\)/);
+  assert.match(patched, /throw failure/);
+  assert.doesNotMatch(patched, /catch \(_settingsWriteFailure\)[\s\S]*?return;/);
+});
+
+test('patched settings controller refreshes and retries one stale implicit revision', async () => {
+  const Controller = patchedController();
+  const revisions: number[] = [];
+  const controller = new Controller();
+  controller.writeGeneration = 0;
+  controller.disposed = false;
+  controller.pendingRevision = undefined;
+  controller.snapshot = { revision: 1 };
+  controller.spec = { namespace: 'computer-user' };
+  controller.mirror = {
+    async load() {
+      controller.snapshot = { revision: 2 };
+    },
+    acceptView(value: { revision: number }) {
+      controller.snapshot = value;
+    },
+  };
+  controller.api = {
+    settings: {
+      async mutate(_ns: string, _ops: unknown[], revision: number) {
+        revisions.push(revision);
+        if (revisions.length === 1) {
+          return {
+            ok: false,
+            error: {
+              code: 'settings-conflict',
+              message: 'stale revision',
+              details: { expected: 1, actual: 2 },
+            },
+          };
+        }
+        return { ok: true, value: { revision: 3 } };
+      },
+    },
+  };
+
+  await controller.mutate([{ op: 'set', path: ['mode'], value: 'auto' }]);
+  assert.deepEqual(revisions, [1, 2]);
+  assert.equal(controller.snapshot.revision, 3);
+});
+
+test('patched settings controller rejects a final write failure with its remote code', async () => {
+  const Controller = patchedController();
+  const controller = new Controller();
+  controller.writeGeneration = 0;
+  controller.disposed = false;
+  controller.pendingRevision = undefined;
+  controller.snapshot = { revision: 4 };
+  controller.spec = { namespace: 'computer-user' };
+  controller.mirror = {
+    async load() {},
+    acceptView() {},
+  };
+  controller.api = {
+    settings: {
+      async mutate() {
+        return {
+          ok: false,
+          error: {
+            code: 'settings-rejected',
+            message: 'disk is read-only',
+            details: { ns: 'computer-user' },
+          },
+        };
+      },
+    },
+  };
+
+  await assert.rejects(
+    () => controller.mutate([{ op: 'set', path: ['mode'], value: 'auto' }]),
+    (error: Error & { code?: string }) =>
+      error.message === 'disk is read-only' && error.code === 'settings-rejected',
+  );
+});
+
+test('settings write patch preserves explicit revision fences', () => {
+  const patched = patchSettingsWriteFailureSource(oldMutate);
+  assert.ok(patched);
+  assert.match(
+    patched,
+    /response\.error\.code === "settings-conflict" && expectedRevision === void 0/,
+  );
+});
+
+test('settings write source transform is idempotent', () => {
+  const once = patchSettingsWriteFailureSource(oldMutate);
+  assert.ok(once);
+  assert.equal(patchSettingsWriteFailureSource(once), once);
+});
+
+test('settings write patch refuses an unknown upstream shape', () => {
+  assert.equal(
+    patchSettingsWriteFailureSource('const upstreamChanged = true;'),
+    undefined,
+  );
+});
+
+test('settings write file patch applies atomically and stays stable', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-settings-write-'));
+  const file = join(dir, 'client.js');
+  try {
+    writeFileSync(file, oldMutate);
+    assert.equal(patchSettingsWriteFailure(file), true);
+    const once = readFileSync(file, 'utf8');
+    assert.equal(patchSettingsWriteFailure(file), true);
+    assert.equal(readFileSync(file, 'utf8'), once);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 目的

修复内置 `computer-user` 插件的设置保存和手动批准问题，并修正 DSH 设置客户端写入失败被误报为成功的行为。

## 主要改动

- 工具执行时同时收集 `agent.id`、`session.header.sessionId` 和 `exec.sessionId`，任一身份获批即可通过手动模式门禁。
- 将 Host 设置作用域错误的 `scope.set()` 调用改为公开契约支持的 `scope.update()`。
- 通过受控 `patch-deps` 链路修补 `dsh-client-ui-settings`：普通写入遇到 `settings-conflict` 时刷新 revision 并重试一次，最终失败向调用方 reject。
- 保留显式 `expectedRevision` 的并发保护，不自动越过调用方指定的 revision fence。
- 增加批准身份、Host 设置接口、冲突重试、错误传播和补丁幂等回归测试。

## 架构与兼容边界

- 插件修改位于内置插件资产层。
- 上游客户端修改仅通过 `dsh-desktop/scripts/patch-deps.ts` 维护，不直接提交 `node_modules`。
- 不修改用户配置、Profile 目录结构、插件启停状态或设置 schema。
- 历史单个 `sessionId` 调用方式继续兼容。

## 验证

- `npm test`：791 项，787 通过，4 项按平台跳过，0 失败。
- `node --test test/computer-user-approval.test.ts`：8/8 通过。
- `node --test test/settings-write-recovery.test.ts`：7/7 通过。
- `node --check assets/plugins/computer-user/src/index.js`：通过。
- `node --check assets/plugins/computer-user/src/tools.js`：通过。
- `node scripts/patch-deps.js` 连续执行保持幂等。
- `classify-change.ps1`：`ready`，无未分类文件。

## 运行时验收

当前开发 Profile 的插件副本已对齐验证；代码生效需要重启 Web 服务并刷新客户端页面。

## 未验证项

按现有要求未执行 `stage-resources.mjs` 资源装配，也未构建安装包或便携包。本次没有 UI 布局变化，因此无截图。

## 回退

回退本 PR 即可恢复原行为；不涉及用户数据迁移或配置文件回写。