### PR TITLE
release(aio): 发布 v1.1.0

### DIFF
--- a/.agents/skills/deepseek-harness-eac-dev/scripts/repo-inventory.ps1
+++ b/.agents/skills/deepseek-harness-eac-dev/scripts/repo-inventory.ps1
@@ -20,8 +20,50 @@ function Count-Files {
     return @(Get-ChildItem -LiteralPath $path -File -Filter $Filter).Count
 }
 
-$desktopPackage = Get-Content -Encoding UTF8 -LiteralPath (Join-Path $root 'dsh-desktop\package.json') -Raw | ConvertFrom-Json
-$tauriConfig = Get-Content -Encoding UTF8 -LiteralPath (Join-Path $root 'tauri-shell\tauri.conf.json') -Raw | ConvertFrom-Json
+$repositoryLayout = if (
+    (Test-Path -LiteralPath (Join-Path $root 'dsh-desktop\package.json') -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $root 'tauri-shell\tauri.conf.json') -PathType Leaf)
+) {
+    'modern-5x'
+} elseif (
+    (Test-Path -LiteralPath (Join-Path $root 'package.json') -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $root 'tauri-app\tauri.conf.json') -PathType Leaf)
+) {
+    'aio-v1'
+} else {
+    throw 'Unsupported repository layout: expected modern 5.x or aio-v1 manifests.'
+}
+
+$layout = if ($repositoryLayout -eq 'modern-5x') {
+    [ordered]@{
+        desktopPackage = 'dsh-desktop\package.json'
+        tauriConfig = 'tauri-shell\tauri.conf.json'
+        plugins = 'dsh-desktop\assets\plugins'
+        skins = 'dsh-desktop\assets\skins'
+        agentPresets = 'dsh-desktop\assets\agent-presets'
+        bundledSkills = 'dsh-desktop\assets\skills'
+        desktopL2 = 'dsh-desktop\lib\desktop'
+        sidecar = 'tauri-shell\sidecar'
+        tests = 'dsh-desktop\test'
+        testFilter = '*.test.ts'
+    }
+} else {
+    [ordered]@{
+        desktopPackage = 'package.json'
+        tauriConfig = 'tauri-app\tauri.conf.json'
+        plugins = 'assets\plugins'
+        skins = 'assets\skins'
+        agentPresets = 'assets\agent-presets'
+        bundledSkills = 'distribution\profile-seed\skills'
+        desktopL2 = ''
+        sidecar = 'sidecar\src'
+        tests = 'test'
+        testFilter = '*.test.mjs'
+    }
+}
+
+$desktopPackage = Get-Content -Encoding UTF8 -LiteralPath (Join-Path $root $layout.desktopPackage) -Raw | ConvertFrom-Json
+$tauriConfig = Get-Content -Encoding UTF8 -LiteralPath (Join-Path $root $layout.tauriConfig) -Raw | ConvertFrom-Json
 
 Push-Location $root
 try {
@@ -55,6 +97,7 @@ foreach ($group in ($extensionNames | Group-Object | Sort-Object Count -Descendi
     status = 'ready'
     generatedAt = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ssK')
     repoRoot = $root
+    repositoryLayout = $repositoryLayout
     gitHead = $head
     gitStatus = $status
     versions = [ordered]@{
@@ -63,14 +106,14 @@ foreach ($group in ($extensionNames | Group-Object | Sort-Object Count -Descendi
         dsh = [string]$desktopPackage.dependencies.'@deepseek-ai/dsh'
     }
     counts = [ordered]@{
-        plugins = Count-Directories 'dsh-desktop\assets\plugins'
-        skins = Count-Directories 'dsh-desktop\assets\skins'
-        agentPresets = Count-Directories 'dsh-desktop\assets\agent-presets'
-        bundledSkills = Count-Directories 'dsh-desktop\assets\skills'
-        desktopL2TypeScript = Count-Files 'dsh-desktop\lib\desktop' '*.ts'
-        sidecarTypeScript = Count-Files 'tauri-shell\sidecar' '*.ts'
+        plugins = Count-Directories $layout.plugins
+        skins = Count-Directories $layout.skins
+        agentPresets = Count-Directories $layout.agentPresets
+        bundledSkills = Count-Directories $layout.bundledSkills
+        desktopL2TypeScript = Count-Files $layout.desktopL2 '*.ts'
+        sidecarTypeScript = Count-Files $layout.sidecar '*.ts'
         rustFiles = @($files | Where-Object { [IO.Path]::GetExtension($_) -eq '.rs' }).Count
-        nodeTestFiles = Count-Files 'dsh-desktop\test' '*.test.ts'
+        nodeTestFiles = Count-Files $layout.tests $layout.testFilter
         rootSmokeScripts = @(Get-ChildItem -LiteralPath $root -File | Where-Object Name -match '(smoke|upgrade-test).*\.js$').Count
         workflows = Count-Files '.github\workflows' '*'
     }

--- a/.agents/skills/deepseek-harness-eac-dev/tests/run-tests.ps1
+++ b/.agents/skills/deepseek-harness-eac-dev/tests/run-tests.ps1
@@ -126,6 +126,15 @@ $pluginCopyRule = if ($isAioLayout) { 'aio-plugin-copy' } else { 'plugin-copy' }
 $manifestRule = if ($isAioLayout) { 'aio-package-manifest' } else { 'desktop-package-manifest' }
 $packagingRule = if ($isAioLayout) { 'aio-packaging' } else { 'packaging' }
 
+$inventory = Invoke-JsonFixture -Script 'repo-inventory.ps1' -Arguments @('-RepoPath', $repoRoot)
+Assert-Fixture -Name 'repo-inventory-layout' -Condition (
+    $inventory.exitCode -eq 0 -and
+    $inventory.data.status -eq 'ready' -and
+    $inventory.data.repositoryLayout -eq $(if ($isAioLayout) { 'aio-v1' } else { 'modern-5x' }) -and
+    [int]$inventory.data.counts.nodeTestFiles -gt 0 -and
+    [int]$inventory.data.counts.rustFiles -gt 0
+) -Failure ($inventory.raw)
+
 $dependencyPatch = Invoke-JsonFixture -Script 'classify-change.ps1' -Arguments @('-RepoPath', $repoRoot, '-FilesJsonBase64', (ConvertTo-FilesJsonBase64 $dependencyFiles))
 Assert-Fixture -Name 'dependency-patch-chain' -Condition ($dependencyPatch.exitCode -eq 0 -and $dependencyPatch.data.minimumValidation -eq 'package' -and $dependencyRule -in @($dependencyPatch.data.matchedRules) -and @($dependencyPatch.data.unmatchedCodeFiles).Count -eq 0) -Failure ($dependencyPatch.raw)
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -83,11 +83,19 @@
 
 已删除 `.modules.yaml`、`.pnpm-workspace-state-v1.json`、`.pnpm/lock.yaml` 等会记录 `H:/CODEX`、原 Windows 用户目录、pnpm store 和 `.dsh-v4lite` 的机器状态；个人化 status-rotator 文案已替换为中性公共默认值。`Set-PublicSeed` 现在会执行全树路径扫描，命中则阻断构建。
 
+### 8. 外部 seed 审计目标错误
+
+发布脚本允许通过 `DSH_PROFILE_SEED_DIR` 注入审核后的完整离线 seed，但脱敏脚本此前始终扫描仓库内占位目录，实际打包输入可能绕过检查。现已统一读取同一环境变量，并增加外部 seed、CRLF 保持和本机路径阻断回归测试。
+
+### 9. 依赖公告与发布哈希兼容性
+
+发布前 npm 审计发现 `fast-uri` 高危、`qs` 与 `@xmldom/xmldom` 中危公告，现通过 overrides 锁定修复版本，完整与生产依赖审计均为 0。发布哈希改用 .NET SHA-256，避免 Windows PowerShell 未自动加载 `Microsoft.PowerShell.Utility` 时在流水线末尾失败。
+
 ## AIO v1 命名与版本
 
 - 版型：AIO（All-in-One）
 - 用户可见版本：v1
-- 机器内部 SemVer：1.0.0
+- 机器内部 SemVer：1.1.0
 - 上游 `v4.5-lite` 只作为源码溯源，不是当前产品版本。
 
 ## 仍未完全解决
@@ -108,7 +116,7 @@
 
 ## 验收标准
 
-本机最终技术验证结果：JavaScript 275/275、Rust 12/12，安装/首启/共存/卸载 E2E 已 PASS。该结论不替代第三方授权、代码签名或商标审查。
+本机最终技术验证结果：JavaScript 291/291、Rust 15/15，安装/首启/共存/卸载 E2E 已 PASS。该结论不替代第三方授权、代码签名或商标审查。
 
 发布前必须看到：
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@
 - Windows SDK 与 Visual Studio C++ Build Tools
 - 可访问 npm、Cargo 与 Tauri/NSIS/WebView2 构建资源的网络环境；依赖已缓存时可部分离线
 
-版型为 `AIO`（All-in-One），用户可见版本为 `v1`，内部 SemVer 为 `1.0.0`。
+版型为 `AIO`（All-in-One），用户可见版本为 `v1`，当前内部 SemVer 为 `1.1.0`。
 
 ## 一键发布构建
 
@@ -31,21 +31,20 @@ npm run dist
 7. 串行运行全部重构版 JavaScript 测试；
 8. `cargo test --locked`；
 9. Tauri/NSIS 打包；
-10. 生成源码归档、构建元数据和 SHA-256 清单并复核。
+10. 生成便携归档和 SHA-256 清单并复核。
 
 ## 产物
 
 ```text
 dist/
 ├── DSHEAC-AIO-v1-Setup-x64.exe
-├── DSHEAC-AIO-v1-Source.zip
+├── portable/
+│   ├── DSHEAC-AIO-v1-Portable-x64.zip
+│   └── SHA256SUMS.txt
 └── SHA256SUMS.txt
-
-verification/
-└── build-metadata.json
 ```
 
-源码归档不包含：
+便携归档不包含构建期文件，例如：
 
 - `.git`；
 - `tauri-app/target`；
@@ -53,7 +52,7 @@ verification/
 - 本地插件 `dist` 目录中的预构建安装器；
 - 本地插件 source map。
 
-这些排除项不属于构建输入，能显著降低源码包体积和解压时间。
+这些排除项不属于运行时，能显著降低便携包体积和解压时间。
 
 ## 安装 E2E
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ DeepSeek Harness（dsh）的 Windows 桌面客户端：内置独立 Node 运行�
 4.4.0（修复设置页「Skills 与 MCP → 打开目录」失效）→
 4.5.0（本版：内核升级 0.1.1-rc.2 + 内置 dsh-market 社区插件市场）。
 
-## [AIO v1] — 2026-09-03
+## [AIO v1.1.0] — 2026-09-03
+
+### 安全与发布维护
+- 锁定 `fast-uri 3.1.6`、`qs 6.16.0` 与 `@xmldom/xmldom 0.8.15`，修复发布前依赖审计发现的高危/中危公告。
+- 修复开发者 Skill 的仓库 inventory 对 AIO 布局不兼容的问题，发布审计现在能正确统计 AIO 插件、皮肤、测试与 Rust/sidecar 文件。
+- 修复外部 `DSH_PROFILE_SEED_DIR` 构建时仍错误扫描仓库占位 seed 的问题，并保持已脱敏 settings 的原始换行格式。
+- 修复 Windows PowerShell 模块未自动加载时 `Get-FileHash` 不可用、导致安装包已生成但发布流水线最终失败的问题。
 
 ### 新增：内置 Composer Dynamic Island 2.1.0
 - 从 `says693/dsh-composer-dynamic-island` 的 `v2.1.0`（`2ccd12ff`）引入

--- a/FINAL_REPORT.md
+++ b/FINAL_REPORT.md
@@ -1,12 +1,12 @@
 # DSHEAC AIO v1 — 最终交付报告
 
-完成时间：2026-09-02
+完成时间：2026-09-03
 
 版型：AIO（All-in-One）
 
 用户版本：v1
 
-机器 SemVer：1.0.0
+机器 SemVer：1.1.0
 
 上游溯源：DSH-Desktop-EAC `v4.5-lite` / `de55ef6d5319eacc24ce60309acc261b9fb78b6c`
 
@@ -14,12 +14,12 @@
 
 | 文件 | 大小 | SHA-256 |
 | --- | ---: | --- |
-| `DSHEAC-AIO-v1-Setup-x64.exe` | 348,573,428 bytes | `19077ca194129864c446959a272a0874b0f38f41f8a78fd1f10e58e364939e88` |
-| `DSHEAC-AIO-v1-Portable-x64.zip` | 152,056,743 bytes | `056aaf2eb0693de5647f45c850cdfeef098a4be79dd90bb0cfda8f64a92c8d5c` |
+| `DSHEAC-AIO-v1-Setup-x64.exe` | 347,988,148 bytes | `1d3aa772a8ef2a8f07f7ade28cbd33ae5b4d9f82b51dd9ce19d02d22075deab4` |
+| `DSHEAC-AIO-v1-Portable-x64.zip` | 128,618,722 bytes | `cb275e8819734cb0e72e05e241d3d72b7b0b7d2a63aa91c334717405f9ab1663` |
 
 ## 测试结果
 
-- JavaScript：282/282 PASS
+- JavaScript：291/291 PASS
 - Rust：15/15 PASS
 - sidecar RPC：PASS
 - NSIS 静态契约：PASS
@@ -32,20 +32,20 @@
 
 最终 E2E 报告：
 
-`verification/verification-20260902-103828-856-22996-7a30886d.json`（本机生成，不提交临时日志目录）
+`verification/verification-20260903-181940-440-70592-fa3389e5.json`（本机生成，不提交临时日志目录）
 
 ### E2E 指标
 
-- 静默安装：48.126 秒，退出码 0
+- 静默安装：45.706 秒，退出码 0
 - 安装路径：包含中文和空格
-- 安装 payload：19,298 文件，335,994,154 bytes
-- 首启至 HTTP 200：13.992 秒
-- HTTP 端口：5290
+- 安装 payload：19,002 文件，311,578,440 bytes
+- 首启至 HTTP 200：11.541 秒
+- HTTP 端口：2173
 - 监听 PID 属于本轮应用进程树：是
 - profile 必需插件/技能缺失：0
 - 私密设置标记：0
 - 本机 pnpm 元数据残留：0
-- 静默卸载完整清理：78.997 秒，退出码 0
+- 静默卸载完整清理：73.026 秒，退出码 0
 - 安装目录残留：无
 - AIO 进程残留：无
 - 监听端口残留：无
@@ -72,12 +72,15 @@
 - profile seed 删除 `.modules.yaml`、`.pnpm-workspace-state-v1.json`、`.pnpm/lock.yaml`；
 - 个人化 status rotator 文案替换为中性公共默认值；
 - 构建时全树扫描原工作区、用户目录、`.dsh-v4lite` 和 pnpm store 痕迹；
+- 外部审核 seed 与实际打包输入现在使用同一 `DSH_PROFILE_SEED_DIR`，避免扫描错目录；
+- npm 完整与生产依赖审计均为 0，已锁定修复 `fast-uri`、`qs` 与 `@xmldom/xmldom` 公告；
+- 发布哈希使用 .NET SHA-256，不依赖 PowerShell 模块自动加载；
 - AIO identifier、进程名、快捷方式 TargetPath、安装数据、DSH_HOME、portable data、NSIS 和卸载注册表均与其他版本隔离；
 - legacy localStorage 导入默认关闭，仅在 `DSH_AIO_IMPORT_LEGACY=1` 时显式启用。
 
 ## 仍未闭合的公开发布风险
 
-技术安装与卸载已在本机验收通过，但当前不建议未经进一步处理就公开发布：
+技术安装与卸载已在本机验收通过，但以下事项仍不满足稳定版发布标准；本次只适合作为明确标注风险的预发布：
 
 1. 安装包未 Authenticode 签名；
 2. 第三方依赖、Node/npm、Rust crates、WebView2、插件和素材尚无完整 SBOM/notice bundle；

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > **用户可见版本：v1**
 >
-> 机器内部 SemVer：`1.0.0`
+> 机器内部 SemVer：`1.1.0`
 >
 > 上游源码基线：`v4.5-lite`，commit `de55ef6d5319eacc24ce60309acc261b9fb78b6c`
 
@@ -41,7 +41,7 @@ AIO 不表示包含上游项目所有历史功能；实际功能以本仓库打�
 发布产物：
 
 - `dist/DSHEAC-AIO-v1-Setup-x64.exe`
-- `dist/DSHEAC-AIO-v1-Source.zip`
+- `dist/portable/DSHEAC-AIO-v1-Portable-x64.zip`
 - `dist/SHA256SUMS.txt`
 
 安装包目前未签名。Windows SmartScreen 可能提示未知发布者；运行前请核对 SHA-256。
@@ -65,11 +65,11 @@ powershell -NoProfile -File .\scripts\verify-aio-installer.ps1
 
 ## 隐私边界
 
-发行 seed 明确排除凭据、会话、记忆、附件、浏览器 profile、日志、usage 数据，以及原用户模型/provider/权限和个人 preset 选择。个人化状态文案已替换为中性公共默认值；构建时 `Set-PublicSeed` 会删除含本机绝对路径的 pnpm 状态文件，并全树扫描原工作区、用户目录、`.dsh-v4lite` 与 pnpm store 痕迹。上传前仍需人工复核。
+发行 seed 明确排除凭据、会话、记忆、附件、浏览器 profile、日志、usage 数据，以及原用户模型/provider/权限和个人 preset 选择。个人化状态文案已替换为中性公共默认值；构建时 `sanitize-public-seed.mjs` 会删除含本机绝对路径的包管理器状态文件，并全树扫描原工作区、用户目录、`.dsh-v4lite` 与 pnpm store 痕迹。上传前仍需人工复核。
 
 ## 本轮工程改进
 
-- 产品名统一为 `DSHEAC AIO`，用户版本统一为 `v1`，内部 SemVer 为 `1.0.0`；
+- 产品名统一为 `DSHEAC AIO`，用户版本统一为 `v1`，当前内部 SemVer 为 `1.1.0`；
 - 修复 Node `fs.cpSync` 在当前中文长路径工作区中以 `0xC0000409` 崩溃；
 - staging 仅对发布树裁剪 `.map`、`.pdb` 和 ARM64 预编译件；
 - 停用可读取任意绝对路径、且无调用方的壳层预览端口；

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## 支持范围
 
-当前仅审计和支持 `DSHEAC AIO`（All-in-One，用户可见版本 `v1`，内部 SemVer `1.0.0`）的 Windows x64 Tauri 构建。
+当前仅审计和支持 `DSHEAC AIO`（All-in-One，用户可见版本 `v1`，内部 SemVer `1.1.0`）的 Windows x64 Tauri 构建。
 
 ## 信任边界
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-desktop-aio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-desktop-aio",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6065,9 +6065,9 @@
       ]
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.14.tgz",
-      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7552,9 +7552,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -9545,9 +9545,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop-aio",
   "productName": "DSHEAC AIO",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "DSHEAC AIO v1（All-in-One）：整合 dsh CLI、Node 运行时、插件与技能快照的 Windows x64 发行版。",
   "main": "main.js",
   "author": "DSH Desktop",
@@ -52,5 +52,10 @@
   "devDependencies": {
     "electron": "^43.4.0",
     "electron-builder": "^26.15.3"
+  },
+  "overrides": {
+    "@xmldom/xmldom": "0.8.15",
+    "fast-uri": "3.1.6",
+    "qs": "6.16.0"
   }
 }

--- a/scripts/build-aio-release.ps1
+++ b/scripts/build-aio-release.ps1
@@ -11,6 +11,20 @@ $RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
 $tauri = Join-Path $RepoRoot 'tauri-app'
 $dist = Join-Path $RepoRoot 'dist'
 
+function Get-Sha256Hex([string]$Path) {
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            return (($sha.ComputeHash($stream) | ForEach-Object { $_.ToString('x2') }) -join '')
+        } finally {
+            $sha.Dispose()
+        }
+    } finally {
+        $stream.Dispose()
+    }
+}
+
 if ([string]::IsNullOrWhiteSpace($ProfileSeedDir)) {
     $ProfileSeedDir = Join-Path $RepoRoot 'distribution\profile-seed'
 }
@@ -51,7 +65,7 @@ if ($LASTEXITCODE -ne 0) { throw 'resource staging failed' }
 & npm.cmd --prefix $tauri run bundle
 if ($LASTEXITCODE -ne 0) { throw 'Tauri bundle failed' }
 
-$builtSetup = Join-Path $tauri 'target\release\bundle\nsis\DSHEAC AIO_1.0.0_x64-setup.exe'
+$builtSetup = Join-Path $tauri 'target\release\bundle\nsis\DSHEAC AIO_1.1.0_x64-setup.exe'
 $setup = Join-Path $dist 'DSHEAC-AIO-v1-Setup-x64.exe'
 Copy-Item -LiteralPath $builtSetup -Destination $setup -Force
 
@@ -61,7 +75,7 @@ if ($LASTEXITCODE -ne 0) { throw 'portable package failed' }
 
 Write-Host '[7/7] release hashes'
 $hashLines = foreach ($file in Get-ChildItem $dist -Recurse -File | Where-Object Name -ne 'SHA256SUMS.txt' | Sort-Object FullName) {
-    $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $file.FullName).Hash.ToLowerInvariant()
+    $hash = Get-Sha256Hex $file.FullName
     $relative = $file.FullName.Substring($dist.Length + 1).Replace('\', '/')
     "$hash  $relative"
 }

--- a/scripts/sanitize-public-seed.mjs
+++ b/scripts/sanitize-public-seed.mjs
@@ -3,18 +3,23 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 
 const root = path.resolve(process.argv[2] || process.cwd());
-const seedRoot = path.join(root, 'distribution', 'profile-seed');
+const seedRoot = process.env.DSH_PROFILE_SEED_DIR
+  ? path.resolve(process.env.DSH_PROFILE_SEED_DIR)
+  : path.join(root, 'distribution', 'profile-seed');
 const settingsFile = path.join(seedRoot, 'settings.yaml');
 const require = createRequire(path.join(root, 'package.json'));
 const yaml = require('js-yaml');
 
-const input = yaml.load(fs.readFileSync(settingsFile, 'utf8')) || {};
+const settingsSource = fs.readFileSync(settingsFile, 'utf8');
+const input = yaml.load(settingsSource) || {};
 const output = {};
 for (const key of ['status-rotator', 'webui-modules']) {
   if (!Object.hasOwn(input, key)) throw new Error(`missing public section: ${key}`);
   output[key] = input[key];
 }
-fs.writeFileSync(settingsFile, yaml.dump(output, { noRefs: true, lineWidth: -1, noCompatMode: true }), 'utf8');
+const eol = settingsSource.includes('\r\n') ? '\r\n' : '\n';
+const sanitizedSettings = yaml.dump(output, { noRefs: true, lineWidth: -1, noCompatMode: true }).replaceAll('\n', eol);
+if (sanitizedSettings !== settingsSource) fs.writeFileSync(settingsFile, sanitizedSettings, 'utf8');
 
 const forbiddenState = ['.modules.yaml', '.pnpm-workspace-state-v1.json', path.join('.pnpm', 'lock.yaml')];
 const profileNodeModules = path.join(seedRoot, 'profiles', 'web-desktop', 'node_modules');

--- a/scripts/verify-aio-installer.ps1
+++ b/scripts/verify-aio-installer.ps1
@@ -32,11 +32,25 @@ $report = [ordered]@{
     edition = 'AIO'
     editionMeaning = 'All-in-One'
     release = 'v1'
-    technicalSemVer = '1.0.0'
+    technicalSemVer = '1.1.0'
     verifiedAt = (Get-Date).ToString('o')
     installer = $installer
     installDirectory = $installRoot
     result = 'RUNNING'
+}
+
+function Get-Sha256Hex([string]$Path) {
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            return (($sha.ComputeHash($stream) | ForEach-Object { $_.ToString('x2') }) -join '')
+        } finally {
+            $sha.Dispose()
+        }
+    } finally {
+        $stream.Dispose()
+    }
 }
 
 function Wait-ProcessBounded([System.Diagnostics.Process]$Process, [int]$TimeoutSeconds, [string]$Label) {
@@ -126,7 +140,7 @@ try {
     if (Test-Path -LiteralPath $runRoot) { throw "Refusing to reuse test directory: $runRoot" }
     New-Item -ItemType Directory -Path $runRoot | Out-Null
 
-    $report.installerSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $installer).Hash.ToLowerInvariant()
+    $report.installerSha256 = Get-Sha256Hex $installer
     $report.installerBytes = (Get-Item -LiteralPath $installer).Length
 
     # Coexistence is conditional: absence of the original product is N/A, not failure.

--- a/tauri-app/Cargo.lock
+++ b/tauri-app/Cargo.lock
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "dsh-desktop-aio"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/tauri-app/Cargo.toml
+++ b/tauri-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsh-desktop-aio"
-version = "1.0.0"
+version = "1.1.0"
 description = "DSHEAC AIO - All-in-One Tauri shell around the dsh web UI"
 edition = "2021"
 rust-version = "1.77"

--- a/tauri-app/package-lock.json
+++ b/tauri-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-desktop-aio-tauri",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-desktop-aio-tauri",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@tauri-apps/cli": "^2.9.6",
         "@types/node": "^24.13.3",

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop-aio-tauri",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "build:inject": "node build-inject.mjs",

--- a/tauri-app/tauri.conf.json
+++ b/tauri-app/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DSHEAC AIO",
   "mainBinaryName": "DSHEAC AIO",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.deepseek.dsh.desktop.aio",
   "build": {
     "beforeDevCommand": "npm run build:inject",

--- a/test/aio-validation-compat.test.mjs
+++ b/test/aio-validation-compat.test.mjs
@@ -62,3 +62,11 @@ test('AIO update smoke rejects client self-update exposure', () => {
   assert.match(smoke, /client auto-update scripts/);
   assert.match(smoke, /plugin auto-update must default to disabled/);
 });
+
+test('release scripts compute SHA-256 without PowerShell module autoloading', () => {
+  for (const rel of ['scripts/build-aio-release.ps1', 'scripts/verify-aio-installer.ps1']) {
+    const source = read(rel);
+    assert.match(source, /System\.Security\.Cryptography\.SHA256/);
+    assert.ok(!source.includes('Get-FileHash'), `${rel} must work when Microsoft.PowerShell.Utility is not auto-loaded`);
+  }
+});

--- a/test/lite-manifest.test.mjs
+++ b/test/lite-manifest.test.mjs
@@ -158,7 +158,16 @@ test('打包：package.json 使用 AIO v1 发布标识、无客户端自更新�
   const pkg = JSON.parse(read('package.json'));
   assert.equal(pkg.name, 'dsh-desktop-aio');
   assert.equal(pkg.productName, 'DSHEAC AIO');
-  assert.equal(pkg.version, '1.0.0');
+  assert.equal(pkg.version, '1.1.0');
+  assert.deepEqual(pkg.overrides, {
+    '@xmldom/xmldom': '0.8.15',
+    'fast-uri': '3.1.6',
+    qs: '6.16.0',
+  });
+  const lock = JSON.parse(read('package-lock.json'));
+  assert.equal(lock.packages['node_modules/@xmldom/xmldom'].version, '0.8.15');
+  assert.equal(lock.packages['node_modules/fast-uri'].version, '3.1.6');
+  assert.equal(lock.packages['node_modules/qs'].version, '6.16.0');
   assert.ok(!JSON.stringify(pkg.scripts).includes('client-update'));
   assert.ok(!JSON.stringify(pkg.scripts).includes('check-client-latest'));
 });

--- a/test/sanitize-public-seed.test.mjs
+++ b/test/sanitize-public-seed.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const script = path.join(root, 'scripts', 'sanitize-public-seed.mjs');
+
+function makeSeed(base, settings) {
+  const seed = path.join(base, 'profile-seed');
+  const modules = path.join(seed, 'profiles', 'web-desktop', 'node_modules');
+  fs.mkdirSync(path.join(modules, '.pnpm'), { recursive: true });
+  fs.writeFileSync(path.join(seed, 'settings.yaml'), settings, 'utf8');
+  fs.writeFileSync(path.join(modules, '.modules.yaml'), 'storeDir: H:/CODEX/pnpm/store\n', 'utf8');
+  fs.writeFileSync(path.join(modules, '.pnpm-workspace-state-v1.json'), '{}\n', 'utf8');
+  fs.writeFileSync(path.join(modules, '.pnpm', 'lock.yaml'), 'lockfileVersion: 9\n', 'utf8');
+  return { seed, modules };
+}
+
+test('seed sanitizer targets DSH_PROFILE_SEED_DIR and preserves CRLF', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-aio-seed-'));
+  try {
+    const settings = 'status-rotator:\r\n  enabled: true\r\nwebui-modules:\r\n  rewind: false\r\nprivate-key:\r\n  value: remove-me\r\n';
+    const { seed, modules } = makeSeed(temp, settings);
+    const result = spawnSync(process.execPath, [script], {
+      cwd: root,
+      env: { ...process.env, DSH_PROFILE_SEED_DIR: seed },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const sanitized = fs.readFileSync(path.join(seed, 'settings.yaml'), 'utf8');
+    assert.ok(sanitized.includes('\r\n'));
+    assert.doesNotMatch(sanitized, /private-key/);
+    assert.ok(!fs.existsSync(path.join(modules, '.modules.yaml')));
+    assert.ok(!fs.existsSync(path.join(modules, '.pnpm-workspace-state-v1.json')));
+    assert.ok(!fs.existsSync(path.join(modules, '.pnpm', 'lock.yaml')));
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test('seed sanitizer rejects machine-local paths in the selected external seed', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-aio-seed-'));
+  try {
+    const { seed } = makeSeed(temp, 'status-rotator:\n  enabled: true\nwebui-modules:\n  rewind: false\n');
+    fs.writeFileSync(path.join(seed, 'leak.json'), '{"path":"C:/Users/32621/private"}\n', 'utf8');
+    const result = spawnSync(process.execPath, [script], {
+      cwd: root,
+      env: { ...process.env, DSH_PROFILE_SEED_DIR: seed },
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /machine-local seed paths found/);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/update-smoke.js
+++ b/update-smoke.js
@@ -12,8 +12,8 @@ const tauriConfig = JSON.parse(fs.readFileSync(path.join(repo, 'tauri-app', 'tau
 const ipc = fs.readFileSync(path.join(repo, 'tauri-app', 'src', 'ipc.rs'), 'utf8');
 const shell = fs.readFileSync(path.join(repo, 'tauri-app', 'frontend', 'chrome.ts'), 'utf8');
 
-assert.equal(packageJson.version, '1.0.0');
-assert.equal(tauriConfig.version, '1.0.0');
+assert.equal(packageJson.version, '1.1.0');
+assert.equal(tauriConfig.version, '1.1.0');
 assert.ok(!JSON.stringify(packageJson.scripts).includes('client-update'), 'AIO must not expose client auto-update scripts');
 assert.ok(!ipc.includes('client_update'), 'AIO native IPC must not expose a client updater');
 assert.ok(!shell.includes('clientUpdater'), 'AIO web bridge must not expose a client updater');


### PR DESCRIPTION
## 概要

准备 DSHEAC AIO v1.1.0 预发布，在 PR #278 的 Composer Dynamic Island 基础上补齐发布门禁与真实产物验证。

## 修复

- 将机器 SemVer 从 1.0.0 升级为 1.1.0，保持用户可见产品线为 AIO v1
- 锁定 fast-uri 3.1.6、qs 6.16.0、@xmldom/xmldom 0.8.15，npm audit 清零
- 修复外部 DSH_PROFILE_SEED_DIR 未被实际脱敏扫描的问题
- 修复 Windows PowerShell 模块未自动加载时 Get-FileHash 导致发布尾步失败
- 让仓库 inventory/Skill validator 正确支持 aio-v1 布局
- 修正文档中的过期版本、测试计数、产物路径和最终交付哈希

## 验证

- JavaScript: 291/291 PASS
- Rust: 15/15 PASS
- npm audit: 0 vulnerabilities
- Tauri/NSIS 完整构建: PASS
- 安装 E2E: Unicode+空格路径安装、首次启动、HTTP 200、profile seed、Composer Dynamic Island、静默卸载与残留检查 PASS
- 便携包 boot/gui smoke: PASS
- Skill validator: PowerShell 7、Windows PowerShell 5.1、official validator PASS

## 发布边界

安装包仍未签名，完整 SBOM/第三方再分发权与品牌审查尚未闭合，因此本次只发布为 GitHub prerelease，不标记稳定版。