### PR TITLE
fix(release): 预取 Windows WebView2 依赖

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -100,6 +100,10 @@ jobs:
           restore-keys: |
             dsh-tauri-win-x64-
 
+      - name: 获取 Tauri Rust 依赖（WebView2Loader.dll）
+        working-directory: tauri-shell
+        run: cargo fetch --locked --target x86_64-pc-windows-msvc
+
       - name: 安装依赖
         working-directory: dsh-desktop
         run: npm run ci:install

--- a/dsh-desktop/test/linux-release-boot.test.ts
+++ b/dsh-desktop/test/linux-release-boot.test.ts
@@ -43,6 +43,13 @@ test('Windows releases rebuild the kernel cache before installing dependencies',
   );
 });
 
+test('Windows releases fetch Tauri crates before staging WebView2Loader.dll', () => {
+  const fetchTauriCrates = windowsRelease.indexOf('cargo fetch --locked --target x86_64-pc-windows-msvc');
+  const stageResources = windowsRelease.indexOf('node ../tauri-shell/stage-resources.mjs');
+  assert.ok(fetchTauriCrates >= 0, 'Windows release must fetch the locked Tauri dependency graph');
+  assert.ok(stageResources > fetchTauriCrates, 'Tauri crates must be available before resources are staged');
+});
+
 test('all staging targets exclude the kernel build tree and remove client build paths', () => {
   const temp = mkdtempSync(join(tmpdir(), 'dsh-linux-stage-'));
   try {


### PR DESCRIPTION
## 问题

`v5.3.6` 首次 Release Tauri 运行 `33745711675` 的 Windows job 在 `stage-resources` 失败：干净 runner 尚未获取 `webview2-com-sys` crate，因此找不到 `WebView2Loader.dll`。

## 修复

- Windows Release 在 Cargo 缓存后运行 `cargo fetch --locked --target x86_64-pc-windows-msvc`
- 增加顺序回归测试，保证 Tauri crates 在 `stage-resources` 前可用

## 验证

- 新增回归测试：PASS
- 全新 `CARGO_HOME` 目标化 fetch：PASS，发现 3 个 `WebView2Loader.dll`
- PR #279 合并树此前已通过本机 Node 812 项、Rust/native/Tauri、boot/GUI、NSIS/Portable 全量审计