### PR TITLE
fix(release): prevent formal updater from selecting AIO assets

### DIFF
--- a/dsh-desktop/client-updater.ts
+++ b/dsh-desktop/client-updater.ts
@@ -389,9 +389,19 @@ function selectAsset(release: ReleaseInfo, { platform = 'win32' }: PlatformAsset
   // V4 平台围栏：文件名带 linux/arm64 等标记的一律不选（双平台发布时
   // 防止误拿；x64 正则本身已排除 arm64，这里再显式拒绝）。
   // Tauri 便携：选 -portable.zip（树交换更新）；Electron 便携/安装版正则不变。
-  const wanted = isTauriPortable() ? /portable\.zip$/i : isPortable() ? /portable.*x64\.exe$/i : /setup.*x64\.exe$/i;
+  const wanted = isTauriPortable()
+    ? /portable\.zip$/i
+    : isPortable()
+      ? /portable.*x64\.exe$/i
+      : /(?:setup.*x64|x64.*setup)\.exe$/i;
   const platformOk = (name: string) => !/linux|arm64|aarch64|appimage|\.deb$|\.rpm$|\.snap$/i.test(name);
-  const direct = release.assets.find((a) => wanted.test(a.name) && platformOk(a.name));
+  // 一个 release 可以同步承载正式版、AIO、Launcher 等不同产品。旧逻辑只
+  // 看 Setup/Portable 后缀，API 或镜像一旦调整 assets 顺序，正式版客户端就
+  // 可能下载到 AIO 安装器。正式版自更新必须同时验证产品身份，不依赖顺序。
+  const officialProduct = (name: string) =>
+    /^deepseek(?:[. _-]+)harness(?:[. _-]+)eac(?:[. _-]|$)/i.test(name)
+    && !/(?:^|[. _-])aio(?:[. _-]|$)|launcher/i.test(name);
+  const direct = release.assets.find((a) => wanted.test(a.name) && platformOk(a.name) && officialProduct(a.name));
   if (direct) return { parts: [direct], name: direct.name, totalSize: direct.size };
 
   // Gitee 单文件 100MB 限制：安装包拆分为 <file>.part1 / <file>.part2 …

--- a/dsh-desktop/scripts/update-check-probe.js
+++ b/dsh-desktop/scripts/update-check-probe.js
@@ -24,7 +24,7 @@ app.whenReady().then(async () => {
     // 下载路径冒烟：取 Setup 资产 URL，用同一条 electron.net 网络栈拉前
     // 64KB，验证重定向到 CDN 后数据能到达且是有效 PE 文件（MZ 头）。
     const net = require('electron').net;
-    const setup = rel.assets.find((a) => /setup.*x64\.exe$/i.test(a.name));
+    const setup = cu.selectAsset(rel).parts[0];
     await new Promise((resolve, reject) => {
       let got = 0;
       let first2 = '';

--- a/dsh-desktop/test/client-updater-asset.test.ts
+++ b/dsh-desktop/test/client-updater-asset.test.ts
@@ -32,6 +32,35 @@ test('selectAsset picks versioned Setup artifact (Setup-v<ver>-x64.exe naming)',
   assert.equal(got.parts.length, 1);
 });
 
+test('selectAsset ignores AIO setup even when it appears before the formal installer', () => {
+  const rel = {
+    version: '5.3.6',
+    assets: [
+      A('DSHEAC-AIO-v1-Setup-x64.exe'),
+      A('Deepseek-Harness-EAC-5.3.6-Setup-x64.exe'),
+    ],
+  };
+  const got = selectAsset(rel);
+  assert.equal(got.name, 'Deepseek-Harness-EAC-5.3.6-Setup-x64.exe');
+});
+
+test('selectAsset accepts the native Tauri x64-setup artifact order', () => {
+  const rel = {
+    version: '5.3.6',
+    assets: [A('Deepseek.Harness.EAC_5.3.6_x64-setup.exe')],
+  };
+  const got = selectAsset(rel);
+  assert.equal(got.name, 'Deepseek.Harness.EAC_5.3.6_x64-setup.exe');
+});
+
+test('selectAsset rejects an AIO-only release for the formal client', () => {
+  const rel = {
+    version: '5.3.6',
+    assets: [A('DSHEAC-AIO-v1-Setup-x64.exe')],
+  };
+  assert.throws(() => selectAsset(rel), /未找到匹配/);
+});
+
 test('selectAsset still picks legacy versioned Portable artifact (<=v2.0.2 naming)', () => {
   const rel = {
     version: '2.0.2',

--- a/dsh-desktop/test/release-windows-asset-name.test.ts
+++ b/dsh-desktop/test/release-windows-asset-name.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflow = readFileSync(join(root, '.github', 'workflows', 'release-tauri.yml'), 'utf8');
+
+test('Windows release publishes the legacy-updater-compatible Setup-x64 name', () => {
+  assert.match(workflow, /Deepseek-Harness-EAC-\$version-Setup-x64\.exe/);
+  assert.match(workflow, /bundle\/nsis\/Deepseek-Harness-EAC-\*-Setup-x64\.exe/);
+  assert.match(workflow, /SHA256SUMS-windows-x64\.txt/);
+  assert.doesNotMatch(workflow, /^\s+tauri-shell\/target\/release\/bundle\/nsis\/\*\.exe\s*$/m);
+});


### PR DESCRIPTION
## 问题

v5.1 正式版更新器只按 Setup/x64 后缀匹配。v5.3.6 同一 Release 同时包含正式版与 AIO 时，正式包原名为 x64-setup，只有 AIO 的 Setup-x64 满足旧正则，导致热更新下载 AIO。

## 修复

- 正式版更新器增加 Deepseek Harness EAC 产品身份围栏，排除 AIO/Launcher。
- 同时兼容 Setup-x64 与 Tauri x64-setup 两种命名顺序。
- 更新检查探针复用正式选择器。
- 增加 AIO 在前、AIO-only、Tauri 原生命名回归测试。

线上 v5.3.6 Release 已同步修复：正式包改为 Deepseek-Harness-EAC-5.3.6-Setup-x64.exe，AIO 改为 DSHEAC-AIO-v1-Windows-x64.exe，并更新 SHA-256 清单。

## 验证

- dsh-desktop 全量测试：816 PASS / 4 SKIP / 0 FAIL（820）
- npm run typecheck：PASS
- v5.1 原始选择算法解析线上 Release：唯一候选为正式版安装包