### PR TITLE
fix(plugin): 全新安装默认展开 better-sidebar

### DIFF
--- a/docs/superpowers/specs/2026-09-04-better-sidebar-fresh-install-default-open-design.md
+++ b/docs/superpowers/specs/2026-09-04-better-sidebar-fresh-install-default-open-design.md
@@ -1,0 +1,37 @@
+# better-sidebar 全新安装默认展开设计
+
+## 目标
+
+全新安装 Deepseek Harness EAC 时，`dsh-better-sidebar` 的“新会话默认打开”
+开关默认为开启。已有安装升级后保持现状，已有会话布局和用户手动选择不变。
+
+## 方案
+
+EAC 在首次生成 `better-sidebar` profile 插件行时写入：
+
+```yaml
+config:
+  openByDefault: true
+```
+
+`dsh-better-sidebar` 将该部署配置作为用户设置命名空间的 base 层。用户设置层仍
+拥有更高优先级，因此用户关闭开关后会稳定保持关闭。
+
+现有 profile 中已存在的插件行不会被 `syncCompanionPlugins` 重写，因此升级用户
+不会获得这个新 base。插件自身在没有部署配置时继续使用 `false`，覆盖通过 bundle、
+市场或历史 profile 加载的既有安装。
+
+## 行为边界
+
+- 只影响尚未产生会话布局的新会话。
+- 已持久化的会话布局优先，不因默认值变化重新展开。
+- 窄屏和宿主剩余宽度保护继续生效。
+- 用户设置中的显式 `true` 或 `false` 均覆盖部署 base。
+- 不增加迁移，不扫描或改写已有 profile。
+
+## 验证
+
+- 锁定 `COMPANION_PLUGINS` 的新安装配置。
+- 锁定插件配置缺省仍为 `false`。
+- 锁定设置注册使用部署配置作为 base。
+- 运行 better-sidebar 定向测试、TypeScript build 和相关 profile/插件测试。

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/dsh.plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/dsh.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "dsh-external/dsh-better-sidebar",
-  "version": "0.15.3-eac.1",
+  "version": "0.15.3-eac.2",
   "main": "./lib/index.js",
   "description": "VSCode 风格右侧侧边栏：文件资源管理器 / 编辑器 / 终端 / Git / 浏览器，按会话隔离。暴露服务供其他插件注册侧边栏页面和文件预览器",
   "engines": {

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/index.js
@@ -33,6 +33,7 @@ const SIDEBAR_PREFS_NS = "dsh-better-sidebar";
 */
 /** Schemastery schema for the plugin configuration. */
 const Config = z.object({
+	openByDefault: z.boolean().default(false),
 	readLimit: z.number().step(1).min(1).default(524288),
 	mediaLimit: z.number().step(1).min(1).default(20971520),
 	uploadLimit: z.number().step(1).min(1).default(134217728),
@@ -50,6 +51,7 @@ const Config = z.object({
 */
 function resolveSidebarConfig(config) {
 	return {
+		openByDefault: config?.openByDefault ?? false,
 		readLimit: config?.readLimit ?? 524288,
 		mediaLimit: config?.mediaLimit ?? 20971520,
 		uploadLimit: config?.uploadLimit ?? 134217728,
@@ -3558,7 +3560,9 @@ function apply(ctx, config) {
 	};
 	ctx.inject(["settings"], (sctx) => {
 		const ns = settingsNamespace(SIDEBAR_PREFS_NS);
-		const scope = sctx.settings.register(ns, PrefsSchema);
+		const scope = sctx.settings.register(ns, PrefsSchema, {
+			base: { openByDefault: resolved.openByDefault }
+		});
 		const viewOf = () => {
 			const descriptor = sctx.settings.describe({ redactSecrets: true }).find((candidate) => candidate.ns === ns);
 			return descriptor === void 0 ? {

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/types/config.d.ts
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/lib/types/config.d.ts
@@ -9,6 +9,8 @@ import { type SidebarPrefs } from './prefs-shared.ts';
 export { SIDEBAR_PREFS_DEFAULTS, SIDEBAR_PREFS_NS, TERMINAL_FONT_SIZE_DEFAULT, TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN, TITLE_BAR_STRIP_DEFAULT, TITLE_BAR_STRIP_MAX, TITLE_BAR_STRIP_MIN, WIDTH_PERCENT_DEFAULT, WIDTH_PERCENT_MAX, WIDTH_PERCENT_MIN, type SidebarPrefs, } from './prefs-shared.ts';
 /** Tunable sidebar host limits (every field optional; defaults fill in). */
 export interface SidebarConfig {
+    /** Deployment base for whether brand-new conversations open the sidebar. */
+    openByDefault?: boolean;
     /** Read cap of one text file (bytes); larger files return truncated. */
     readLimit?: number;
     /** Media route cap (bytes); larger binaries are refused. */
@@ -42,6 +44,7 @@ export interface SidebarConfig {
 export declare const Config: z<SidebarConfig>;
 /** Fully defaulted sidebar host settings. */
 export interface ResolvedSidebarConfig {
+    openByDefault: boolean;
     readLimit: number;
     mediaLimit: number;
     uploadLimit: number;

--- a/dsh-desktop/assets/plugins/dsh-better-sidebar/package.json
+++ b/dsh-desktop/assets/plugins/dsh-better-sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-better-sidebar",
-  "version": "0.15.3-eac.1",
+  "version": "0.15.3-eac.2",
   "description": "DSH web plugin: a VSCode-like right sidebar (explorer / editor / terminal / git / browser), isolated per conversation session. Exposes a service for other plugins to register sidebar tabs and file viewers.",
   "type": "module",
   "repository": {

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -134,8 +134,9 @@ export const COMPANION_PLUGINS: CompanionPluginDef[] = [
   { id: 'meow-smooth', name: 'meow-smooth', dir: 'dsh-meow-smooth', config: { enabled: true } },
   // VSCode 风格右侧边栏（文件树 / 编辑器 / 终端 / Git，按会话隔离）。
   // lib/ 预编译自包含（codemirror、xterm 已内嵌），服务端仅额外依赖
-  // schemastery（已加入 app 闭包，见 package.json）。
-  { id: 'better-sidebar', name: 'dsh-better-sidebar', dir: 'dsh-better-sidebar' },
+  // schemastery（已加入 app 闭包，见 package.json）。config 只随缺失的新行写入；
+  // 已有 profile 行会在同步时跳过，保留升级用户的现有默认与自定义设置。
+  { id: 'better-sidebar', name: 'dsh-better-sidebar', dir: 'dsh-better-sidebar', config: { openByDefault: true } },
   // VCP 视觉通感协议（dsh-raw-html 0.6.1 EAC 托管版，源自 plolpl789，MIT）：消息 HTML 渲染
   // 为界面（卡片 / KaTeX / Mermaid / 内置 7 款 OFL 书法字体）。EAC 集成通过
   // conversation.chat.node 的 assistant-step slot 接管，不修改上游压缩 bundle。

--- a/dsh-desktop/test/better-sidebar-bundle.test.ts
+++ b/dsh-desktop/test/better-sidebar-bundle.test.ts
@@ -22,7 +22,7 @@ test('dsh-better-sidebar plugin package is vendored with prebuilt lib', () => {
   const pkg = JSON.parse(readFileSync(join(PLUGIN, 'package.json'), 'utf8'));
   const manifest = JSON.parse(readFileSync(join(PLUGIN, 'dsh.plugin.json'), 'utf8'));
   assert.equal(pkg.name, 'dsh-better-sidebar');
-  assert.equal(pkg.version, '0.15.3-eac.1',
+  assert.equal(pkg.version, '0.15.3-eac.2',
     'EAC must ship the patched 0.15.2-compatible build above the broken upstream version');
   assert.equal(manifest.version, pkg.version, 'EAC plugin manifest version must match package.json');
   assert.ok(existsSync(join(PLUGIN, 'lib', 'index.js')), 'server entry lib/index.js missing');
@@ -77,20 +77,36 @@ test('schemastery 在运行时闭包中可解析（声明 + node_modules 实装�
     'schemastery 未实装进 node_modules（stage npm ci 将据此进安装包）');
 });
 
-test('COMPANION_PLUGINS registers dsh-better-sidebar', () => {
+test('COMPANION_PLUGINS registers dsh-better-sidebar with a fresh-install open default', () => {
   // ADR 0002：注册表迁至 lib/desktop/companion-sync.js。
   const mainSrc = readFileSync(join(ROOT, 'lib', 'desktop', 'companion-sync.ts'), 'utf8');
-  assert.ok(/\{[^}]*id:\s*'better-sidebar'[^}]*name:\s*'dsh-better-sidebar'[^}]*\}/.test(mainSrc),
-    'COMPANION_PLUGINS entry missing');
+  assert.match(
+    mainSrc,
+    /\{\s*id:\s*'better-sidebar',\s*name:\s*'dsh-better-sidebar',\s*dir:\s*'dsh-better-sidebar',\s*config:\s*\{\s*openByDefault:\s*true\s*\}\s*\}/,
+    'newly generated profile rows must opt into opening the sidebar',
+  );
+  const existingRowGuard = mainSrc.indexOf('if (hasEntryId(patch, p.id)) continue;');
+  const configWrite = mainSrc.indexOf('block += configLinesFor(p.config)');
+  assert.ok(existingRowGuard >= 0 && configWrite > existingRowGuard,
+    'existing profile rows must be kept before new-row config is serialized');
 });
 
 test('vendored plugin ships without TypeScript sources (installer size)', () => {
   assert.equal(existsSync(join(PLUGIN, 'src')), false, 'src/ must not ship in the installer');
 });
 
-test('automatic better-sidebar restores do not collapse the host sidebar', () => {
+test('fresh-install open default composes below user settings without changing legacy defaults', () => {
   const serverSrc = readFileSync(join(PLUGIN, 'lib', 'index.js'), 'utf8');
-  assert.match(serverSrc, /openByDefault:\s*z\.boolean\(\)\.default\(false\)/,
+  assert.match(serverSrc, /const Config = z\.object\(\{\s*openByDefault:\s*z\.boolean\(\)\.default\(false\)/,
+    'deployment config must default false so existing profile rows keep their behavior');
+  assert.match(serverSrc, /openByDefault:\s*config\?\.openByDefault\s*\?\?\s*false/,
+    'direct callers without the new profile config must keep the legacy default');
+  assert.match(
+    serverSrc,
+    /sctx\.settings\.register\(ns,\s*PrefsSchema,\s*\{\s*base:\s*\{\s*openByDefault:\s*resolved\.openByDefault\s*\}\s*\}\)/,
+    'fresh-install config must be a settings base that explicit user values can override',
+  );
+  assert.match(serverSrc, /const PrefsSchema = z\.object\(\{\s*openByDefault:\s*z\.boolean\(\)\.default\(false\)/,
     'server preference schema must default openByDefault to false');
 
   for (const entry of ['client.js', 'client-registry.js']) {


### PR DESCRIPTION
## 目的

全新安装 Deepseek Harness EAC 时，让 `dsh-better-sidebar` 的“新会话默认打开”默认开启。

已有安装升级后保持原状：不改写已有 profile 插件行，不覆盖用户显式设置，也不改变已有会话持久化布局。

## 架构与范围

- L2 profile/plugin 同步：`COMPANION_PLUGINS` 仅在首次创建 `better-sidebar` 行时写入 `config.openByDefault: true`。
- vendored DSH 插件：增加部署配置 schema 和解析结果，并作为用户设置命名空间的 base 层。
- 插件版本：`dsh-better-sidebar` 从 `0.15.3-eac.1` 更新为 `0.15.3-eac.2`。
- 测试与设计：增加新安装默认值、存量兼容和设置层级契约。

## 风险与兼容

- `syncCompanionPlugins` 在序列化 config 前先执行 `hasEntryId` 检查，已有 profile 行直接跳过。
- 插件部署配置缺省仍为 `false`，历史 profile、bundle 或直接调用不会自动获得新默认值。
- 用户 settings 层优先于 base，用户手动关闭后仍保持关闭。
- 已有会话布局、窄屏保护和剩余宽度保护不变。

## 验证

- `npm run build`：通过（基于最新 `origin/main`，桌面版本 `5.3.6`）。
- 定向回归：8 个相关测试文件，共 66 项通过、0 失败。
- `npm test`：813 项，809 通过、4 项按平台跳过、0 失败。
- `node tauri-shell/stage-resources.mjs`：实现工作区资源装配成功，修改后的插件版本和配置进入 staging。
- 当前安装版 EAC 已完成重启，shell、sidecar 和 Web 服务正常拉起。

- [x] Skill 推荐的最低验证级别已完成
- [x] `git diff --check` 已通过
- [x] 没有无关文件、日志、凭据、用户数据或大范围行尾变化
- [x] UI 无现有安装可见改动，无需截图；变化仅在全新 profile 的默认状态
- [x] 未验证项已明确列出

未验证项：尚未使用新构建的真实安装包执行全新安装事务验收；当前自动化已覆盖首次行配置和存量行不重写契约。

## 配置与迁移

不增加迁移。仅对缺失的 `better-sidebar` profile 行写入：

```yaml
config:
  openByDefault: true
```

已有行保持不变。

## 回退方式

回退本提交即可恢复旧行为。由于没有存量配置迁移或用户数据改写，回退不需要修复 profile 或会话数据。