### PR TITLE
feat(guard): 版本兼容防线 —— 插件与内核版本对应关系启动前静态核验（dsh-plugin-shield 0.2.0）

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -47,6 +47,25 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
 官方版本升级自动检出并一键迁移/回滚 —— 核心在 L2 功能包引擎 + CLI，
 交互集成进 dsh-unified-market 插件；详见下方「功能包体系（Feature Pack）」批次）
 
+## next（版本兼容防线：插件与内核版本对应关系启动前静态核验）
+
+- **版本兼容防线（plugin-guard.ts v0.2 · dsh-plugin-shield 0.2.0）**：
+  `cordis.patch.yml` 引用的插件包/入口缺失（9/3 连环启动失败根因）、peer
+  依赖未满足、`dsh.client.inject` 客户端包缺失、`dsh.kernel` 版本窗口违例
+  在启动前静态检出（只读 manifest，绝不执行插件代码）；模块缺失与 peer
+  大版本不满足自动隔离 —— 快照先行 + patch disabled + 事故记录，内核照常
+  启动而非整树崩溃；`@deepseek-ai/*` 内核同源包不自动隔离（缺失为安装
+  损坏，走回滚/重装）。
+- peer 版本务实比对：rc/alpha 时代插件的 `*` 与 `^0.1.0-rc.x` 声明对实际
+  `-alpha/-rc` 内核版本按「剥 prerelease tag 宽松比对」，仅 major.minor
+  版本线不符判不兼容；semver 缺失环境自动降级为提示级，绝不误判。
+- 设置页「插件保护」新增「版本兼容防线」卡片：内核版本、逐条插件的
+  安装/入口/peer/inject/版本窗口状态与一键手动隔离。
+- 新契约：插件可在 package.json 声明 `dsh.kernel`（semver range 或
+  `{ min, max }`）声明兼容的内核版本窗口。
+- `guard.action` RPC 新增 `version` / `quarantine`；启动链路预检接入
+  `quarantineFatal`，重启服务即生效。
+
 ## 5.3.6（内置输入灵动岛与分发契约补强）· 2026-09-03
 
 - 内置 `dsh-composer-dynamic-island` 2.1.0（says693，MIT），作为推荐插件

--- a/dsh-desktop/assets/plugins/dsh-plugin-shield/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-plugin-shield/lib/client.js
@@ -88,7 +88,23 @@ window.__ModuleLoader__.load({
       busy: "处理中…",
       reason: "原因",
       pluginRows: "插件行",
-      files: "文件"
+      files: "文件",
+      compatTitle: "版本兼容防线",
+      compatIntro: "启动前与体检时静态核对每个插件与内核的对应关系：插件包/入口缺失（loader 必崩，9/3 连环启动失败根因）、peer 依赖不满足、客户端注入缺失、dsh.kernel 版本窗口违例。可自动处置的项在启动前已自动隔离（快照 + patch disabled + 事故记录），此处可查看明细或手动隔离。",
+      compatKernel: "内核版本",
+      compatEntries: "插件条目",
+      compatIssues: "存在问题",
+      compatHealthy: "全部对应正常",
+      compatNone: "（无可隔离项）",
+      compatInstalled: "未安装",
+      compatEntryMissing: "包/入口缺失",
+      compatPeerBad: "依赖不满足",
+      compatPeerDrift: "依赖漂移",
+      compatInjectBad: "注入缺失",
+      compatKernelBad: "版本窗口违例",
+      compatQuarantine: "隔离此插件",
+      quarantineConfirm: "隔离将立即把该插件在 cordis.patch.yml 中标记为 disabled（先自动创建快照，可随时回滚），重启 Web 服务后生效。确定继续？",
+      quarantined: "已隔离，重启 Web 服务后生效"
     };
     var en = {
       nav: "Plugin Guard",
@@ -123,7 +139,23 @@ window.__ModuleLoader__.load({
       busy: "Working…",
       reason: "reason",
       pluginRows: "plugin rows",
-      files: "files"
+      files: "files",
+      compatTitle: "Version Compatibility Line",
+      compatIntro: "Static checks on boot and in health checks: plugin package/entry missing (fatal for the loader — the root cause of the Sep 3 boot-failure chain), unsatisfied peer dependencies, missing client injects, and dsh.kernel window violations. Auto-quarantinable findings are isolated before boot (snapshot + patch disabled + incident); inspect details or quarantine manually here.",
+      compatKernel: "kernel version",
+      compatEntries: "plugin entries",
+      compatIssues: "issues",
+      compatHealthy: "all entries compatible",
+      compatNone: "(nothing to quarantine)",
+      compatInstalled: "not installed",
+      compatEntryMissing: "package/entry missing",
+      compatPeerBad: "dependency unsatisfied",
+      compatPeerDrift: "dependency drift",
+      compatInjectBad: "inject missing",
+      compatKernelBad: "kernel window violated",
+      compatQuarantine: "Quarantine",
+      quarantineConfirm: "Quarantining immediately marks this plugin as disabled in cordis.patch.yml (a snapshot is taken first; you can roll back anytime). Restart the web service to apply. Continue?",
+      quarantined: "Quarantined — restart the web service to apply"
     };
 
     var inject = ["slots", "locale"];
@@ -153,11 +185,21 @@ window.__ModuleLoader__.load({
       var incidentState = react.useState(null);
       var incident = incidentState[0];
       var setIncident = incidentState[1];
+      var versionState = react.useState(null);
+      var version = versionState[0];
+      var setVersion = versionState[1];
 
       var call = function (action, value) {
         if (!bridge) return Promise.resolve({ ok: false, error: "no-bridge" });
         return bridge.action(action, value);
       };
+
+      var loadVersion = react.useCallback(function () {
+        if (!bridge) return;
+        call("version").then(function (r) {
+          if (r && r.ok) setVersion(r.report || null);
+        }).catch(function () { /* 版本报告失败不打扰 */ });
+      }, [bridge]);
 
       var load = react.useCallback(function () {
         if (!bridge) { setData({ status: "no-bridge" }); return; }
@@ -168,6 +210,7 @@ window.__ModuleLoader__.load({
         }).catch(function (e) { setData({ status: "error", error: String(e) }); });
       }, [bridge]);
       react.useEffect(load, [load]);
+      react.useEffect(loadVersion, [loadVersion]);
 
       if (data.status === "loading") return h("div", { className: "__sh_root" }, h("p", { className: "__sh_hint" }, "…"));
       if (data.status === "no-bridge") {
@@ -218,9 +261,39 @@ window.__ModuleLoader__.load({
         setBusy("resolve:" + id);
         call("resolve-incident", id).then(function () { setBusy(null); setIncident(null); load(); }).catch(function () { setBusy(null); });
       };
+      var doQuarantine = function (id) {
+        if (!window.confirm(t("quarantineConfirm"))) return;
+        setBusy("q:" + id);
+        call("quarantine", id).then(function (r) {
+          setBusy(null);
+          if (r && r.ok) { window.alert(t("quarantined")); loadVersion(); load(); }
+          else window.alert(String((r && r.error) || "failed"));
+        }).catch(function () { setBusy(null); });
+      };
 
       var findings = report && report.findings ? report.findings : null;
       var repairedList = report && report.repaired ? report.repaired : null;
+
+      var compatEntries = version && version.entries ? version.entries : null;
+      var compatIssues = function (e) {
+        var out = [];
+        if (!e.installed) out.push(t("compatInstalled"));
+        if (e.installed && !e.entryPoint) out.push(t("compatEntryMissing"));
+        if (!e.enabled) return out;
+        (e.peers || []).forEach(function (p) {
+          if (p.optional) return; // 可选 peer 不算问题
+          if (p.verdict === "missing" || p.verdict === "high") out.push(p.dep + " → " + t("compatPeerBad"));
+          else if (p.verdict === "low") out.push(p.dep + " → " + t("compatPeerDrift"));
+        });
+        (e.inject || []).forEach(function (i2) { if (i2.ok !== true) out.push(i2.dep + " → " + t("compatInjectBad")); });
+        (e.issues || []).forEach(function (i3) { out.push(t("compatKernelBad") + "：" + i3); });
+        return out;
+      };
+      var compatQuarantinable = function (e) {
+        if (!e.enabled || !e.id) return false;
+        if (!e.installed || (e.installed && !e.entryPoint)) return true;
+        return (e.peers || []).some(function (p) { return p.verdict === "missing" || p.verdict === "high"; });
+      };
 
       return h("div", { className: "__sh_root" },
         h("p", { className: "__sh_hint", style: { margin: 0 } }, t("intro")),
@@ -252,6 +325,38 @@ window.__ModuleLoader__.load({
         repairedList ? h("div", null,
           repairedList.length ? h("p", { className: "__sh_ok" }, t("repaired") + "：") : h("p", { className: "__sh_ok" }, t("repairedNone")),
           repairedList.length ? h("ul", { className: "__sh_hint" }, repairedList.map(function (a, i) { return h("li", { key: String(i) }, a); })) : null
+        ) : null,
+
+        compatEntries ? h("div", null,
+          h("h3", { className: "__sh_h3" }, t("compatTitle")),
+          h("p", { className: "__sh_hint" }, t("compatIntro")),
+          version && version.kernel ? h("div", { className: "__sh_cards" },
+            h("div", { className: "__sh_card" }, h("div", { className: "__sh_cardk" }, t("compatKernel")), h("div", { className: "__sh_cardv" }, String(version.kernel.version || "—"))),
+            h("div", { className: "__sh_card" }, h("div", { className: "__sh_cardk" }, t("compatEntries")), h("div", { className: "__sh_cardv" }, String(compatEntries.length))),
+            h("div", { className: "__sh_card" },
+              h("div", { className: "__sh_cardk" }, t("compatIssues")),
+              h("div", { className: "__sh_cardv", style: { color: compatEntries.some(compatIssues) ? "var(--dsw-alias-state-error-primary)" : undefined } },
+                String(compatEntries.filter(compatIssues).length))
+            )
+          ) : null,
+          compatEntries.filter(compatIssues).length === 0 ? h("p", { className: "__sh_ok" }, t("compatHealthy")) :
+            h("div", { className: "__sh_list", style: { maxHeight: 360 } }, compatEntries.map(function (e, i) {
+              var issues = compatIssues(e);
+              if (!issues.length) return null;
+              return h("div", { className: "__sh_row", key: String(i) },
+                h("div", { className: "__sh_rowmain" },
+                  h("div", { className: "__sh_rowtitle" }, String(e.name || e.id) + (e.version ? " v" + e.version : "") + (e.enabled ? "" : "（disabled）")),
+                  h("div", { className: "__sh_rowsub" }, issues.map(function (m, k) {
+                    return h("div", { key: String(k), className: k < 2 ? "__sh_err" : "__sh_warn" }, "· " + m);
+                  }))
+                ),
+                compatQuarantinable(e) ? h("button", {
+                  className: "__sh_btn __sh_btnDanger",
+                  disabled: !!busy,
+                  onClick: function () { doQuarantine(e.id); }
+                }, busy === "q:" + e.id ? t("busy") : t("compatQuarantine")) : null
+              );
+            }))
         ) : null,
 
         h("div", null,

--- a/dsh-desktop/assets/plugins/dsh-plugin-shield/package.json
+++ b/dsh-desktop/assets/plugins/dsh-plugin-shield/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-plugin-shield",
-  "description": "插件保护中心（DSH Desktop 配套插件）：快照/一键回滚/健康检查/事故报告，经桌面壳 IPC 驱动内置 plugin-guard 引擎 —— 融合 dsh-plugin-guard / dsh-web-plugin-manager / dsh-plugin-healthcheck 三大社区保护插件并内置",
-  "version": "0.1.0",
+  "description": "插件保护中心 · 版本兼容防线（DSH Desktop 配套插件）：启动前 static 核对插件与内核的版本对应关系（包/入口缺失、peer 依赖、client 注入、dsh.kernel 窗口），自动隔离不兼容插件防内核崩溃；快照/一键回滚/健康检查/事故报告，经桌面壳 IPC 驱动内置 plugin-guard 引擎。",
+  "version": "0.2.0",
   "type": "module",
   "main": "lib/index.js",
   "exports": {

--- a/dsh-desktop/plugin-guard.ts
+++ b/dsh-desktop/plugin-guard.ts
@@ -36,6 +36,19 @@ const { healSoulMdPatchRow, removeBundledRowDuplicates, collectBundleEntryIds } 
   removeBundledRowDuplicates(patch: string, rowIds: Record<string, unknown>, bundleNames: unknown[], bundleEntryIds: Set<string>): { patch: string; removed: string[] };
   collectBundleEntryIds(bundleNames: unknown[], profileNodeModules: string): Set<string>;
 };
+const { togglePluginInPatch } = require('./scripts/plugin-manager-patch') as {
+  togglePluginInPatch(text: string, id: string, enabled: boolean, name?: string): string;
+};
+// semver 随 dsh 内核闭包/锁文件携带；个别精简环境缺失时降级：peer 版本比对
+// 全部按「提示级」处理（绝不误判、绝不崩），模块缺失/入口/注入检查不受影响。
+interface SemverLike {
+  satisfies(v: string, r: string): boolean;
+  validRange(r: string): string | null;
+  minVersion(r: string): { major: number; minor: number; patch: number } | null;
+  coerce(v: string): { major: number; minor: number; patch: number } | null;
+}
+let semverLib: SemverLike | null = null;
+try { semverLib = require('semver') as SemverLike; } catch { /* semver 不可用 → 降级 */ }
 
 // 快照覆盖的 profile 配置面：插件树的全部「声明性」状态。
 const GUARD_FILES: string[] = ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'cordis.patch.yml'];
@@ -79,6 +92,42 @@ interface Finding {
   severity: 'high' | 'medium' | 'low';
   message: string;
   fixable: boolean;
+  /** 版本兼容防线的发现项归属（patch 行条目），供自动/手动隔离定位。 */
+  entry?: { id: string | null; name: string; fromBundle?: boolean };
+}
+
+/** 版本兼容防线（v0.2）：内核版本 + 每条 patch 条目的安装/入口/peer/inject 状态。 */
+interface CompatPeer {
+  dep: string;
+  required: string;
+  actual: string | null;
+  verdict: 'ok' | 'low' | 'high' | 'missing' | 'optional';
+  ok: boolean;
+  optional: boolean;
+}
+interface CompatInject {
+  dep: string;
+  ok: boolean;
+  alias?: boolean;
+}
+interface CompatRow {
+  id: string | null;
+  name: string | null;
+  enabled: boolean;
+  fromBundle: boolean;
+  installed: boolean;
+  version: string | null;
+  entryPoint: string | null;
+  kernelWindow: string | null;
+  peers: CompatPeer[];
+  inject: CompatInject[];
+  issues: string[];
+}
+interface CompatReport {
+  at: string;
+  profile: string;
+  kernel: { name: string; version: string | null };
+  entries: CompatRow[];
 }
 
 interface GuardState {
@@ -107,6 +156,11 @@ interface GuardApi {
   readIncident(id: string): { ok: boolean; content?: string; error?: string };
   resolveIncident(id: string): { ok: boolean; error?: string };
   attributeBootFailure(errText: string): BootAttribution | null;
+  // 版本兼容防线（v0.2）
+  compatFindings(dir?: string): Finding[];
+  versionReport(): CompatReport;
+  quarantineFatal(opts?: { quarantinePeers?: boolean }): { checked: number; quarantined: string[] };
+  quarantineById(id: string): { ok: boolean; error?: string; snapshot?: string | null; alreadyDisabled?: boolean; restartRequired?: boolean };
 }
 
 function createGuard(opts: GuardOpts): GuardApi {
@@ -268,6 +322,10 @@ function createGuard(opts: GuardOpts): GuardApi {
 
     // 高危静态扫描：只扫非内置的第三方包。
     findings.push(...trojanFindings(dir));
+
+    // 版本兼容防线（v0.2）：插件包/入口缺失、peer 依赖不满足、client 注入
+    // 缺失、内核版本窗口违例（只读 manifest，绝不执行插件代码）。
+    findings.push(...compatFindings(dir));
 
     return { at: new Date().toISOString(), profile: getProfile(), findings };
   }
@@ -469,6 +527,419 @@ function createGuard(opts: GuardOpts): GuardApi {
     return out;
   }
 
+  // ── 版本兼容防线（v0.2）────────────────────────────────────────────
+  // 把「插件与内核/依赖对不上」在启动前静态揪出来，而不是等 loader import
+  // 时整棵插件树崩掉（实战根因：cordis.patch.yml 引用 dsh-memory 但包缺失
+  // → ERR_MODULE_NOT_FOUND → dsh web 退出码 1 连环事故）。只读 manifest 与
+  // package.json（绝不执行插件代码）；可自动处置的发现项走「快照 → patch
+  // disabled → incident」隔离，与其余 repair 同层：只动配置面与插件层。
+  //
+  // 检查面：
+  //   ENTRY_MODULE_MISSING    patch 行/bundle 引用的插件包或入口文件缺失
+  //                           （loader import 必崩）
+  //   ENTRY_PEER_UNSATISFIED  peerDependencies 未安装或大版本线不满足
+  //   PEER_RANGE_DRIFT        peer 版本仅 pre-release/patch 层面漂移（提示级）
+  //   ENTRY_INJECT_MISSING    dsh.client.inject 引用的客户端包缺失（UI 挂点崩）
+  //   KERNEL_RANGE_VIOLATION  dsh.kernel 声明的版本窗口与内核不匹配（新契约）
+  // 隔离边界：@deepseek-ai/* 内核同源包不自动隔离（缺失=安装损坏，走回滚/重装）。
+  const COMPAT_MAX_FINDINGS = 40;
+  const COMPAT_CORE_PREFIXES = ['@deepseek-ai/'];
+
+  interface PatchEntryRow {
+    id: string | null;
+    name: string | null;
+    disabled: boolean;
+    inInsert: boolean;
+    fromBundle: boolean;
+  }
+
+  function patchEntryRows(dir: string): PatchEntryRow[] {
+    const out: PatchEntryRow[] = [];
+    const file = path.join(dir, 'cordis.patch.yml');
+    let text: string;
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch {
+      return out;
+    }
+    const lines = text.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line) continue;
+      const m = /^([ \t]*)- id:\s*([A-Za-z0-9_.-]+)\s*$/.exec(line);
+      if (!m) continue;
+      const indent = m[1]!.length;
+      const entry: PatchEntryRow = { id: m[2]!, name: null, disabled: false, inInsert: indent > 0, fromBundle: false };
+      for (let j = i + 1; j < lines.length; j++) {
+        const l2 = lines[j];
+        if (!l2) break;
+        const m2 = /^([ \t]*)(.*)$/.exec(l2);
+        if (!m2) break;
+        const ws = m2[1] ?? '';
+        const rest = m2[2] ?? '';
+        if (!rest || ws.length <= indent) break; // 兄弟条目 / 外层结构：块结束
+        const nm = /^name:\s*['"]?([^'"\s]+)['"]?\s*(?:#.*)?$/.exec(rest);
+        if (nm) entry.name = nm[1]!;
+        const dm = /^disabled:\s*(true|false)\b/.exec(rest);
+        if (dm) entry.disabled = dm[1] === 'true';
+      }
+      out.push(entry);
+    }
+    // bundle 聚合（profile package.json dsh.profile.bundles）：bundle 包自身
+    // 缺失同样会拖垮启动 → 并入条目集做存在性检查。
+    const manifest = readJson(path.join(dir, 'package.json'), {});
+    const bundles: string[] = (manifest.dsh && manifest.dsh.profile && Array.isArray(manifest.dsh.profile.bundles)) ? manifest.dsh.profile.bundles : [];
+    for (const name of bundles) {
+      if (out.some((e) => e.name === name || e.id === name)) continue;
+      out.push({ id: null, name, disabled: false, inInsert: false, fromBundle: true });
+    }
+    return out;
+  }
+
+  // 包目录查找：profile node_modules → 共享 junction 层 → 安装闭包 node_modules。
+  function resolvePkgDir(dir: string, name: string): string | null {
+    const roots = [path.join(dir, 'node_modules'), path.join(home(), 'profiles', 'node_modules')];
+    const closure = expectedClosureRoot();
+    if (closure) roots.push(closure); // expectedClosureRoot 即 node_modules 根
+    for (const root of roots) {
+      const p = path.join(root, ...String(name).split('/'));
+      try {
+        if (fs.statSync(p).isDirectory() && fs.existsSync(path.join(p, 'package.json'))) return p;
+      } catch { /* 顺着找 */ }
+    }
+    return null;
+  }
+
+  // 入口解析：exports['.'] → main → index.js（对齐 ESM loader 行为）。
+  function resolveEntryPoint(pkgDir: string, pkg: Record<string, unknown> | null): string | null {
+    const candidates: string[] = [];
+    const dot = pkg && pkg.exports && typeof pkg.exports === 'object' ? (pkg.exports as Record<string, unknown>)['.'] : null;
+    if (typeof dot === 'string') candidates.push(dot);
+    else if (dot && typeof dot === 'object') {
+      const ex = dot as Record<string, unknown>;
+      if (typeof ex.import === 'string') candidates.push(ex.import);
+      if (typeof ex.default === 'string') candidates.push(ex.default);
+      if (typeof ex.require === 'string') candidates.push(ex.require);
+    }
+    if (pkg && typeof pkg.main === 'string') candidates.push(pkg.main);
+    candidates.push('index.js');
+    for (const c of candidates) {
+      const p = path.join(pkgDir, c);
+      try {
+        if (fs.statSync(p).isFile()) return p;
+        if (fs.statSync(p).isDirectory() && fs.existsSync(path.join(p, 'index.js'))) return path.join(p, 'index.js');
+      } catch { /* 下一个候选 */ }
+    }
+    return null;
+  }
+
+  // 依赖实际版本查找（peers 对照）：profile → 共享层 → 闭包。
+  function resolveDepVersion(dir: string, dep: string): string | null {
+    const roots = [path.join(dir, 'node_modules'), path.join(home(), 'profiles', 'node_modules')];
+    const closure = expectedClosureRoot();
+    if (closure) roots.push(closure);
+    for (const root of roots) {
+      const pkg = readJson(path.join(root, ...String(dep).split('/'), 'package.json'), null);
+      if (pkg && pkg.version) return pkg.version;
+    }
+    return null;
+  }
+
+  // 内核版本：从安装闭包 @deepseek-ai/dsh 读（expectedClosureRoot 即闭包
+  // node_modules 根；dshBin 已区分内置/overlay）。
+  function kernelVersion(): string | null {
+    const closure = expectedClosureRoot();
+    if (!closure) return null;
+    const pkg = readJson(path.join(closure, '@deepseek-ai', 'dsh', 'package.json'), null);
+    return (pkg && pkg.version) || null;
+  }
+
+  // peer 版本务实比对：dsh 生态在 rc/alpha 时代普遍用 `*`、^0.1.0-rc.x 声明
+  // 兼容范围，而内核实际版本常带 -alpha/-rc tag —— 严格 semver（prerelease
+  // 版本只匹配显式含同族 prerelease 的 range）会把全部兼容插件误报为不兼容。
+  // 策略：先严格比对；失败则剥掉全部 prerelease tag 宽松比对；仍失败且
+  // 主次版本线（major.minor）不一致 → 真不兼容（'high'，可隔离）；仅
+  // prerelease/patch 层面差 → 'low'（提示级，不隔离）。semver 不可用时
+  // 全部落 'low'，绝不误判。
+  function peerCheck(got: string, want: string): 'ok' | 'low' | 'high' {
+    if (semverLib) {
+      try { if (semverLib.satisfies(got, want)) return 'ok'; } catch { /* 落宽松 */ }
+    }
+    const strip = (r: string) => String(r).replace(/-[0-9A-Za-z.-]+/g, '').trim();
+    try {
+      const w2 = strip(want);
+      const g2 = strip(got);
+      if (!w2 || w2 === '*' || w2 === 'x') return 'ok'; // 任意版本
+      if (!semverLib) return 'low'; // semver 不可用 → 提示级
+      if (!semverLib.validRange(w2)) return 'low'; // range 无法解析 → 提示级
+      if (semverLib.satisfies(g2, w2)) return 'ok'; // 剥 tag 后满足 → 生态兼容
+      // 宽松仍不满足 → 区分真不兼容（主次版本线不符）与补丁/预发布漂移
+      const wMin = semverLib.minVersion(w2);
+      const gv = semverLib.coerce(g2);
+      if (wMin && gv && (wMin.major !== gv.major || wMin.minor !== gv.minor)) return 'high';
+      return 'low';
+    } catch {
+      return 'low';
+    }
+  }
+
+  // dsh.kernel 契约：semver range 字符串或 { min, max }；不满足返回说明，否则 null。
+  function kernelWindowCheck(pkg: Record<string, unknown> | null, kernel: string | null): string | null {
+    const w = pkg && pkg.dsh ? (pkg.dsh as Record<string, unknown>).kernel : null;
+    if (!w || w === true) return null; // 未声明 / true = 只要求运行在 dsh 内核上
+    if (!semverLib) return null;
+    try {
+      if (typeof w === 'string') {
+        if (!kernel || !semverLib.validRange(w)) return null;
+        return semverLib.satisfies(kernel, w) ? null : `要求 ${w}，当前 ${kernel || '未知'}`;
+      }
+      if (w && typeof w === 'object') {
+        const k = kernel || '0.0.0';
+        const wo = w as Record<string, unknown>;
+        if (typeof wo.min === 'string' && !semverLib.satisfies(k, '>=' + wo.min)) return `要求 >=${wo.min}，当前 ${kernel || '未知'}`;
+        if (typeof wo.max === 'string' && !semverLib.satisfies(k, '<=' + wo.max)) return `要求 <=${wo.max}，当前 ${kernel || '未知'}`;
+      }
+    } catch { /* 声明不可解析 → 不拦 */ }
+    return null;
+  }
+
+  function compatFindings(dir: string): Finding[] {
+    const out: Finding[] = [];
+    const kernel = kernelVersion();
+    for (const entry of patchEntryRows(dir)) {
+      if (out.length >= COMPAT_MAX_FINDINGS) break;
+      const name = entry.name || entry.id;
+      if (!name) continue;
+      const pkgDir = resolvePkgDir(dir, name);
+      if (!pkgDir) {
+        if (!entry.disabled) {
+          out.push({
+            code: 'ENTRY_MODULE_MISSING', severity: 'high', fixable: true,
+            entry: { id: entry.id, name, fromBundle: entry.fromBundle },
+            message: `${entry.fromBundle ? 'bundle' : 'patch 行'} ${entry.id || name}（${name}）引用的插件包不存在（loader import 必崩）`,
+          });
+        }
+        continue;
+      }
+      const pkg = readJson(path.join(pkgDir, 'package.json'), null) as Record<string, unknown> | null;
+      if (!entry.disabled && pkg && !resolveEntryPoint(pkgDir, pkg)) {
+        out.push({
+          code: 'ENTRY_MODULE_MISSING', severity: 'high', fixable: true,
+          entry: { id: entry.id, name },
+          message: `${entry.id || name}（${name}）的入口文件缺失（main/exports 均不可解析）: ${path.relative(dir, pkgDir)}`,
+        });
+      }
+      if (!entry.disabled && pkg && pkg.peerDependencies) {
+        const optional = pkg.peerDependenciesMeta && typeof pkg.peerDependenciesMeta === 'object' ? pkg.peerDependenciesMeta as Record<string, Record<string, unknown>> : {};
+        const peers = pkg.peerDependencies as Record<string, unknown>;
+        let n = 0;
+        for (const dep of Object.keys(peers)) {
+          if (n >= 4 || out.length >= COMPAT_MAX_FINDINGS) break;
+          if (optional[dep] && optional[dep].optional === true) continue; // 可选 peer：不拦
+          const want = String(peers[dep]);
+          const got = resolveDepVersion(dir, dep);
+          if (!got) {
+            n += 1;
+            out.push({
+              code: 'ENTRY_PEER_UNSATISFIED', severity: 'high', fixable: true,
+              entry: { id: entry.id, name },
+              message: `${entry.id || name}（${name}）的运行时依赖 ${dep}（要求 ${want}）未安装`,
+            });
+            continue;
+          }
+          const verdict = peerCheck(got, want);
+          if (verdict === 'high') {
+            n += 1;
+            out.push({
+              code: 'ENTRY_PEER_UNSATISFIED', severity: 'high', fixable: true,
+              entry: { id: entry.id, name },
+              message: `${entry.id || name}（${name}）的运行时依赖不兼容：${dep} 要求 ${want}，实际 ${got}`,
+            });
+          } else if (verdict === 'low') {
+            n += 1;
+            out.push({
+              code: 'PEER_RANGE_DRIFT', severity: 'low', fixable: false,
+              entry: { id: entry.id, name },
+              message: `${entry.id || name}（${name}）依赖 ${dep} 版本漂移：要求 ${want}，实际 ${got}（预发布/补丁级差异，仅提示）`,
+            });
+          }
+        }
+      }
+      // dsh.client.inject 客户端包缺失 → web UI 挂点崩（只报告，自动隔离无意义）。
+      // 裸名依赖是内核的别名机制（如 slots → @deepseek-ai/dsh-client-ui-slots），
+      // 只有含 @scope/ 或裸包名的完整引用才做存在性检查。
+      if (!entry.disabled && pkg && pkg.dsh) {
+        const dshMeta = pkg.dsh as Record<string, unknown>;
+        const inject = dshMeta.client && typeof dshMeta.client === 'object' ? (dshMeta.client as Record<string, unknown>).inject : null;
+        if (Array.isArray(inject)) {
+          let n = 0;
+          for (const dep of inject as string[]) {
+            if (n >= 3 || out.length >= COMPAT_MAX_FINDINGS) break;
+            if (!String(dep).includes('/') && !String(dep).startsWith('@')) continue; // 别名引用：交给内核解析
+            if (!resolvePkgDir(dir, dep)) {
+              n += 1;
+              out.push({
+                code: 'ENTRY_INJECT_MISSING', severity: 'medium', fixable: false,
+                entry: { id: entry.id, name },
+                message: `${entry.id || name}（${name}）注入的客户端包 ${dep} 不存在（UI 挂点缺失）`,
+              });
+            }
+          }
+        }
+      }
+      // 内核版本窗口（dsh.kernel 新契约）。
+      const badWindow = !entry.disabled && pkg ? kernelWindowCheck(pkg, kernel) : null;
+      if (badWindow) {
+        out.push({
+          code: 'KERNEL_RANGE_VIOLATION', severity: 'medium', fixable: true,
+          entry: { id: entry.id, name },
+          message: `${entry.id || name}（${name}）声明与内核版本不兼容：${badWindow}`,
+        });
+      }
+    }
+    return out;
+  }
+
+  // 隔离执行器：快照先行 → patch disabled（togglePluginInPatch，防 loader
+  // 双登记）→ 原子写 → incident 留痕。@deepseek-ai/* 同源内核包跳过。
+  function quarantineEligible(findings: Finding[] | null | undefined, dirP?: string): string[] {
+    const unique: Array<{ id: string | null; name: string | null; message: string }> = [];
+    for (const f of findings || []) {
+      if (!f || !f.entry) continue;
+      const { id, name } = f.entry;
+      const key = id || name;
+      if (!key || unique.some((u) => (u.id || u.name) === key)) continue;
+      if (name && COMPAT_CORE_PREFIXES.some((p) => String(name).startsWith(p))) continue;
+      unique.push({ id, name, message: f.message });
+    }
+    if (!unique.length) return [];
+    const dir = dirP || profileDir();
+    const snap = snapshot('隔离不兼容插件: ' + unique.map((u) => u.id || u.name).join(','));
+    const file = path.join(dir, 'cordis.patch.yml');
+    let text = '';
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch {
+      return [];
+    }
+    if (!text.trim()) return [];
+    const applied: string[] = [];
+    for (const u of unique) {
+      if (!u.id) continue; // bundle 行无 id 无法 toggle → 仅报告
+      try {
+        const patched = togglePluginInPatch(text, u.id, false, u.name || u.id);
+        if (patched === text) continue; // 已是 disabled
+        text = patched;
+        applied.push(`隔离 ${u.id}（${u.name || u.id}：${u.message}）`);
+      } catch (err) {
+        log('guard', `隔离 ${u.id} 失败: ${(err as Error).message}`);
+      }
+    }
+    if (applied.length) {
+      try {
+        writeFileAtomic(file, text);
+        reportIncident('compat 自动隔离', `启动前版本兼容体检发现并隔离 ${applied.length} 个不兼容插件：\n\n${applied.join('\n')}${snap ? `\n\n已先创建快照 ${snap.id}（插件保护中心可随时回滚）` : ''}`);
+        log('guard', '版本兼容体检自动隔离: ' + applied.join('；'));
+      } catch (err) {
+        log('guard', '写隔离配置失败: ' + (err as Error).message);
+      }
+    }
+    return applied;
+  }
+
+  // 启动前预检：ENTRY_MODULE_MISSING 必然拖垮启动，无条件隔离；
+  // ENTRY_PEER_UNSATISFIED 默认也隔离（quarantinePeers=false 关闭）。
+  function quarantineFatal(opts?: { quarantinePeers?: boolean }): { checked: number; quarantined: string[] } {
+    const findings = compatFindings(profileDir());
+    const eligible = findings.filter((f) => f.code === 'ENTRY_MODULE_MISSING' || (opts && opts.quarantinePeers !== false && f.code === 'ENTRY_PEER_UNSATISFIED'));
+    const applied = quarantineEligible(eligible, undefined);
+    return { checked: findings.length, quarantined: applied };
+  }
+
+  // 手动隔离（UI/IPC）：按 patch 行 id 禁入指定插件。
+  function quarantineById(id: string): { ok: boolean; error?: string; snapshot?: string | null; alreadyDisabled?: boolean; restartRequired?: boolean } {
+    const dir = profileDir();
+    const row = patchEntryRows(dir).find((e) => e.id === id);
+    if (!row) return { ok: false, error: 'patch 行不存在: ' + String(id) };
+    if (row.name && COMPAT_CORE_PREFIXES.some((p) => String(row.name).startsWith(p))) {
+      return { ok: false, error: '内核同源插件不建议隔离（缺失时应走回滚/重装）: ' + id };
+    }
+    const snap = snapshot('手动隔离插件: ' + id);
+    const file = path.join(dir, 'cordis.patch.yml');
+    let text = '';
+    try {
+      text = fs.readFileSync(file, 'utf8');
+    } catch { /* 空 */ }
+    if (!text) return { ok: false, error: 'patch 文件不可读' };
+    let patched: string;
+    try {
+      patched = togglePluginInPatch(text, id, false, row.name || id);
+    } catch (err) {
+      return { ok: false, error: String((err as Error).message) };
+    }
+    if (patched === text) return { ok: true, alreadyDisabled: true };
+    try {
+      writeFileAtomic(file, patched);
+      reportIncident('compat 手动隔离', `手动隔离插件 ${id}（${row.name || id}）${snap ? `，快照 ${snap.id}` : ''}`);
+    } catch (err) {
+      return { ok: false, error: String((err as Error).message) };
+    }
+    return { ok: true, snapshot: snap ? snap.id : null, restartRequired: true };
+  }
+
+  // 完整版本兼容报告（UI 展示）：内核版本 + 每条 patch 条目的安装/入口/peer/
+  // inject/版本窗口状态。
+  function versionReport(): CompatReport {
+    const dir = profileDir();
+    const kernel: CompatReport['kernel'] = { name: '@deepseek-ai/dsh', version: kernelVersion() };
+    const entries: CompatRow[] = [];
+    for (const entry of patchEntryRows(dir)) {
+      const name = entry.name || entry.id;
+      const row: CompatRow = {
+        id: entry.id, name, enabled: !entry.disabled, fromBundle: entry.fromBundle,
+        installed: false, version: null, entryPoint: null, kernelWindow: null,
+        peers: [], inject: [], issues: [],
+      };
+      const pkgDir = name ? resolvePkgDir(dir, name) : null;
+      const pkg = pkgDir ? readJson(path.join(pkgDir, 'package.json'), null) as Record<string, unknown> | null : null;
+      if (pkgDir && pkg) {
+        row.installed = true;
+        row.version = typeof pkg.version === 'string' ? pkg.version : null;
+        row.entryPoint = resolveEntryPoint(pkgDir, pkg);
+        row.kernelWindow = pkg.dsh && typeof pkg.dsh === 'object' ? String((pkg.dsh as Record<string, unknown>).kernel || '') || null : null;
+        if (pkg.peerDependencies) {
+          const optional = pkg.peerDependenciesMeta && typeof pkg.peerDependenciesMeta === 'object' ? pkg.peerDependenciesMeta as Record<string, Record<string, unknown>> : {};
+          const peers = pkg.peerDependencies as Record<string, unknown>;
+          for (const dep of Object.keys(peers)) {
+            const want = String(peers[dep]);
+            const got = resolveDepVersion(dir, dep);
+            const optionalFlag = !!(optional[dep] && optional[dep].optional === true);
+            let verdict: CompatPeer['verdict'] = got ? peerCheck(got, want) : 'missing';
+            if (optionalFlag) verdict = 'optional'; // 可选 peer：缺失/漂移都不算问题
+            row.peers.push({ dep, required: want, actual: got, verdict, ok: verdict === 'ok' || verdict === 'optional', optional: optionalFlag });
+          }
+        }
+        if (pkg.dsh) {
+          const dshMeta = pkg.dsh as Record<string, unknown>;
+          const inject = dshMeta.client && typeof dshMeta.client === 'object' ? (dshMeta.client as Record<string, unknown>).inject : null;
+          if (Array.isArray(inject)) {
+            for (const dep of inject as string[]) {
+              if (!String(dep).includes('/') && !String(dep).startsWith('@')) {
+                row.inject.push({ dep, ok: true, alias: true }); // 内核别名机制
+                continue;
+              }
+              row.inject.push({ dep, ok: !!resolvePkgDir(dir, dep) });
+            }
+          }
+        }
+        const bw = kernelWindowCheck(pkg, kernel.version);
+        if (bw) row.issues.push(bw);
+      }
+      entries.push(row);
+    }
+    return { at: new Date().toISOString(), profile: getProfile(), kernel, entries };
+  }
+
   // ── 修复执行器（只动插件/配置层）────────────────────────────────────
   function repair(findings?: Finding[]): { applied: string[] } {
     const applied: string[] = [];
@@ -510,6 +981,13 @@ function createGuard(opts: GuardOpts): GuardApi {
     if (list.some((f) => f.code === 'JUNCTION_FOREIGN' || f.code === 'JUNCTION_DANGLING')) {
       const result = repairJunctions();
       if (result.repaired.length) applied.push('恢复共享模块指向: ' + result.repaired.slice(0, 5).join(', ') + (result.repaired.length > 5 ? ` 等 ${result.repaired.length} 个` : ''));
+    }
+
+    // 版本兼容防线：模块缺失 / peer 不满足 / 内核窗口违例 → 自动隔离
+    //（快照 + patch disabled + incident）。
+    if (list.some((f) => f.code === 'ENTRY_MODULE_MISSING' || f.code === 'ENTRY_PEER_UNSATISFIED' || f.code === 'KERNEL_RANGE_VIOLATION')) {
+      const zapped = quarantineEligible(list, dir);
+      applied.push(...zapped);
     }
 
     return { applied };
@@ -742,6 +1220,8 @@ function createGuard(opts: GuardOpts): GuardApi {
     healthCheck, repair, repairJunctions, junctionFindings,
     reportIncident, listIncidents, readIncident, resolveIncident,
     attributeBootFailure,
+    // 版本兼容防线（v0.2）
+    compatFindings, versionReport, quarantineFatal, quarantineById,
   };
 }
 

--- a/dsh-desktop/test/plugin-guard.test.ts
+++ b/dsh-desktop/test/plugin-guard.test.ts
@@ -225,3 +225,87 @@ test('repair removes duplicate patch rows that conflict with bundle entry ids (i
 
   rmSync(home, { recursive: true, force: true });
 });
+
+// ── 版本兼容防线（v0.2）──────────────────────────────────────────────
+// 语义：把「插件与内核/依赖对不上」静态拦在启动前 —— patch 行引用的插件包
+// 缺失（实战连环启动失败根因）、peer 依赖不满足 → 自动隔离（快照 + patch
+// disabled + incident），而不是等 loader import 时整棵插件树崩掉。
+// 测试环境无 semver 包 → peer 比对自动降级为提示级，本组只断言不依赖
+// semver 的链路（模块缺失 / 隔离 / 报告形状）。
+
+test('compat flags missing plugin packages and quarantines them pre-boot', () => {
+  const t0 = { after: (fn) => fn };
+  const { home, profile, guard } = makeHome(t0);
+  // patch 行引用一个不存在的插件包（9/3 连环事故形态：行在包被清）。
+  writeFileSync(join(profile, 'cordis.patch.yml'),
+    '- insert:\n    - id: ghost-app\n      name: \'ghost-app\'\n' +
+    '- insert:\n    - id: sub\n      name: \'sub\'\n');
+  // sub 是真实安装的插件（带入口文件），不应被误隔离。
+  mkdirSync(join(profile, 'node_modules', 'sub', 'lib'), { recursive: true });
+  writeFileSync(join(profile, 'node_modules', 'sub', 'package.json'),
+    JSON.stringify({ name: 'sub', version: '1.0.0', main: 'lib/index.js' }));
+  writeFileSync(join(profile, 'node_modules', 'sub', 'lib', 'index.js'), 'export {};\n');
+
+  const { findings } = guard.healthCheck();
+  const missing = findings.filter((f) => f.code === 'ENTRY_MODULE_MISSING');
+  assert.ok(missing.some((f) => f.message.includes('ghost-app')), 'ghost-app must be flagged, got: ' + JSON.stringify(missing));
+  assert.ok(!missing.some((f) => f.message.includes('sub')), 'installed plugin must not be flagged');
+
+  // 启动前预检自动隔离：ghost-app 被禁入，sub 保留。
+  const pre = guard.quarantineFatal({});
+  assert.equal(pre.quarantined.length, 1, 'only ghost-app should be quarantined, got: ' + JSON.stringify(pre.quarantined));
+  const patchAfter = readFileSync(join(profile, 'cordis.patch.yml'), 'utf8');
+  assert.ok(/disabled: true/.test(patchAfter), 'patch must carry a disabled row, got:\n' + patchAfter);
+  assert.ok(patchAfter.includes('ghost-app'), 'quarantined entry must remain listed (disabled), got:\n' + patchAfter);
+
+  // 隔离后复检：不再报模块缺失；且已留 incident 与快照（可回滚）。
+  const after = guard.healthCheck().findings;
+  assert.ok(!after.some((f) => f.code === 'ENTRY_MODULE_MISSING' && f.message.includes('ghost-app')), 're-check must be clean');
+  assert.ok(guard.listIncidents().length >= 1, 'auto-quarantine must leave an incident');
+  assert.ok(guard.listSnapshots().length >= 1, 'auto-quarantine must snapshot first');
+
+  rmSync(home, { recursive: true, force: true });
+});
+
+test('quarantineById manually disables a patch row with a snapshot', () => {
+  const t0 = { after: (fn) => fn };
+  const { home, profile, guard } = makeHome(t0);
+  writeFileSync(join(profile, 'cordis.patch.yml'),
+    '- insert:\n    - id: sub\n      name: \'sub\'\n      config:\n        x: 1\n');
+  mkdirSync(join(profile, 'node_modules', 'sub', 'lib'), { recursive: true });
+  writeFileSync(join(profile, 'node_modules', 'sub', 'package.json'),
+    JSON.stringify({ name: 'sub', version: '1.0.0', main: 'lib/index.js' }));
+  writeFileSync(join(profile, 'node_modules', 'sub', 'lib', 'index.js'), 'export {};\n');
+
+  const res = guard.quarantineById('sub');
+  assert.equal(res.ok, true, 'quarantineById must succeed');
+  assert.equal(res.restartRequired, true);
+  const patchAfter = readFileSync(join(profile, 'cordis.patch.yml'), 'utf8');
+  assert.ok(/disabled: true/.test(patchAfter), 'patch must carry a disabled row, got:\n' + patchAfter);
+  // 已有对应快照（手动隔离前自动创建）。
+  const snaps = guard.listSnapshots();
+  assert.ok(snaps.some((s) => s.reason.includes('隔离')), 'a snapshot must precede manual quarantine');
+  rmSync(home, { recursive: true, force: true });
+});
+
+test('versionReport lists kernel version and per-entry install state', () => {
+  const t0 = { after: (fn) => fn };
+  const { home, profile, guard } = makeHome(t0);
+  writeFileSync(join(profile, 'cordis.patch.yml'),
+    '- insert:\n    - id: ghost-app\n      name: \'ghost-app\'\n' +
+    '- insert:\n    - id: sub\n      name: \'sub\'\n');
+  mkdirSync(join(profile, 'node_modules', 'sub', 'lib'), { recursive: true });
+  writeFileSync(join(profile, 'node_modules', 'sub', 'package.json'),
+    JSON.stringify({ name: 'sub', version: '1.0.0', main: 'lib/index.js' }));
+  writeFileSync(join(profile, 'node_modules', 'sub', 'lib', 'index.js'), 'export {};\n');
+
+  const rep = guard.versionReport();
+  assert.equal(rep.kernel.name, '@deepseek-ai/dsh');
+  assert.equal(rep.kernel.version, '1.0.0'); // makeHome 闭包写入的 fake 版本
+  const ghost = rep.entries.find((e) => e.id === 'ghost-app');
+  assert.ok(ghost && ghost.installed === false, 'ghost-app must report not installed');
+  const sub = rep.entries.find((e) => e.id === 'sub');
+  assert.ok(sub && sub.installed === true && sub.entryPoint && sub.entryPoint.endsWith('index.js'), 'sub must resolve its entry point');
+  assert.equal(sub.issues.length, 0, 'healthy plugin must carry no issues');
+  rmSync(home, { recursive: true, force: true });
+});

--- a/tauri-shell/sidecar/server.ts
+++ b/tauri-shell/sidecar/server.ts
@@ -571,7 +571,18 @@ async function guardedStartAndWait(overlays: string[]): Promise<{ webUrl: string
     snapshot(r: string): { id: string } | null;
     markGood(id: string): void;
     reportIncident(t: string, d: string): { ok: boolean };
+    quarantineFatal(o?: { quarantinePeers?: boolean }): { checked: number; quarantined: string[] };
   })();
+  // 版本兼容防线（v0.2）：启动前静态核对插件与内核的对应关系 —— patch 引用的
+  // 插件包/入口缺失（实战根因：行在包被清 → ERR_MODULE_NOT_FOUND → 整棵插件
+  // 树起不来）与关键 peer 不满足 → 自动隔离（快照 + patch disabled + incident），
+  // 让内核照常启动而非整树崩溃。快照先行保证任何时刻可回滚。
+  try {
+    const pre = g.quarantineFatal({});
+    if (pre.quarantined.length) say('版本兼容预检: 自动隔离 ' + pre.quarantined.length + ' 个不兼容插件');
+  } catch (e) {
+    say('版本兼容预检失败（继续启动）: ' + String(((e as Error).message) || e));
+  }
   const snap = g.snapshot('boot');
   try {
     const r = await (bootMod.startAndWait as (o: string[]) => Promise<{ webUrl: string; port: number }>)(overlays);
@@ -1163,6 +1174,14 @@ const batch: Record<string, (p: RpcParams) => unknown> = {
       case 'repair': {
         const r = (g.repair as () => { applied: unknown })();
         return { ok: true, applied: r.applied };
+      }
+      case 'version':
+        // 版本兼容防线（v0.2）：内核版本 + 每条 patch 条目的安装/入口/peer/inject 状态
+        return { ok: true, report: (g.versionReport as () => unknown)() };
+      case 'quarantine': {
+        const r = (g.quarantineById as (v: unknown) => Record<string, unknown>)(String(value || ''));
+        if (r.ok && r.restartRequired) log('guard', '手动隔离插件: ' + String(value));
+        return r;
       }
       case 'incident':
         return (g.readIncident as (v: unknown) => Record<string, unknown>)(value) as Record<string, unknown>;


### PR DESCRIPTION
## 背景

插件保护中心（plugin-guard + dsh-plugin-shield）此前是「事后」安全网：插件把启动搞崩后，守护启动再归因→停用→回滚。但**启动前没有任何环节核对「插件与内核对应不对得上」**——patch 行引用的插件包/入口缺失（实战连环事故：`cordis.patch.yml` 引用 dsh-memory 但包被清 → `ERR_MODULE_NOT_FOUND` → 整棵插件树起不来、dsh web 退出码 1）、peer 依赖未安装/版本线不符，都会在 loader import 时直接把内核带走。

本 PR 为插件保护中心补齐「版本兼容防线」（v0.2）：启动前**静态**核对（只读 manifest 与 package.json，绝不执行插件代码），可自动处置的发现项走「快照 → patch disabled → incident」隔离，内核照常启动而非整树崩溃。

## 改动

| 文件 | 内容 |
|---|---|
| `dsh-desktop/plugin-guard.ts` | 新增 compatFindings（`ENTRY_MODULE_MISSING` / `ENTRY_PEER_UNSATISFIED` / `ENTRY_INJECT_MISSING` / `KERNEL_RANGE_VIOLATION` / `PEER_RANGE_DRIFT` 提示级）与 `quarantineFatal`（启动预检）/ `quarantineById`（手动隔离）/ `versionReport`（UI 报告）；healthCheck 与 repair 接入 |
| `tauri-shell/sidecar/server.ts` | `guardedStartAndWait` 启动前预检 `quarantineFatal`；`guard.action` 新增 `version` / `quarantine` |
| `dsh-desktop/assets/plugins/dsh-plugin-shield` | 0.2.0：设置页「插件保护」新增「版本兼容防线」卡片（内核版本、逐条插件的安装/入口/peer/inject/版本窗口状态、一键手动隔离） |
| `dsh-desktop/test/plugin-guard.test.ts` | 新增 3 个用例：缺失隔离全链路（复检干净 + incident + 快照）/ 手动隔离 / versionReport 形状；全套 14 用例通过 |

## 设计要点

- **peer 务实比对**：dsh 生态在 rc/alpha 时代普遍用 `*`、`^0.1.0-rc.x` 声明兼容范围，而内核实际版本常带 `-alpha/-rc` tag——严格 semver 会把全部兼容插件误报为不兼容（如 `0.1.2-alpha.1` 连 `*` 都不满足）。策略：先严格比对，失败则**剥掉全部 prerelease tag 宽松比对**，仅 major.minor 版本线不符判为真不兼容（`high`，可隔离）；仅 pre-release/patch 层面差为提示级（不隔离）；semver 缺失环境自动降级为提示级，绝不误判。
- **隔离边界**：`@deepseek-ai/*` 内核同源包不自动隔离（缺失=安装损坏，应走回滚/重装）；可选 peer（`peerDependenciesMeta.optional`）不拦；bundle 行无 id 只报告不写盘。
- **新契约**：插件可在 package.json 声明 `dsh.kernel`（semver range 字符串或 `{ min, max }`）声明兼容的内核版本窗口，未来插件生态可按此声明做显式兼容。
- 遵循 HARD RULE：只动配置面（cordis.patch.yml）与插件层，绝不修改内核与用户会话数据。

## 验证

- `tsc -p dsh-desktop/tsconfig.json` 类型检查通过（唯一残留是既有 `lib/extension-host/rpc.ts` 的 nanoid 依赖缺失，与本 PR 无关，CI 完整依赖环境不受影响）
- 单测 14/14 通过（11 个既有 + 3 个新用例），零回归
- 真实 profile（68 条插件条目）实测：仅 1 条真实 high 发现（内置 file-changes 的 zod ^3 vs 实际 4），`@deepseek-ai/*` 同源仅报告不隔离；无任何误伤