### PR TITLE
fix(patch-deps): 二级菜单容器按产物形态捕获入口变量，修复悬停第三方整单崩溃

### DIFF
--- a/dsh-desktop/scripts/patch-deps.ts
+++ b/dsh-desktop/scripts/patch-deps.ts
@@ -644,6 +644,69 @@ const SUBMENU_BTN_NEW_012 = 'd.jsxs("button",{type:"button",role:"menuitem",clas
 const SUBMENU_LABEL_ANCHOR_012 = 'd.jsx("span",{className:Pe.itemLabel,children:fe.label})';
 const SUBMENU_LABEL_NEW_012 = 'd.jsx("span",{className:Pe.itemLabel,style:{whiteSpace:"normal",overflow:"visible","' + SUBMENU_ITEM_MARKER + '":"1"},children:fe.label})';
 
+// Menu 二级菜单容器补丁（变量名捕获版）：上游两代压缩产物里 renderEntry 的
+// 入口行变量与 submenu-id setter 变量名不同 —— rc.2 用 B/z，0.1.2-alpha.1 用
+// $/J。旧补丁把 B/z 写死拼进重建的容器，0.1.2 里 B 是列表 ref（B.submenu 为
+// undefined）：鼠标一悬停挂载二级菜单就 undefined.map 抛错，错误边界卸载整个
+// conversation.hero.agentPreset slot —— 菜单连同「标准模式」字样一起消失
+//（issue #295 / #297）。入口与 setter 一律从 itemWrap 锚点正则捕获；已打过
+// 旧补丁的包走修复分支（rc.2 包捕获即 B/z，修复为无操作，天然幂等）。
+// itemWrap 头必须 enter/leave 成对出现且 setter 一致（反向引用锁死）：
+// 0.1.2 为 J(re?$.id:null) / J(null)；rc.2 为 z(se?B.id:null) / z(null)。
+// 配对写法让已注入 div 自带的 z(B.id)/z(null) 永远匹配不上，不会污染捕获。
+const MENU_PAIR_RE = /onMouseEnter:\(\)=>\{(?:clearTimeout\(window\.__dshMenuTimer\);)?([A-Za-z_$][\w$]*)\((?:re|se)\?([A-Za-z_$][\w$]*)\.id:null\)\},onMouseLeave:\(\)=>\{(?:clearTimeout\(window\.__dshMenuTimer\);)?(?:window\.__dshMenuTimer=setTimeout\(\(\)=>)?\1\(null\)/g;
+
+// 在 anchorIdx 之前的临近 scope 里抓最近一对（entry, setter）。
+function captureMenuVars(src: string, anchorIdx: number): { entry: string; setter: string } | undefined {
+  const scope = src.slice(Math.max(0, anchorIdx - 3000), anchorIdx);
+  MENU_PAIR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = null;
+  let last: RegExpExecArray | null = null;
+  while ((m = MENU_PAIR_RE.exec(scope)) !== null) last = m;
+  if (!last) return undefined;
+  return { entry: last[2], setter: last[1] };
+}
+
+function patchMenuSubmenuContainerSource(source: string): string | undefined {
+  const markerIdx = source.indexOf(MENU_SUBMENU_HOVER_MARKER);
+  if (markerIdx >= 0) {
+    // 修复分支：容器已被旧补丁重建，把写死的变量改回捕获值。
+    const vars = captureMenuVars(source, markerIdx);
+    if (!vars) return undefined;
+    const divStart = source.lastIndexOf('role:"menu",', markerIdx);
+    const mapIdx = source.indexOf(MENU_SUBMENU_ANCHOR, markerIdx);
+    if (divStart < 0 || mapIdx < 0 || markerIdx - divStart > 800 || mapIdx - divStart > 2000) return undefined;
+    const head = source.slice(0, divStart);
+    let div = source.slice(divStart, mapIdx);
+    const tail = source.slice(mapIdx);
+    div = div.replace(
+      /onMouseEnter:\(\)=>\{clearTimeout\(window\.__dshMenuTimer\);[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.id\)\}/,
+      'onMouseEnter:()=>{clearTimeout(window.__dshMenuTimer);' + vars.setter + '(' + vars.entry + '.id)}');
+    div = div.replace(
+      /window\.__dshMenuTimer=setTimeout\(\(\)=>[A-Za-z_$][\w$]*\(null\),400\)/,
+      'window.__dshMenuTimer=setTimeout(()=>'+vars.setter+'(null),400)');
+    div = div.replace(/children:[A-Za-z_$][\w$]*\./, 'children:' + vars.entry + '.');
+    return head + div + tail;
+  }
+  // 新打分支：上游原始形态。
+  if (source.includes('minWidth:' + MENU_SUBMENU_MINW)) return source;
+  const submenuIdx = source.indexOf(MENU_SUBMENU_ANCHOR);
+  const roleIdx = submenuIdx >= 0 ? source.lastIndexOf('role:"menu",', submenuIdx) : -1;
+  // role:"menu", 必须紧邻 submenu.map（submenu 容器的 role），距离过大说明命中了别处
+  if (submenuIdx < 0 || roleIdx < 0 || submenuIdx - roleIdx > 400) return undefined;
+  const vars = captureMenuVars(source, submenuIdx);
+  if (!vars) return undefined;
+  // 校验 children: 后的入口变量与捕获一致，防止 role 锚点命中别处。
+  const childM = MENU_CHILDREN_RE.exec(source.slice(roleIdx, submenuIdx + 40));
+  if (!childM || childM[1] !== vars.entry) return undefined;
+  const newBlock = 'role:"menu",onMouseEnter:()=>{clearTimeout(window.__dshMenuTimer);' + vars.setter + '(' + vars.entry + '.id)},'
+    + 'onMouseLeave:()=>{clearTimeout(window.__dshMenuTimer);window.__dshMenuTimer=setTimeout(()=>'+vars.setter+'(null),400)},'
+    + 'style:{maxHeight:"' + MENU_SUBMENU_MAXH + '",overflowY:"auto",minWidth:' + MENU_SUBMENU_MINW + '},/*' + MENU_SUBMENU_HOVER_MARKER + '*/children:' + vars.entry + '.';
+  return source.slice(0, roleIdx) + newBlock + source.slice(submenuIdx);
+}
+
+const MENU_CHILDREN_RE = /children:([A-Za-z_$][\w$]*)\.submenu\.map\(/;
+
 function patchMenuSubmenuScroll(file?: string): boolean {
   let target: string | undefined = file;
   if (!target) {
@@ -672,21 +735,14 @@ function patchMenuSubmenuScroll(file?: string): boolean {
   // 旧版 bundle 已有 hover marker 时，后续新增的 minWidth / root pointerleave
   // 改动仍要能补打上（锚点替换后原始文本消失，自然幂等）。
 
-  // 1) submenu 容器：悬停保持 + 高度/宽度自适应（minWidth 缺失才重建整段）
-  if (!src.includes('minWidth:' + MENU_SUBMENU_MINW)) {
-    const submenuIdx = src.indexOf(MENU_SUBMENU_ANCHOR);
-    const roleIdx = submenuIdx >= 0 ? src.lastIndexOf('role:"menu",', submenuIdx) : -1;
-    // role:"menu", 必须紧邻 submenu.map（submenu 容器的 role），距离过大说明命中了别处
-    if (submenuIdx < 0 || roleIdx < 0 || submenuIdx - roleIdx > 400) {
-      console.log('[patch-deps] Menu submenu 未匹配到目标代码（版本可能已更新），跳过');
-      return false;
-    }
-    // 替换 role:"menu", 到 submenu.map( 之间整段（旧版可能已注入 style + scroll marker）：
-    // 二级菜单悬停保持（onMouseEnter 取消关闭定时器并重新激活，onMouseLeave 关闭），
-    // 高度自适应视口（内容少自然高度，超高才滚动）、宽度对齐一级菜单，配合
-    // itemWrap / root 延迟关闭让鼠标可跨过一级菜单与二级菜单之间的间隙。
-    const newBlock = 'role:"menu",onMouseEnter:()=>{clearTimeout(window.__dshMenuTimer);z(B.id)},' + SUBMENU_LEAVE_NEW + ',style:{maxHeight:"' + MENU_SUBMENU_MAXH + '",overflowY:"auto",minWidth:' + MENU_SUBMENU_MINW + '},/*' + MENU_SUBMENU_HOVER_MARKER + '*/children:B.';
-    src = src.slice(0, roleIdx) + newBlock + src.slice(submenuIdx);
+  // 1) submenu 容器：悬停保持 + 高度/宽度自适应（变量名捕获版，见上）。
+  const container = patchMenuSubmenuContainerSource(src);
+  if (container === undefined) {
+    console.log('[patch-deps] Menu submenu 未匹配到目标代码（版本可能已更新），跳过');
+    return false;
+  }
+  if (container !== src) {
+    src = container;
     changed = true;
     console.log('[patch-deps] 已补丁主 bundle：二级菜单悬停保持 + 高度/宽度自适应');
   }
@@ -798,6 +854,7 @@ if (require.main === module) {
 module.exports = {
   patchAgentPresetMenu,
   patchMenuSubmenuScroll,
+  patchMenuSubmenuContainerSource,
   patchClientModulesResolve,
   patchModelImageInputSource,
   patchModelImageInputToggle,

--- a/dsh-desktop/test/menu-submenu-container.test.ts
+++ b/dsh-desktop/test/menu-submenu-container.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { patchMenuSubmenuContainerSource } = require(join(root, 'scripts', 'patch-deps.js'));
+
+// 0.1.2-alpha.1 产物形态：入口行变量 $，setter J（最小复刻，锚点结构与真包一致）。
+const FIX_012 = [
+  'const ae=!o.some($=>$.submenu!==void 0&&$.submenu.length>0),V=$=>{',
+  'const re=$.submenu!==void 0&&$.submenu.length>0,ie=re&&F===$.id;',
+  'return d.jsxs("div",{className:Pe.itemWrap,',
+  'onMouseEnter:()=>{J(re?$.id:null)},onMouseLeave:()=>{J(null)},',
+  'children:[d.jsxs("button",{children:$.label}),',
+  'ie&&$.submenu!==void 0&&d.jsx("div",{className:Pe.submenu,role:"menu",',
+  'children:$.submenu.map(fe=>fe.id)})]},$.id)};',
+].join('');
+// rc.2 产物形态：入口行变量 B，setter z。
+const FIX_RC2 = [
+  'const ae=!o.some($=>$.submenu!==void 0&&$.submenu.length>0),V=$=>{',
+  'const se=$.submenu!==void 0&&$.submenu.length>0,le=se&&F===$.id;',
+  'return f.jsxs("div",{className:Re.itemWrap,',
+  'onMouseEnter:()=>{z(se?B.id:null)},onMouseLeave:()=>{z(null)},',
+  'children:[f.jsxs("button",{children:B.label}),',
+  'le&&B.submenu!==void 0&&f.jsx("div",{className:Re.submenu,role:"menu",',
+  'children:B.submenu.map(he=>he.id)})]},$.id)};',
+].join('');
+// 0.1.2 包 + 旧补丁（写死 B/z）的实际输出形态。
+const FIX_BROKEN = FIX_012.replace(
+  'role:"menu",children:$.submenu.map(',
+  'role:"menu",onMouseEnter:()=>{clearTimeout(window.__dshMenuTimer);z(B.id)},'
+  + 'onMouseLeave:()=>{clearTimeout(window.__dshMenuTimer);window.__dshMenuTimer=setTimeout(()=>z(null),400)},'
+  + 'style:{maxHeight:"calc(100dvh - 96px)",overflowY:"auto",minWidth:320},'
+  + '/*dsh-desktop:menu-submenu-hover*/children:B.submenu.map(');
+
+test('0.1.2 形态：容器重建使用捕获的 $/J，不引入未定义的 B/z', () => {
+  const out = patchMenuSubmenuContainerSource(FIX_012);
+  assert.notEqual(out, undefined);
+  assert.match(out, /children:\$\.submenu\.map\(/);
+  assert.match(out, /J\(\$\.id\)/);
+  assert.match(out, /setTimeout\(\(\)=>J\(null\),400\)/);
+  assert.equal(out.includes('B.submenu'), false, 'B 在 0.1.2 里是列表 ref，绝不能出现在 submenu 取值位');
+  assert.equal(out.includes('z(B.id)'), false);
+});
+
+test('rc.2 形态：捕获即 B/z，重建结果与旧补丁字节一致（行为不变）', () => {
+  const out = patchMenuSubmenuContainerSource(FIX_RC2);
+  assert.notEqual(out, undefined);
+  assert.match(out, /children:B\.submenu\.map\(/);
+  assert.match(out, /z\(B\.id\)/);
+});
+
+test('修复分支：旧补丁打坏的 0.1.2 包把 B/z 改回 $/J', () => {
+  const out = patchMenuSubmenuContainerSource(FIX_BROKEN);
+  assert.notEqual(out, undefined);
+  assert.match(out, /children:\$\.submenu\.map\(/);
+  assert.match(out, /J\(\$\.id\)/);
+  assert.match(out, /setTimeout\(\(\)=>J\(null\),400\)/);
+  assert.equal(out.includes('B.submenu'), false);
+  assert.equal(out.includes('z(B.id)'), false);
+});
+
+test('幂等：已正确补丁的包原样返回', () => {
+  const once012 = patchMenuSubmenuContainerSource(FIX_012);
+  assert.notEqual(once012, undefined);
+  assert.equal(patchMenuSubmenuContainerSource(once012), once012);
+  const onceBroken = patchMenuSubmenuContainerSource(FIX_BROKEN);
+  assert.notEqual(onceBroken, undefined);
+  assert.equal(patchMenuSubmenuContainerSource(onceBroken), onceBroken);
+  const onceRc2 = patchMenuSubmenuContainerSource(FIX_RC2);
+  assert.notEqual(onceRc2, undefined);
+  assert.equal(patchMenuSubmenuContainerSource(onceRc2), onceRc2);
+});
+
+test('fail-closed：无 submenu 锚点返回 undefined', () => {
+  assert.equal(patchMenuSubmenuContainerSource('const x = 1;\n'), undefined);
+});
+
+test('fail-closed：role 锚点距离过远返回 undefined', () => {
+  const bad = 'role:"menu",' + 'x'.repeat(500) + 'children:$.submenu.map(fe=>fe.id)';
+  assert.equal(patchMenuSubmenuContainerSource(bad), undefined);
+});


### PR DESCRIPTION
## 现象（closes #295，closes #297）

首页点「标准模式」展开菜单，鼠标移到最下一项「第三方模式」瞬间：菜单连同触发器字样一起消失，无法切换。控制台：

`TypeError: Cannot read properties of undefined (reading 'map')`，onMouseEnter 触发，`slot entry crashed in 'conversation.hero.agentPreset'`，错误边界卸载整个 slot。

## 根因

`patchMenuSubmenuScroll` 重建 submenu 容器时把压缩变量名写死为 `z(B.id)` / `children:B.`。这在 rc.2 产物里是对的（入口行变量 B、setter z），但 0.1.2-alpha.1 产物里入口行变量是 `$`、setter 是 `J`，`B` 是列表 ref —— `B.submenu` 为 undefined，悬停挂载二级菜单即抛错。守卫（`\$.submenu !== void 0`）和取值（`B.submenu.map`）不是同一个变量。

已用官方发布的 rc.2 包与 0.1.2 安装产物双向核对变量形态。

## 修复

- 容器重建改从 itemWrap 锚点正则捕获（entry, setter），enter/leave 成对反向引用锁死；
- 已被旧补丁打坏的包走修复分支改回捕获值（rc.2 包捕获即 B/z，修复为无操作，天然幂等）；
- 其余步骤（悬停延迟、两行布局）不动；fail-closed：捕获失败整单跳过。

## 验证

- 新增 `dsh-desktop/test/menu-submenu-container.test.ts`（双形态 fixture＋修复分支＋幂等＋fail-closed，共 6 用例）。
- 用 tsc 实编译出的 patch-deps.js 跑真包：线上坏包修复后 `B.submenu`/`z(B.id)` 归零、node --check 通过；rc.2 原始包输出 B/z 不变。
- 本地起隔离 `dsh web`（临时 DSH_HOME、临时端口，未动线上数据）肉眼验收：悬停「第三方模式」子菜单正常展开、可点选，之前必崩。