### PR TITLE
fix(build): 提升 Windows 首次编译兼容性

### DIFF
--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -49,6 +49,8 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
 
 ## 5.3.6（内置输入灵动岛与分发契约补强）· 2026-09-03
 
+- Windows 首次源码构建兼容：内核归档工具仅在必需源码输入完整时容忍 Windows `tar` 对不支持链接条目的非零退出；原生 N-API 模块统一选择 `x86_64-pc-windows-msvc` 并从目标专属目录回填 `index.node`，避免 GNU 默认工具链与 `lld-link` 混用导致的链接失败。Linux/macOS 与显式非 MSVC Windows target 保持严格拒绝。
+
 - 内置 `dsh-composer-dynamic-island` 2.1.0（says693，MIT），作为推荐插件
   同步到独立 `web-desktop` profile；不修改 DSH 内核与插件运行时代码。
 - 为 EAC Web loader 补齐 React、Settings 与 Slots 的加载依赖元数据。

--- a/dsh-desktop/scripts/build-native.ts
+++ b/dsh-desktop/scripts/build-native.ts
@@ -47,6 +47,22 @@ const targetDir = path.join(crateRoot, 'target');
 const manifest = path.join(crateRoot, 'Cargo.toml');
 const artifactBase = `dsh_${moduleName}_native`;
 
+const WINDOWS_MSVC_TARGET = 'x86_64-pc-windows-msvc';
+
+function windowsCargoTarget(): string | undefined {
+  if (process.platform !== 'win32') return undefined;
+  const configured = process.env.CARGO_BUILD_TARGET;
+  if (configured !== undefined && configured !== WINDOWS_MSVC_TARGET) {
+    throw new Error(`[build-native] Windows 原生模块要求 ${WINDOWS_MSVC_TARGET}，当前 CARGO_BUILD_TARGET=${configured}`);
+  }
+  return WINDOWS_MSVC_TARGET;
+}
+
+function cargoReleaseDir(): string {
+  const target = windowsCargoTarget();
+  return target === undefined ? path.join(targetDir, 'release') : path.join(targetDir, target, 'release');
+}
+
 /** 取工具链 sysroot（失败抛出 —— 没有 rustc 时无法构建）。 */
 function sysroot(): string {
   const r = cp.spawnSync('rustc', ['--print', 'sysroot'], { encoding: 'utf8' });
@@ -80,7 +96,10 @@ function runCargo(sub: string, rest: string[]): number {
     env.CARGO_ENCODED_RUSTFLAGS = ['-C', `linker=${linker}`].join('\x1f');
     delete env.RUSTFLAGS;
   }
-  const r = cp.spawnSync('cargo', [sub, '--manifest-path', manifest, ...rest], {
+  const args = [sub, '--manifest-path', manifest, ...rest];
+  const target = windowsCargoTarget();
+  if (target !== undefined) args.push('--target', target);
+  const r = cp.spawnSync('cargo', args, {
     stdio: 'inherit',
     env,
     cwd: crateRoot,
@@ -90,7 +109,7 @@ function runCargo(sub: string, rest: string[]): number {
 
 /** 复制 cargo cdylib 产物 → index.node（存在性断言）。 */
 function copyArtifact(): void {
-  const releaseDir = path.join(targetDir, 'release');
+  const releaseDir = cargoReleaseDir();
   const candidates =
     process.platform === 'win32' ? [`${artifactBase}.dll`]
     : process.platform === 'darwin' ? [`lib${artifactBase}.dylib`]

--- a/dsh-desktop/scripts/fetch-kernel.js
+++ b/dsh-desktop/scripts/fetch-kernel.js
@@ -88,6 +88,33 @@ function resolvePnpmEntry() {
     const version = capture(process.execPath, [entry, '--version']);
     return { entry, version };
 }
+function extractKernelArchive(tgzPath) {
+    const result = cp.spawnSync('tar', ['-xzf', path.basename(tgzPath)], { cwd: WORK, stdio: 'inherit' });
+    if (result.error !== undefined)
+        throw result.error;
+    if (result.status === 0)
+        return;
+    const srcDir = findKernelSourceDirectory();
+    // Windows 的 bsdtar 会在不支持的 symlink 上返回非零，但仍会完整解出
+    // 内核构建所需源码。只接受经严格校验的这一个已知降级路径。
+    if (process.platform === 'win32' && srcDir !== undefined && hasKernelBuildInputs(srcDir)) {
+        console.warn(`fetch-kernel: tar 因 Windows 不支持的链接条目返回 ${String(result.status)}，已校验源码完整，继续构建`);
+        return;
+    }
+    throw new Error(`解包失败（${String(result.status)}）: tar -xzf ${path.basename(tgzPath)}`);
+}
+function findKernelSourceDirectory() {
+    const srcDir = fs.readdirSync(WORK).find((entry) => entry.startsWith('deepseek-harness-') && fs.statSync(path.join(WORK, entry)).isDirectory());
+    return srcDir === undefined ? undefined : path.join(WORK, srcDir);
+}
+function hasKernelBuildInputs(src) {
+    return [
+        'package.json',
+        'scripts/pnpm-invocation.ts',
+        'scripts/release/pack.ts',
+        'scripts/release/tarball.ts',
+    ].every((file) => fs.existsSync(path.join(src, file)));
+}
 function main() {
     const tag = process.argv[2] || DEFAULT_TAG;
     const version = tag.replace(/^dsh-v/, '');
@@ -123,11 +150,10 @@ function main() {
         run('curl', curlArgs, WORK);
     }
     console.log('fetch-kernel: 解包');
-    run('tar', ['-xzf', path.basename(tgzPath)], WORK);
-    const srcDir = fs.readdirSync(WORK).find((e) => e.startsWith('deepseek-harness-') && fs.statSync(path.join(WORK, e)).isDirectory());
-    if (!srcDir)
+    extractKernelArchive(tgzPath);
+    const src = findKernelSourceDirectory();
+    if (src === undefined)
         throw new Error('解包后找不到源码目录');
-    const src = path.join(WORK, srcDir);
     // 补丁 1：pack.ts 走 pnpmInvocation（Windows spawn('pnpm') ENOENT）。
     const packTs = path.join(src, 'scripts', 'release', 'pack.ts');
     let pack = fs.readFileSync(packTs, 'utf8');

--- a/dsh-desktop/scripts/fetch-kernel.ts
+++ b/dsh-desktop/scripts/fetch-kernel.ts
@@ -101,6 +101,36 @@ function resolvePnpmEntry(): { entry: string; version: string } {
   return { entry, version };
 }
 
+function extractKernelArchive(tgzPath: string): void {
+  const result = cp.spawnSync('tar', ['-xzf', path.basename(tgzPath)], { cwd: WORK, stdio: 'inherit' });
+  if (result.error !== undefined) throw result.error;
+  if (result.status === 0) return;
+
+  const srcDir = findKernelSourceDirectory();
+  // Windows 的 bsdtar 会在不支持的 symlink 上返回非零，但仍会完整解出
+  // 内核构建所需源码。只接受经严格校验的这一个已知降级路径。
+  if (process.platform === 'win32' && srcDir !== undefined && hasKernelBuildInputs(srcDir)) {
+    console.warn(`fetch-kernel: tar 因 Windows 不支持的链接条目返回 ${String(result.status)}，已校验源码完整，继续构建`);
+    return;
+  }
+  throw new Error(`解包失败（${String(result.status)}）: tar -xzf ${path.basename(tgzPath)}`);
+}
+
+function findKernelSourceDirectory(): string | undefined {
+  const srcDir = fs.readdirSync(WORK).find((entry) =>
+    entry.startsWith('deepseek-harness-') && fs.statSync(path.join(WORK, entry)).isDirectory());
+  return srcDir === undefined ? undefined : path.join(WORK, srcDir);
+}
+
+function hasKernelBuildInputs(src: string): boolean {
+  return [
+    'package.json',
+    'scripts/pnpm-invocation.ts',
+    'scripts/release/pack.ts',
+    'scripts/release/tarball.ts',
+  ].every((file) => fs.existsSync(path.join(src, file)));
+}
+
 function main(): void {
   const tag = process.argv[2] || DEFAULT_TAG;
   const version = tag.replace(/^dsh-v/, '');
@@ -137,10 +167,9 @@ function main(): void {
   }
 
   console.log('fetch-kernel: 解包');
-  run('tar', ['-xzf', path.basename(tgzPath)], WORK);
-  const srcDir = fs.readdirSync(WORK).find((e) => e.startsWith('deepseek-harness-') && fs.statSync(path.join(WORK, e)).isDirectory());
-  if (!srcDir) throw new Error('解包后找不到源码目录');
-  const src = path.join(WORK, srcDir);
+  extractKernelArchive(tgzPath);
+  const src = findKernelSourceDirectory();
+  if (src === undefined) throw new Error('解包后找不到源码目录');
 
   // 补丁 1：pack.ts 走 pnpmInvocation（Windows spawn('pnpm') ENOENT）。
   const packTs = path.join(src, 'scripts', 'release', 'pack.ts');

--- a/dsh-desktop/test/windows-build-compat.test.ts
+++ b/dsh-desktop/test/windows-build-compat.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = join(fileURLToPath(import.meta.url), '..', '..');
+const fetchKernel = readFileSync(join(root, 'scripts', 'fetch-kernel.ts'), 'utf8');
+const buildNative = readFileSync(join(root, 'scripts', 'build-native.ts'), 'utf8');
+
+test('Windows tar fallback requires the complete kernel build inputs', () => {
+  assert.match(fetchKernel, /process\.platform === 'win32' && srcDir !== undefined && hasKernelBuildInputs\(srcDir\)/);
+  for (const required of [
+    'package.json',
+    'scripts/pnpm-invocation.ts',
+    'scripts/release/pack.ts',
+    'scripts/release/tarball.ts',
+  ]) {
+    assert.match(fetchKernel, new RegExp(`'${escapeRegex(required)}'`));
+  }
+  assert.match(fetchKernel, /throw new Error\(`解包失败/);
+});
+
+test('Windows native builds use the MSVC target and target-specific artifact directory', () => {
+  assert.match(buildNative, /const WINDOWS_MSVC_TARGET = 'x86_64-pc-windows-msvc'/);
+  assert.match(buildNative, /args\.push\('--target', target\)/);
+  assert.match(buildNative, /path\.join\(targetDir, target, 'release'\)/);
+  assert.match(buildNative, /CARGO_BUILD_TARGET=\$\{configured\}/);
+});
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tauri-shell/stage-resources.mjs
+++ b/tauri-shell/stage-resources.mjs
@@ -391,9 +391,10 @@ if (existsSync(vendoredBashFix)) {
 // 已停止」）。从 dev 树回填已编译产物（同 vendored 回填模式；交叉打包已被
 // 上方 targetPlatform===process.platform 门禁拒绝，这里产物必属本机平台）。
 const fsExtNative = path.join(dd, 'node_modules', 'fs-ext', 'build');
-if (existsSync(path.join(fsExtNative, 'Release', 'fs_ext.node'))) {
-  cpSync(fsExtNative, path.join(nmDest, 'fs-ext', 'build'), { recursive: true });
-  console.log('[stage] 已回填 fs-ext 原生构建（fs_ext.node，内核 0.1.3 会话锁依赖）');
+const fsExtRelease = path.join(fsExtNative, 'Release');
+if (existsSync(path.join(fsExtRelease, 'fs_ext.node'))) {
+  cpSync(fsExtRelease, path.join(nmDest, 'fs-ext', 'build', 'Release'), { recursive: true });
+  console.log('[stage] 已回填 fs-ext 原生运行时（build/Release/fs_ext.node）');
 } else {
   throw new Error('[stage] dev 树缺少 fs-ext 原生构建（node_modules/fs-ext/build/Release/fs_ext.node）——先在 dev 树 npm install 触发 node-gyp 编译，或换用支持预编译分发的 fs-ext 版本');
 }


### PR DESCRIPTION
## 背景
Windows 从零构建时，内核源码归档中的链接条目会让系统 tar 返回非零；默认 GNU Rust toolchain 也会与项目使用的 lld-link/MSVC 库链不一致。

## 改动
- 仅在 Windows 且内核必需构建输入完整时，接受 tar 的已知链接条目非零退出。
- Windows 原生 N-API 模块统一指定 x86_64-pc-windows-msvc，并按 target 专属目录回填 index.node。
- 新增回归测试和中文 changelog。

## 验证
- 从零运行 fetch-kernel：Windows tar 告警后完成 257 个 tarball 生成。
- npm test：823 tests passed，0 failed，5 skipped。
- x64 Native Tools 环境下原生模块构建、资源装配和 NSIS 安装包生成成功。
