### PR TITLE
feat(std): dsh-dock-settings 补齐 dsh-plugin.json（std v0.15，eac-private）

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-dock-settings/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-dock-settings/dsh-plugin.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
+  "manifestVersion": "0.15",
+  "id": "io.github.zouyuxuan122.dsh-desktop-eac.dsh-dock-settings",
+  "name": "dsh-dock-settings",
+  "version": "0.1.0",
+  "facets": {
+    "host": {
+      "entry": "lib/host.js",
+      "apiVersion": "v1alpha1"
+    }
+  },
+  "requires": {
+    "contracts": []
+  },
+  "permissions": [],
+  "contributes": {
+    "commands": []
+  },
+  "subscriptions": [],
+  "license": "MIT",
+  "source": {
+    "repository": "https://github.com/zouyuxuan122/DSH-Desktop-EAC"
+  },
+  "overrides": [],
+  "x-eac": {
+    "role": "identity-metadata",
+    "note": "EAC 原研插件（私有维护，不参与内置插件自动更新）。EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
+    "maintenance": "eac-private",
+    "autoUpdate": false,
+    "ledger": "assets/SOURCES.json#C011"
+  }
+}


### PR DESCRIPTION
配套 #307（生成器 eac-original 批次）、#308（私有维护自动更新黑名单）。按台账 C 编号逐个为 eac-original 插件补 manifest 的第 1/14 个。

| 字段 | 值 |
|---|---|
| 台账 | `assets/SOURCES.json#C011`（origin=eac-original） |
| id | `io.github.zouyuxuan122.dsh-desktop-eac.dsh-dock-settings` |
| 版本 | 0.1.0（= package.json） |
| entry | `lib/host.js` |
| 标记 | `x-eac.maintenance: 'eac-private'`、`autoUpdate: false` |

诚实性约束：facets/permissions 留空 = 尚未参与 std 协商；描述性身份元数据，加载路径不变（companion-sync）。

验证：`plugin-ledger.mjs` 门禁通过（34/34 manifest）；`npm run typecheck` 通过；注册表契约测试通过。