### PR TITLE
feat: Plugin Sync Manifest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,7 @@
 /tauri-shell/ @zouyuxuan122
 /dsh-desktop/scripts/patch-deps.js @zouyuxuan122
 /dsh-desktop/node_modules/@deepseek-ai/ @zouyuxuan122
+/.sync/ @zouyuxuan122
+/dsh-desktop/assets/plugins/ @zouyuxuan122
+/dsh-desktop/assets/skins/ @zouyuxuan122
+/dsh-desktop/assets/sdk-plugins/ @zouyuxuan122

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /tauri-shell/ @zouyuxuan122
 /dsh-desktop/scripts/patch-deps.js @zouyuxuan122
 /dsh-desktop/node_modules/@deepseek-ai/ @zouyuxuan122
-/.sync/ @zouyuxuan122
+/.sync/ @metaone01
 /dsh-desktop/assets/plugins/ @zouyuxuan122
 /dsh-desktop/assets/skins/ @zouyuxuan122
 /dsh-desktop/assets/sdk-plugins/ @zouyuxuan122

--- a/.sync/plugins.json
+++ b/.sync/plugins.json
@@ -1,0 +1,2125 @@
+{
+  "schemaVersion": 1,
+  "generatedRegistry": "dsh-desktop/lib/desktop/plugin-sync-registry.ts",
+  "plugins": [
+    {
+      "id": "agent-teams",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-agent-teams",
+      "packageName": "@nanmicoder/dsh-agent-teams",
+      "class": "patched",
+      "source": {
+        "kind": "github",
+        "repository": "git+https://github.com/NanmiCoder/dsh-agent-teams.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.13-eac.3"
+      },
+      "sync": {
+        "mode": "patch-rebase",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "balance",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-balance",
+      "packageName": "@deepseek-ai/dsh-balance",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-balance",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "better-sidebar",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-better-sidebar",
+      "packageName": "dsh-better-sidebar",
+      "class": "patched",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-better-sidebar",
+        "repository": "https://github.com/omdsh-dev/DSH-better-sidebar"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "patch-rebase",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-better-sidebar"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "change-review",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-change-review",
+      "packageName": "dsh-change-review",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "client-file-changes",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-client-file-changes",
+      "packageName": "@deepseek-ai/dsh-client-file-changes",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-client-file-changes",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "compact",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-compact",
+      "packageName": "dsh-compact",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "1.0.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "composer-dynamic-island",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-composer-dynamic-island",
+      "packageName": "dsh-composer-dynamic-island",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "github",
+        "repository": "git+https://github.com/says693/dsh-composer-dynamic-island.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "2.1.0"
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/types/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "computer-user",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/computer-user",
+      "packageName": "computer-user",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "computer-user",
+        "repository": "git+https://github.com/jing-hy/computer-user.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "computer-user"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "src/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "conversation-tweaks",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-conversation-tweaks",
+      "packageName": "@deepseek-ai/dsh-conversation-tweaks",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-conversation-tweaks",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dock-settings",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-dock-settings",
+      "packageName": "dsh-dock-settings",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/host.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-dafeiyu",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-dafeiyu",
+      "packageName": "dsh-dafeiyu",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "git+https://github.com/QCYTSN/dsh-dafeiyu.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0-alpha.6"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "src/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "SEE LICENSE IN ASSET_LICENSE.md",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-feature-toggles",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-feature-toggles",
+      "packageName": "dsh-feature-toggles",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.1"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-navbar",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-navbar",
+      "packageName": "@vlln/dsh-navbar",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "@vlln/dsh-navbar"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "@vlln/dsh-navbar"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.mjs"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-pet",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-pet",
+      "packageName": "dsh-pet",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-pet",
+        "repository": "git+https://github.com/PC2005-cloud/dsh-pet.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-pet"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins",
+      "defaultDisabled": true
+    },
+    {
+      "id": "dsh-pet-settings",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-pet-settings",
+      "packageName": "dsh-pet-settings",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-phone",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-phone",
+      "packageName": "dsh-phone",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "dsh-phone",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-raw-html",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-raw-html",
+      "packageName": "dsh-raw-html",
+      "class": "manual",
+      "source": {
+        "kind": "internal",
+        "name": "dsh-raw-html",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.6.2"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-session-manager",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-session-manager",
+      "packageName": "dsh-session-manager",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-session-manager"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-session-manager"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.mjs"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-undo",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-undo-savepoint",
+      "packageName": "dsh-undo-savepoint",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/lire1131/dsh-undo-savepoint"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "github",
+          "repository": "https://github.com/lire1131/dsh-undo-savepoint"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-webui-prompt-optimizer",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-webui-prompt-optimizer",
+      "packageName": "dsh-webui-prompt-optimizer",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "dsh-whale-widget",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-whale-widget",
+      "packageName": "dsh-whale-widget",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "git+https://github.com/MeteorNOX/DeepSeek-Balance-Whale-Widget.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.2.10"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins",
+      "defaultDisabled": true
+    },
+    {
+      "id": "eac-core-bridge",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-eac-core-bridge",
+      "packageName": "dsh-eac-core-bridge",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "1.0.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "eac-locale-compat",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-eac-locale-compat",
+      "packageName": "dsh-eac-locale-compat",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "1.0.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "easy-setup",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-easy-setup",
+      "packageName": "@deepseek-ai/dsh-easy-setup",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-easy-setup",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "file-changes",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-file-changes",
+      "packageName": "@deepseek-ai/dsh-file-changes",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-file-changes",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "file-drop-eac",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-file-drop-eac",
+      "packageName": "dsh-file-drop-eac",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "dsh-file-drop-eac",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.2"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "float-window",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-float-window",
+      "packageName": "@deepseek-ai/dsh-float-window",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-float-window",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "font-custom",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-font-custom",
+      "packageName": "dsh-font-custom",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "image-paste",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-image-paste",
+      "packageName": "dsh-image-paste",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins",
+      "defaultDisabled": true
+    },
+    {
+      "id": "meow-smooth",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-meow-smooth",
+      "packageName": "meow-smooth",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "github",
+        "repository": "git+https://github.com/Phant0Meow/dsh-meow-smooth.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.5.0"
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "message-rewind",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-message-rewind",
+      "packageName": "dsh-message-rewind",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/host.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "mobile-fix",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-web-mobile-fix",
+      "packageName": "dsh-web-mobile-fix",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-web-mobile-fix",
+        "repository": "git+https://github.com/AcidGr/dsh-web-mobile-fix.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-web-mobile-fix"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "offpeak",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-offpeak",
+      "packageName": "dsh-offpeak",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-offpeak",
+        "repository": "git+https://github.com/christophersmith2737-commits/OffPeak.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-offpeak"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "src/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "openclaw-bridge",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-openclaw-bridge",
+      "packageName": "@deepseek-ai/dsh-openclaw-bridge",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-openclaw-bridge",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.7.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "picturereader",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/picturereader",
+      "packageName": "picturereader",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "picturereader",
+        "repository": "https://github.com/jing-hy/picturereader.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "picturereader"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "src/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "plugin-manager",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-plugin-manager",
+      "packageName": "@deepseek-ai/dsh-plugin-manager",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-plugin-manager",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "plugin-shield",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-plugin-shield",
+      "packageName": "dsh-plugin-shield",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "plugin-wizard",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-plugin-wizard",
+      "packageName": "dsh-plugin-wizard",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "prompt-custom",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-prompt-custom",
+      "packageName": "@deepseek-ai/dsh-prompt-custom",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-prompt-custom",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "settings-groups",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-settings-groups",
+      "packageName": "dsh-settings-groups",
+      "class": "manual",
+      "source": {
+        "kind": "unknown",
+        "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "settings-scroll-fix",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-settings-scroll-fix",
+      "packageName": "dsh-settings-scroll-fix",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "dsh-settings-scroll-fix",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "2.0.2"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "side-session",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-side-session",
+      "packageName": "@dsh-external/dsh-side-session",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@dsh-external/dsh-side-session",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.2.8"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "skin-switch",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-skin-switch",
+      "packageName": "@deepseek-ai/dsh-skin-switch",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-skin-switch",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "soul-md",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-soul-md",
+      "packageName": "dsh-soul-md",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-soul-md",
+        "repository": "git+https://github.com/Scorp1o117/dsh-soul-md.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-soul-md"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "terminal",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-terminal",
+      "packageName": "@deepseek-ai/dsh-terminal",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "@deepseek-ai/dsh-terminal",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "unified-market",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-unified-market",
+      "packageName": "dsh-unified-market",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "npm",
+        "name": "dsh-unified-market",
+        "repository": "git+https://github.com/jing-hy/dsh-unified-market.git"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "npm",
+          "name": "dsh-unified-market"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/host.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    },
+    {
+      "id": "viewport-lock",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-viewport-lock",
+      "packageName": "dsh-viewport-lock",
+      "class": "internal",
+      "source": {
+        "kind": "internal",
+        "name": "dsh-viewport-lock",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "1.0.1"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
+    }
+  ],
+  "skins": [
+    {
+      "id": "ui-skin-blue-fantasy",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/blue-fantasy",
+      "packageName": "@linxin666/dsh-client-ui-skin-blue-fantasy",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-dragon-heir",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/dragon-heir",
+      "packageName": "@linxin666/dsh-client-ui-skin-dragon-heir",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-maid-atelier",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/maid-atelier",
+      "packageName": "@dsh-external/dsh-client-ui-skin-maid-atelier",
+      "class": "resource",
+      "source": {
+        "kind": "internal",
+        "name": "@dsh-external/dsh-client-ui-skin-maid-atelier",
+        "reason": "maintained in this repository; no external source is declared"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.0.1"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "CC-BY-NC-SA-4.0",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-miku",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/miku",
+      "packageName": "@linxin666/dsh-client-ui-skin-miku",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-minecraft",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/minecraft",
+      "packageName": "@linxin666/dsh-client-ui-skin-minecraft",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-qq98",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/qq98",
+      "packageName": "@linxin666/dsh-client-ui-skin-qq98",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-ths",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/ths",
+      "packageName": "@linxin666/dsh-client-ui-skin-ths",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-trading",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/trading",
+      "packageName": "@linxin666/dsh-client-ui-skin-trading",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-whale-song",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/whale-song",
+      "packageName": "@linxin666/dsh-client-ui-skin-whale-song",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    },
+    {
+      "id": "ui-skin-xp",
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins/xp",
+      "packageName": "@linxin666/dsh-client-ui-skin-xp",
+      "class": "resource",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "0.1.11"
+      },
+      "sync": {
+        "mode": "metadata-only",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "BSD-3-Clause",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-skins"
+    }
+  ],
+  "sdkPlugins": [
+    {
+      "id": "sample-sdk-plugin",
+      "kind": "sdk-plugin",
+      "path": "dsh-desktop/assets/sdk-plugins/sample-sdk-plugin",
+      "packageName": "sample-sdk-plugin",
+      "class": "isolated-sdk",
+      "source": {
+        "kind": "internal",
+        "name": "sample-sdk-plugin",
+        "reason": "SDK fixture maintained with the desktop repository"
+      },
+      "request": {
+        "mode": "exact",
+        "version": "1.0.0"
+      },
+      "sync": {
+        "mode": "manual",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": false,
+        "defaultAction": "prompt"
+      },
+      "validation": {
+        "entrypoints": [
+          "index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-sdk"
+    }
+  ]
+}

--- a/.sync/plugins.schema.json
+++ b/.sync/plugins.schema.json
@@ -1,0 +1,499 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:dsh-desktop:plugins.schema:v1",
+  "title": "DSH Desktop bundled asset sync manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "generatedRegistry",
+    "plugins",
+    "skins",
+    "sdkPlugins"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "generatedRegistry": {
+      "const": "dsh-desktop/lib/desktop/plugin-sync-registry.ts"
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/inventoryEntry"
+      }
+    },
+    "skins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/inventoryEntry"
+      }
+    },
+    "sdkPlugins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/inventoryEntry"
+      }
+    }
+  },
+  "$defs": {
+    "inventoryEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "path",
+        "packageName",
+        "class",
+        "source",
+        "request",
+        "sync",
+        "runtimeUpdate",
+        "validation",
+        "license",
+        "owner"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "kind": {
+          "enum": [
+            "plugin",
+            "skin",
+            "sdk-plugin"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^dsh-desktop/assets/(plugins|skins|sdk-plugins)/[^/]+$"
+        },
+        "packageName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "class": {
+          "enum": [
+            "follow-upstream",
+            "patched",
+            "internal",
+            "manual",
+            "resource",
+            "isolated-sdk"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/source"
+        },
+        "request": {
+          "$ref": "#/$defs/request"
+        },
+        "sync": {
+          "$ref": "#/$defs/sync"
+        },
+        "runtimeUpdate": {
+          "$ref": "#/$defs/runtimeUpdate"
+        },
+        "validation": {
+          "$ref": "#/$defs/validation"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "defaultDisabled": {
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "skin"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "class": {
+                "const": "resource"
+              },
+              "sync": {
+                "properties": {
+                  "mode": {
+                    "const": "metadata-only"
+                  }
+                }
+              },
+              "runtimeUpdate": {
+                "properties": {
+                  "allowed": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "sdk-plugin"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "class": {
+                "const": "isolated-sdk"
+              },
+              "runtimeUpdate": {
+                "properties": {
+                  "allowed": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "npm",
+            "github",
+            "internal",
+            "unknown"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "npm"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "github"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "repository"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "enum": [
+                  "internal",
+                  "unknown"
+                ]
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "reason"
+            ],
+            "not": {
+              "required": [
+                "repository"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "latest",
+            "exact"
+          ]
+        },
+        "range": {
+          "type": "string"
+        },
+        "releaseAgeHours": {
+          "type": "number",
+          "minimum": 0
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "commit": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "latest"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "range",
+              "releaseAgeHours"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "exact"
+              }
+            }
+          },
+          "then": {
+            "anyOf": [
+              {
+                "required": [
+                  "version"
+                ]
+              },
+              {
+                "required": [
+                  "commit"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "sync": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "patches",
+        "preservePaths"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "mirror",
+            "patch-rebase",
+            "metadata-only",
+            "manual"
+          ]
+        },
+        "patches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preservePaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "runtimeUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allowed",
+        "defaultAction"
+      ],
+      "properties": {
+        "allowed": {
+          "type": "boolean"
+        },
+        "defaultAction": {
+          "enum": [
+            "prompt",
+            "none"
+          ]
+        },
+        "source": {
+          "$ref": "#/$defs/runtimeSource"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "allowed": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "source"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "allowed": {
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "required": [
+                "source"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "runtimeSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "npm",
+            "github"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "npm"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "name"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "github"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "repository"
+            ]
+          }
+        }
+      ]
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entrypoints",
+        "commands"
+      ],
+      "properties": {
+        "entrypoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "license": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected",
+        "reviewOnChange"
+      ],
+      "properties": {
+        "expected": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewOnChange": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/.sync/policies.json
+++ b/.sync/policies.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "manifest": ".sync/plugins.json",
+  "schema": ".sync/plugins.schema.json",
+  "inventoryRoots": [
+    {
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins",
+      "manifestKey": "plugins"
+    },
+    {
+      "kind": "skin",
+      "path": "dsh-desktop/assets/skins",
+      "manifestKey": "skins"
+    },
+    {
+      "kind": "sdk-plugin",
+      "path": "dsh-desktop/assets/sdk-plugins",
+      "manifestKey": "sdkPlugins"
+    }
+  ],
+  "allowedClasses": [
+    "follow-upstream",
+    "patched",
+    "internal",
+    "manual",
+    "resource",
+    "isolated-sdk"
+  ],
+  "allowedSyncModes": [
+    "mirror",
+    "patch-rebase",
+    "metadata-only",
+    "manual"
+  ],
+  "allowedSourceKinds": [
+    "npm",
+    "github",
+    "internal",
+    "unknown"
+  ],
+  "owners": {
+    "desktop-plugins": [
+      "dsh-desktop/assets/plugins/"
+    ],
+    "desktop-skins": [
+      "dsh-desktop/assets/skins/"
+    ],
+    "desktop-sdk": [
+      "dsh-desktop/assets/sdk-plugins/"
+    ]
+  },
+  "runtimeUpdates": {
+    "defaultAllowed": false,
+    "requiresExplicitSource": true,
+    "legacySourceCount": 11,
+    "sourceMapMustBeOneToOne": true
+  },
+  "forbiddenTrackedNames": [
+    "node_modules",
+    "vendor",
+    "cache"
+  ],
+  "sourcePolicy": {
+    "unknownRequiresReason": true,
+    "unknownMustNotContainRepository": true,
+    "directoryNameIsNotSourceEvidence": true
+  }
+}

--- a/dsh-desktop/test/companion-plugins-registry.test.ts
+++ b/dsh-desktop/test/companion-plugins-registry.test.ts
@@ -25,8 +25,36 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const syncRoot = join(root, '..', '.sync');
 // ADR 0002：COMPANION_PLUGINS / RETIRED_BUILTIN_PLUGINS 已迁至 L2 模块。
 const main = readFileSync(join(root, 'lib', 'desktop', 'companion-sync.ts'), 'utf8');
+const manifest = JSON.parse(readFileSync(join(syncRoot, 'plugins.json'), 'utf8')) as {
+  schemaVersion: number;
+  generatedRegistry: string;
+  plugins: ManifestEntry[];
+  skins: ManifestEntry[];
+  sdkPlugins: ManifestEntry[];
+};
+const policies = JSON.parse(readFileSync(join(syncRoot, 'policies.json'), 'utf8')) as {
+  inventoryRoots: { kind: string; path: string; manifestKey: string }[];
+  runtimeUpdates: { legacySourceCount: number; sourceMapMustBeOneToOne: boolean };
+};
+
+interface ManifestEntry {
+  id: string;
+  kind: 'plugin' | 'skin' | 'sdk-plugin';
+  path: string;
+  packageName: string;
+  class: 'follow-upstream' | 'patched' | 'internal' | 'manual' | 'resource' | 'isolated-sdk';
+  source: { kind: string; name?: string; repository?: string; reason?: string };
+  request: { mode: string; range?: string; releaseAgeHours?: number; version?: string; commit?: string };
+  sync: { mode: string; patches: string[]; preservePaths: string[] };
+  runtimeUpdate: { allowed: boolean; defaultAction: string; source?: { kind: string; name?: string; repository?: string } };
+  validation: { entrypoints: string[]; commands: string[] };
+  license: { expected: string; reviewOnChange: boolean };
+  owner: string;
+  defaultDisabled?: boolean;
+}
 
 function companionSlice() {
   const start = main.indexOf('const COMPANION_PLUGINS');
@@ -34,6 +62,49 @@ function companionSlice() {
   const end = main.indexOf('];', start);
   assert.ok(end > start, 'COMPANION_PLUGINS array must be closed');
   return main.slice(start, end);
+}
+
+function companionRows() {
+  return [...companionSlice().matchAll(
+    /\{\s*id:\s*'([^']+)'\s*,\s*name:\s*'([^']+)'(?:\s*,\s*dir:\s*'([^']+)')?/g,
+  )].map((match) => ({
+    id: match[1],
+    packageName: match[2],
+    dir: match[3] || (match[2].includes('/') ? match[2].split('/').pop() : match[2]),
+  }));
+}
+
+function updateSourceRows() {
+  const start = main.indexOf('export const PLUGIN_UPDATE_SOURCES');
+  assert.ok(start >= 0, 'PLUGIN_UPDATE_SOURCES must exist in lib/desktop/companion-sync.ts');
+  const end = main.indexOf('};', start);
+  assert.ok(end > start, 'PLUGIN_UPDATE_SOURCES object must be closed');
+  return [...main.slice(start, end).matchAll(
+    /'([^']+)'\s*:\s*\{\s*(npm|github):\s*'([^']+)'\s*\}/g,
+  )].map((match) => ({ id: match[1], kind: match[2], source: match[3] }));
+}
+
+function allManifestEntries() {
+  return [...manifest.plugins, ...manifest.skins, ...manifest.sdkPlugins];
+}
+
+function inventoryDirectories(kind: ManifestEntry['kind']) {
+  const directory = kind === 'plugin'
+    ? join(root, 'assets', 'plugins')
+    : kind === 'skin'
+      ? join(root, 'assets', 'skins')
+      : join(root, 'assets', 'sdk-plugins');
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function packageFor(entry: ManifestEntry) {
+  return JSON.parse(readFileSync(join(root, entry.path.replace('dsh-desktop/', ''), 'package.json'), 'utf8')) as {
+    name: string;
+    license?: string;
+  };
 }
 
 // 有 package.json 但明确不随 COMPANION_PLUGINS 分发的目录（退役等）。
@@ -66,6 +137,96 @@ test('every registration row with dir points at a real vendored package', () => 
   const rows = [...slice.matchAll(/dir:\s*'([^']+)'/g)].map((m) => m[1]);
   const bad = rows.filter((d) => !existsSync(join(root, 'assets', 'plugins', d, 'package.json')));
   assert.deepEqual(bad, [], '注册行指向不存在的插件目录');
+});
+
+test('manifest covers every bundled plugin, skin, and SDK directory exactly once', () => {
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.generatedRegistry, 'dsh-desktop/lib/desktop/plugin-sync-registry.ts');
+  assert.deepEqual(policies.inventoryRoots, [
+    { kind: 'plugin', path: 'dsh-desktop/assets/plugins', manifestKey: 'plugins' },
+    { kind: 'skin', path: 'dsh-desktop/assets/skins', manifestKey: 'skins' },
+    { kind: 'sdk-plugin', path: 'dsh-desktop/assets/sdk-plugins', manifestKey: 'sdkPlugins' },
+  ]);
+  const entries = allManifestEntries();
+  assert.equal(manifest.plugins.length, 47);
+  assert.equal(manifest.skins.length, 10);
+  assert.equal(manifest.sdkPlugins.length, 1);
+  assert.equal(new Set(entries.map((entry) => entry.id)).size, entries.length, 'manifest ids must be unique');
+  for (const kind of ['plugin', 'skin', 'sdk-plugin'] as const) {
+    const rows = entries.filter((entry) => entry.kind === kind);
+    const manifestDirs = rows.map((entry) => entry.path.split('/').pop()).sort();
+    assert.deepEqual(manifestDirs, inventoryDirectories(kind), `${kind} directories must match manifest paths`);
+  }
+});
+
+test('manifest plugin rows map one-to-one to COMPANION_PLUGINS', () => {
+  const registrations = companionRows();
+  assert.equal(registrations.length, 47);
+  assert.equal(new Set(registrations.map((row) => row.id)).size, registrations.length, 'companion ids must be unique');
+  assert.deepEqual(
+    manifest.plugins.map((entry) => entry.id).sort(),
+    registrations.map((row) => row.id).sort(),
+  );
+  for (const registration of registrations) {
+    const matches = manifest.plugins.filter((entry) => (
+      entry.id === registration.id
+      && entry.packageName === registration.packageName
+      && entry.path.endsWith(`/plugins/${registration.dir}`)
+    ));
+    assert.equal(matches.length, 1, `${registration.id} must have one matching manifest row`);
+  }
+});
+
+test('manifest entries agree with package metadata and use explicit source policy', () => {
+  const classes = new Set(['follow-upstream', 'patched', 'internal', 'manual', 'resource', 'isolated-sdk']);
+  const syncModes = new Set(['mirror', 'patch-rebase', 'metadata-only', 'manual']);
+  for (const entry of allManifestEntries()) {
+    const pkg = packageFor(entry);
+    assert.equal(entry.packageName, pkg.name, `${entry.id} packageName must match package.json`);
+    assert.equal(entry.license.expected, pkg.license || 'UNKNOWN', `${entry.id} license must match package.json`);
+    assert.ok(classes.has(entry.class), `${entry.id} has an invalid class`);
+    assert.ok(syncModes.has(entry.sync.mode), `${entry.id} has an invalid sync mode`);
+    assert.ok(entry.owner, `${entry.id} must have an owner`);
+    assert.equal(entry.runtimeUpdate.defaultAction, 'prompt');
+    assert.equal(entry.license.reviewOnChange, true);
+    assert.ok(entry.validation.entrypoints.length > 0, `${entry.id} must declare an entrypoint`);
+    const packageRoot = join(root, '..', entry.path);
+    assert.ok(entry.validation.entrypoints.every((path) => existsSync(join(packageRoot, path))),
+      `${entry.id} declares a missing entrypoint`);
+    if (entry.source.kind === 'unknown') {
+      assert.ok(entry.source.reason, `${entry.id} unknown source requires a reason`);
+      assert.equal(entry.source.repository, undefined, `${entry.id} unknown source must not guess a repository`);
+    }
+    if (entry.kind === 'skin') {
+      assert.equal(entry.class, 'resource');
+      assert.equal(entry.sync.mode, 'metadata-only');
+      assert.equal(entry.runtimeUpdate.allowed, false);
+    }
+    if (entry.kind === 'sdk-plugin') {
+      assert.equal(entry.class, 'isolated-sdk');
+      assert.equal(entry.runtimeUpdate.allowed, false);
+    }
+  }
+});
+
+test('all legacy plugin update sources map to exactly one manifest entry', () => {
+  const sources = updateSourceRows();
+  const entries = allManifestEntries();
+  assert.equal(sources.length, 11);
+  assert.equal(policies.runtimeUpdates.legacySourceCount, sources.length);
+  assert.equal(policies.runtimeUpdates.sourceMapMustBeOneToOne, true);
+  for (const source of sources) {
+    const matches = entries.filter((entry) => entry.id === source.id);
+    assert.equal(matches.length, 1, `${source.id} must map to exactly one manifest entry`);
+    const entry = matches[0];
+    assert.equal(entry.runtimeUpdate.allowed, true, `${source.id} must allow its declared runtime source`);
+    assert.ok(entry.runtimeUpdate.source, `${source.id} must copy its runtime source into the manifest`);
+    assert.equal(entry.runtimeUpdate.source.kind, source.kind);
+    if (source.kind === 'npm') assert.equal(entry.runtimeUpdate.source.name, source.source);
+    if (source.kind === 'github') assert.equal(entry.runtimeUpdate.source.repository, `https://github.com/${source.source}`);
+  }
+  const allowedIds = entries.filter((entry) => entry.runtimeUpdate.allowed).map((entry) => entry.id).sort();
+  assert.deepEqual(allowedIds, sources.map((source) => source.id).sort(), 'manifest must not add extra runtime update sources');
 });
 
 test('regression: settings-groups stays registered, retired plugins never return', () => {


### PR DESCRIPTION
## 目的

为插件同步/版本锁定后续工作建立可审查的 manifest 基线，补齐主仓库内置资源的归属、来源、同步方式、运行时更新策略和验证入口。当前变更不改变用户可见的运行时行为。
 

## 架构与范围

本 PR 只涉及 L2 桌面插件资源的 inventory 与契约测试，不修改运行时同步实现：

- `.sync/plugins.schema.json`：定义 manifest v1 的 JSON Schema，约束 `plugins`、`skins`、`sdkPlugins` 条目及 `class`、`source`、`request`、`sync`、`runtimeUpdate`、入口、license、owner 等字段；皮肤固定为 `resource`/`metadata-only`，SDK 插件固定为 `isolated-sdk`，未知来源必须给出原因且不得猜测 repository。
- `.sync/plugins.json`：登记 47 个 legacy plugin、10 个 skin 和 1 个 SDK plugin，共 58 条唯一的 `id`/`path` inventory；记录 package metadata、入口、license、维护归属和来源策略。**在本PR中，此部分使用保守方案，很多plugin都是固定版本而非同步上游修改，在全PR链完成且试发布没问题之后再做版本同步**
- `.sync/policies.json`：声明三个 inventory 根目录、允许的分类/同步/来源类型、维护者路径、运行时来源一一映射规则，以及 `node_modules`、`vendor`、`cache` 等禁止纳管项。
- `dsh-desktop/test/companion-plugins-registry.test.ts`：验证目录与 manifest 一一对应、package name/license/入口一致、来源策略合法、47 条 `COMPANION_PLUGINS` 注册与 manifest 一一映射，并锁定现有 11 条 `PLUGIN_UPDATE_SOURCES` 不增不减。
- `.github/CODEOWNERS`：为 `.sync/` 指定 `@metaone01`，为插件、皮肤和 SDK 资源目录指定 `@zouyuxuan122`。

本阶段明确不包含 validator、lock、generated registry、syncer、workflow、staging/release 或 runtime overlay；`companion-sync.ts` 未修改。
 

## 风险与兼容

- 现有 `COMPANION_PLUGINS`、`PLUGIN_UPDATE_SOURCES`、profile copy、安装包内容和用户数据路径未改动；新增内容是仓库元数据与测试护栏。
- 运行时更新仍只有既有 11 个白名单来源：`better-sidebar`、`computer-user`、`dsh-navbar`、`dsh-pet`、`dsh-session-manager`、`dsh-undo`、`mobile-fix`、`offpeak`、`picturereader`、`soul-md`、`unified-market`。其余条目默认禁止运行时更新。
- 14 个来源未知条目保留 `reason`，未根据目录名推断 URL：`change-review`、`compact`、`dock-settings`、`dsh-feature-toggles`、`dsh-pet-settings`、`dsh-webui-prompt-optimizer`、`eac-core-bridge`、`eac-locale-compat`、`font-custom`、`image-paste`、`message-rewind`、`plugin-shield`、`plugin-wizard`、`settings-groups`。
- 回滚本 PR 即可移除 manifest、策略和契约测试，并恢复 CODEOWNERS；无配置、用户数据或升级迁移需要回滚。
 

## 验证

- [ ] Skill 推荐的最低验证级别已完成：V2 全量 `npm test` 未完成，当前 worktree 缺少完整依赖，`@types/node` 缺失导致 TypeScript build 在 `TS2688` 处失败。
- [x] `node --test --experimental-strip-types test/companion-plugins-registry.test.ts`：7/7 通过。
- [x] `node --check dsh-desktop/scripts/check-latest.js && node --check dsh-desktop/scripts/fetch-kernel.js`：通过。
- [x] `git diff --check`：通过。
- [x] JSON inventory 统计：47 plugins / 10 skins / 1 SDK plugin，合计 58 条；`id` 与 `path` 均唯一。
- [x] 没有纳入无关文件、日志、凭据、用户数据或依赖安装产物；UI 不涉及，截图/录屏不适用。
- [ ] 未验证项已明确列出：`npm --prefix dsh-desktop run typecheck` 与 `npm test` 均受缺少 `@types/node` 阻断；`node dsh-desktop/scripts/plugin-sync.mjs validate-manifest` 当前入口尚不存在，按范围留给后续 validator 任务。
 

## 配置与迁移

无。新增 `.sync/` 是仓库内的静态 inventory/策略元数据，不读取或改写用户 profile、sessions、配置或安装数据。

## 回退方式

直接 revert 本 PR 即可恢复原有目录清单、CODEOWNERS 和测试状态。由于本阶段未改变运行时逻辑、锁文件或用户数据，不需要额外的数据迁移或恢复步骤。