### PR TITLE
fix(shell)：修复导航后窗口控制失效

### DIFF
--- a/dsh-desktop/test/window-bridge-port.test.ts
+++ b/dsh-desktop/test/window-bridge-port.test.ts
@@ -1,0 +1,40 @@
+// 回归：无边框主窗的窗口控制依赖 WS 桥。
+//
+// 桥端口在 19873 被占用时会回退到其他端口；如果真实 Web UI 导航后
+// 仍注入裸 BRIDGE_JS，页面侧客户端会退回固定 19873，导致拖动、最小化、
+// 最大化和关闭按钮全部失效。
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const main = readFileSync(join(root, 'tauri-shell', 'src', 'main.rs'), 'utf8');
+
+test('壳层初始化脚本绑定实际桥端口', () => {
+  assert.match(main, /fn bridge_init_script\(\) -> String/, '应有统一初始化脚本生成器');
+  assert.match(
+    main,
+    /fn bridge_init_script\(\)[\s\S]*?ws_port\(\)[\s\S]*?BRIDGE_JS/,
+    '初始化脚本必须把实际 ws_port 注入到单源 bridge 前',
+  );
+  assert.doesNotMatch(
+    main,
+    /\.initialization_script\(BRIDGE_JS\)/,
+    'WebView 不得直接注入不带实际端口的裸 BRIDGE_JS',
+  );
+  assert.match(
+    main,
+    /\.initialization_script\(&bridge_init_script\(\)\)/,
+    '主窗必须使用带实际端口的初始化脚本',
+  );
+});
+
+test('浮窗初始化脚本也绑定实际桥端口', () => {
+  assert.match(
+    main,
+    /window\.__DSH_FLOAT__[\s\S]*?bridge_init_script\(\)/,
+    '浮窗不得绕过实际桥端口注入',
+  );
+});

--- a/tauri-shell/src/main.rs
+++ b/tauri-shell/src/main.rs
@@ -63,6 +63,19 @@ fn ws_port() -> u16 {
     WS_PORT_EFFECTIVE.load(Ordering::SeqCst)
 }
 
+/// 生成带实际桥端口的 WebView 初始化脚本。
+///
+/// 主窗首屏 /loading 会通过页面 HTML 注入端口，但导航到真实 Web UI
+/// 后页面上下文会重建；仅注入裸 BRIDGE_JS 会让客户端退回固定的
+/// 19873，端口发生回退时窗口控制全部失效。
+fn bridge_init_script() -> String {
+    format!(
+        "window.__DSH_BRIDGE_WS__='ws://127.0.0.1:{}/ws';\n{}",
+        ws_port(),
+        BRIDGE_JS,
+    )
+}
+
 fn locale_tag_is_chinese(tag: &str) -> bool {
     tag.trim()
         .split(['-', '_'])
@@ -1486,7 +1499,7 @@ fn open_float_window(app: &tauri::AppHandle, session_id: &str) -> Result<bool, S
          window.dshDesktop._onReady(function(){{\
            window.dshDesktop._send('float.ready',{{win:{:?}}});\
          }});",
-        session_id, label, BRIDGE_JS, label
+        session_id, label, bridge_init_script(), label
     );
     let data_dir: PathBuf = app
         .path()
@@ -2445,7 +2458,7 @@ fn main() {
                                     // msWebOOUI/msPdfOOUI/msSmartScreenProtection 禁用项，
                                     // 与浮窗（显式拼接该前缀）行为分裂。
                                     .additional_browser_args("--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --autoplay-policy=no-user-gesture-required")
-                                    .initialization_script(BRIDGE_JS);
+                                    .initialization_script(&bridge_init_script());
                                     if let Some((px, py)) = sim_pos {
                                         builder = builder.position(px, py);
                                     }


### PR DESCRIPTION
## 目的
修复 Windows 正式使用时，页面导航后窗口无法拖动、最大化/还原、缩小和关闭的问题。

## 根因与实现
- 主窗口导航到真实 Web UI 后，WebView 上下文会重新初始化。
- 原实现只注入裸 `BRIDGE_JS`，页面侧可能回退到固定的 `19873` 端口；当实际桥端口发生回退时，窗口控制请求无法到达壳层。
- 新增统一的 `bridge_init_script()`，将当前 `ws_port()` 注入主窗口和浮窗初始化脚本。
- 新增回归测试，防止后续再次直接注入不带实际端口的裸 bridge。

## 影响范围
- `tauri-shell/src/main.rs`
- `dsh-desktop/test/window-bridge-port.test.ts`
- 不涉及配置迁移、用户数据和插件契约变更。

## 验证
- `node --test dsh-desktop/test/window-bridge-port.test.ts`：2/2 通过
- `rustup run 1.96.1-x86_64-pc-windows-msvc cargo check`：通过
- `rustup run 1.96.1-x86_64-pc-windows-msvc cargo test`：5/5 通过
- `git diff --check`：通过

## 未验证项
GUI 自动冒烟未能在当前环境发现 WebView2 CDP target，因此未完成自动点击窗口按钮；壳层构建和桥端口回归测试已通过，建议合并后由 Windows 实机手动确认窗口控制。

## 回退方式
如需回退，可直接回退提交 `363e7af`。