### PR TITLE
fix(plugin)：修复“本会话修改”页显示暂无文件更改记录

### DIFF
--- a/dsh-desktop/assets/plugins/dsh-file-changes/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-file-changes/lib/index.js
@@ -44,12 +44,15 @@ function clamp(text) {
 
 const fileChangesProjectionDefinition = {
   key: "fileChanges",
-  // dsh 0.1.0-rc.6 requires stateVersion (non-negative integer) and a
-  // `view` that shapes the raw state into the schema-validated value.
+  // dsh 5.3.x 使用 stateSchema + wire.{viewSchema,view} 契约。
+  // 旧版顶层 schema/view 不会进入客户端可见的 snapshot。
   stateVersion: 0,
-  schema: fileChangesSchema,
+  stateSchema: fileChangesSchema,
   init: () => ({ changes: [], truncated: false }),
-  view: (state) => state,
+  wire: {
+    viewSchema: fileChangesSchema,
+    view: (state) => state
+  },
   apply: (state, event) => {
     if (event.type !== "tool/result") return state;
     const diffs = event.data?.meta?.diffs;

--- a/dsh-desktop/test/dsh-file-changes-projection.test.ts
+++ b/dsh-desktop/test/dsh-file-changes-projection.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { apply as applyPlugin } from '../assets/plugins/dsh-file-changes/lib/index.js';
+
+test('dsh-file-changes 使用客户端可见的投影契约并保留 diffs 折叠', () => {
+  let definition: any;
+  const disposers: Array<() => void> = [];
+  const ctx = {
+    sessionProjections: {
+      register(value: any) {
+        definition = value;
+        const dispose = () => {};
+        disposers.push(dispose);
+        return dispose;
+      },
+    },
+    webServer: {
+      register() {
+        const dispose = () => {};
+        disposers.push(dispose);
+        return dispose;
+      },
+    },
+  };
+
+  const disposePlugin = applyPlugin(ctx as any);
+  try {
+    assert.ok(definition, '插件必须注册 fileChanges 投影');
+    assert.equal(definition.key, 'fileChanges');
+    assert.ok(definition.stateSchema, '投影必须声明 stateSchema');
+    assert.ok(definition.wire, '投影必须声明 wire');
+    assert.equal(definition.wire.viewSchema, definition.stateSchema);
+    assert.equal(typeof definition.wire.view, 'function');
+    assert.equal('schema' in definition, false, '不得继续使用旧的顶层 schema');
+    assert.equal('view' in definition, false, '不得继续使用旧的顶层 view');
+
+    const state = definition.apply(
+      definition.init(),
+      {
+        type: 'tool/result',
+        seq: 7,
+        time: 1234,
+        data: {
+          meta: {
+            diffs: [
+              { path: 'src/example.ts', oldText: 'old', newText: 'new' },
+            ],
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(state.changes, [{
+      seq: 7,
+      time: 1234,
+      path: 'src/example.ts',
+      op: 'edit',
+      oldText: 'old',
+      newText: 'new',
+    }]);
+    assert.deepEqual(
+      definition.wire.viewSchema.parse(definition.wire.view(state)),
+      state,
+    );
+  } finally {
+    disposePlugin();
+    for (const dispose of disposers) dispose();
+  }
+});


### PR DESCRIPTION
## 目的
修复在当前会话中通过文件工具修改文件后，「文件 → 本会话修改」页面仍显示“暂无文件更改记录”的问题。

## 变更内容
- 将 `dsh-file-changes` 的会话投影从旧版顶层 `schema/view` 契约迁移到当前 `stateSchema + wire.viewSchema/view` 契约。
- 新增回归测试，覆盖投影注册、`tool/result.meta.diffs` 折叠和 wire schema 校验。

## 影响范围
- 仅修改内置 `dsh-file-changes` 插件及其回归测试。
- 不修改客户端页面、文件还原逻辑、会话数据格式或配置迁移。
- profile 中的插件副本会在下次启动同步时更新。

## 验证结果
- `node --check assets/plugins/dsh-file-changes/lib/index.js`
- 定向投影回归测试：通过
- `npm run build`：通过
- `npm test`：829 通过，4 个按平台条件跳过，0 失败
- `git diff --check`：通过

## 未验证项
- 未进行安装版手工 GUI 回归；本次变更已完成源码、构建和全量自动化测试。

## 回退方式
如需回退，可还原本 PR 提交，不涉及用户会话数据迁移。