### PR TITLE
fix(手机桥)：修复配对端刷新后会话列表为空

### DIFF
--- a/dsh-desktop/test/phone-bridge.test.ts
+++ b/dsh-desktop/test/phone-bridge.test.ts
@@ -161,12 +161,18 @@ test('phone bridge: start → 配对页/门禁/状态，错误 token 被拒', as
 
 test('phone bridge: 桌面批准 → approved + cookie + 完整代理（Host/Origin 改写 + 正文透传）', async () => {
   // 模拟内核：记录收到的头，回一个静态页/JSON。
-  const seen: { url: string; host: string | undefined; origin: string | undefined; body: string }[] = []
+  const seen: { url: string; host: string | undefined; origin: string | undefined; acceptEncoding: string | undefined; body: string }[] = []
   const kernel = http.createServer((req, res) => {
     const body: Buffer[] = []
     req.on('data', (c) => body.push(c as Buffer))
     req.on('end', () => {
-      seen.push({ url: req.url ?? '', host: req.headers.host, origin: req.headers.origin, body: Buffer.concat(body).toString('utf8') })
+      seen.push({
+        url: req.url ?? '',
+        host: req.headers.host,
+        origin: req.headers.origin,
+        acceptEncoding: req.headers['accept-encoding'],
+        body: Buffer.concat(body).toString('utf8'),
+      })
       if ((req.url ?? '').startsWith('/api/')) {
         res.writeHead(200, { 'content-type': 'application/json', connection: 'close' })
         res.end(JSON.stringify({ ok: true, items: [1, 2, 3] }))
@@ -204,9 +210,11 @@ test('phone bridge: 桌面批准 → approved + cookie + 完整代理（Host/Ori
     const page = await request(base + '/', { cookie: mobileCookie })
     assert.equal(page.status, 200)
     assert.match(page.text, /DeepSeek Harness/)
+    assert.match(page.text, /crypto\.randomUUID/)
     assert.equal(seen[0].url, '/')
     // Host/Origin 改写：内核看到自己的 origin（信任围栏视为同源）
     assert.equal(seen[0].host, `127.0.0.1:${kernelPort(kernel)}`)
+    assert.equal(seen[0].acceptEncoding, 'identity')
 
     // POST /api/*：请求体原样透传（不再有 client-request 信封协议）
     const api = await request(base + '/api/session.list', { method: 'POST', body: { cursor: 7 }, cookie: mobileCookie, headers: { origin: `http://192.168.1.20:${info.port}` } })
@@ -246,6 +254,42 @@ test('phone bridge: 桌面批准 → approved + cookie + 完整代理（Host/Ori
     // 断言失败也必须停桥：泄漏的监听句柄会让 node --test 进程永不退出
     // （全量测试「跑完不退出」挂起的直接来源）。stop 幂等，重复调用无害。
     if (bridge !== null) await bridge.stop().catch(() => {})
+  }
+})
+
+test('phone bridge: 上游已有 gzip 编码时不重复压缩 JSON', async () => {
+  const payload = JSON.stringify({ ok: true, items: ['历史会话 A', '历史会话 B'] })
+  const kernel = http.createServer((req, res) => {
+    if ((req.url ?? '').startsWith('/api/')) {
+      res.writeHead(200, {
+        'content-type': 'application/json',
+        'content-encoding': 'gzip',
+        connection: 'close',
+      })
+      res.end(zlib.gzipSync(payload))
+      return
+    }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', connection: 'close' })
+    res.end('<!doctype html><html><head><title>DeepSeek Harness</title></head><body><div id="root"></div></body></html>')
+  })
+  await new Promise<void>((resolve) => kernel.listen(0, '127.0.0.1', resolve))
+  const { bridge } = launch(kernel)
+  try {
+    const info = await bridge.start()
+    const base = `http://127.0.0.1:${info.port}`
+    const cookie = await approveAndCookie(bridge, info)
+    const response = await request(base + '/api/session.list', {
+      method: 'POST',
+      body: {},
+      cookie,
+      headers: { 'accept-encoding': 'gzip' },
+    })
+    assert.equal(response.status, 200)
+    assert.equal(response.headers['content-encoding'], 'gzip')
+    assert.deepEqual(JSON.parse(zlib.gunzipSync(response.raw).toString('utf8')), JSON.parse(payload))
+  } finally {
+    await bridge.stop()
+    kernel.close()
   }
 })
 
@@ -386,8 +430,19 @@ test('phone bridge: lanAddress 优先 RFC1918 私网地址，避免 169.254 链�
   })
   // 混合网卡：有家用网段就不选 APIPA/虚拟网卡
   assert.equal(lanAddress({ 'Wi-Fi': [v4('192.168.1.23')], 'Ethernet': [v4('169.254.83.107'), v4('10.0.0.5')] }), '192.168.1.23')
+  // VMware/VirtualBox/Hyper-V 等虚拟网卡即使是 RFC1918，也不能抢在物理网卡前。
+  assert.equal(lanAddress({
+    'VMware Network Adapter VMnet1': [v4('192.168.230.1')],
+    'Wi-Fi': [v4('192.168.1.23')],
+  }), '192.168.1.23')
+  assert.equal(lanAddress({
+    'vEthernet (Default Switch)': [v4('172.22.0.1')],
+    Ethernet: [v4('192.168.1.23')],
+  }), '192.168.1.23')
   // 10./172.16-31 网段同样优先
   assert.equal(lanAddress({ 'VPN': [v4('10.8.0.2')], 'Ethernet': [v4('172.22.0.9')], 'Wi-Fi': [v4('192.168.1.23')] }), '10.8.0.2')
+  // 没有普通 LAN 时允许 Tailscale 地址作为远程配对入口。
+  assert.equal(lanAddress({ Tailscale: [v4('100.89.1.2')] }), '100.89.1.2')
   // 只有链路本地 → 兜底可用（好过直接回环）
   assert.equal(lanAddress({ 'Ethernet': [v4('169.254.83.107')] }), '169.254.83.107')
   // 只有回环 → 127.0.0.1

--- a/tauri-shell/sidecar/phone-bridge.ts
+++ b/tauri-shell/sidecar/phone-bridge.ts
@@ -69,31 +69,45 @@ interface PairingState {
   decided: boolean | null; // null=未决, true=批准, false=拒绝
 }
 
-// 挑一个手机可达的 LAN IPv4：优先 RFC1918 私网地址（192.168/10./172.16-31，
-// 普通家用/办公 Wi-Fi 网段），其次任意非回环地址（含 169.254 链路本地——DHCP
-// 失败时的兜底，本机可达、同网段手机通常也可达），最后回环。旧实现直接取第一
-// 个非回环地址，经常选中虚拟网卡/APIPA 的 169.254.x，手机扫出来的地址连不上。
+// 挑一个手机可达的 LAN IPv4：优先真实网卡上的 RFC1918 私网地址
+//（192.168/10./172.16-31），其次 Tailscale 的 CGNAT 地址和其他非回环地址，
+// 最后才回退到第一个非回环地址或回环。Windows 上 VMware/VirtualBox/
+// Hyper-V/WSL/Docker 的虚拟网卡也可能提供 RFC1918 地址，不能再只看网段；
+// 先按网卡名称降权，避免二维码默认落到 VMnet/Default Switch 这类手机不可达地址。
 // interfaces 参数仅为测试注入 fake 网卡表（生产调用不传，走 os.networkInterfaces）。
+const VIRTUAL_INTERFACE_PATTERN =
+  /(?:vmware|vmnet|virtualbox|vbox|hyper[- ]?v|vEthernet|wsl|docker|container|host[- ]?only|nat network)/i;
+
+function isRfc1918Address(address: string): boolean {
+  const parts = address.split('.').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  const first = parts[0] ?? -1;
+  const second = parts[1] ?? -1;
+  return first === 10 || (first === 192 && second === 168) || (first === 172 && second >= 16 && second <= 31);
+}
+
+function isTailscaleAddress(address: string): boolean {
+  const parts = address.split('.').map((part) => Number(part));
+  return parts.length === 4 && parts[0] === 100 && (parts[1] ?? -1) >= 64 && (parts[1] ?? -1) <= 127;
+}
+
 export function lanAddress(interfaces?: NodeJS.Dict<os.NetworkInterfaceInfo[]>): string {
   const ifaces = interfaces ?? os.networkInterfaces();
   let fallback: string | null = null;
+  let best: { address: string; score: number } | null = null;
   for (const name of Object.keys(ifaces)) {
     for (const entry of ifaces[name] ?? []) {
       if (entry.family !== 'IPv4' || entry.internal) continue;
       const ip = entry.address;
       if (fallback === null) fallback = ip;
-      const p = ip.split('.').map((s) => Number(s));
-      if (p.length !== 4 || p.some((n) => Number.isNaN(n))) continue;
-      const a = p[0] ?? -1;
-      const b = p[1] ?? -1;
-      const rfc1918 =
-        a === 10 ||
-        (a === 192 && b === 168) ||
-        (a === 172 && b >= 16 && b <= 31);
-      if (rfc1918) return ip;
+      const virtual = VIRTUAL_INTERFACE_PATTERN.test(name);
+      let score = isRfc1918Address(ip) ? 300 : isTailscaleAddress(ip) ? 250 : 100;
+      if (/tailscale/i.test(name)) score += 20;
+      if (virtual) score -= 1000;
+      if (best === null || score > best.score) best = { address: ip, score };
     }
   }
-  return fallback ?? '127.0.0.1';
+  return best?.address ?? fallback ?? '127.0.0.1';
 }
 
 function isLoopback(address: string | undefined): boolean {
@@ -303,6 +317,10 @@ export function createPhoneBridge(options: PhoneBridgeOptions) {
     const headers = { ...req.headers };
     const target = new URL(origin);
     headers.host = target.host;
+    // 内核 WebServer 自身默认会按 Accept-Encoding gzip。桥必须先拿到原始
+    // 响应：否则 JSON 会被桥再次 gzip，HTML 也无法注入非安全上下文所需的
+    // crypto.randomUUID polyfill。压缩统一由桥在客户端支持时处理。
+    headers['accept-encoding'] = 'identity';
     if (typeof headers.origin === 'string' && headers.origin !== '') headers.origin = target.origin;
     if (typeof headers.referer === 'string' && headers.referer !== '') {
       try { headers.referer = new URL(new URL(headers.referer).pathname + new URL(headers.referer).search, origin).toString(); } catch { /* 保留原值 */ }
@@ -501,7 +519,7 @@ export function createPhoneBridge(options: PhoneBridgeOptions) {
           const wantsGzip = (req.headers['accept-encoding'] ?? '').includes('gzip');
           const isUnaryJson =
             req.method === 'POST' && pathName.startsWith('/api/') && contentType.includes('application/json');
-          if (isUnaryJson && wantsGzip) {
+          if (isUnaryJson && wantsGzip && up.headers['content-encoding'] === undefined) {
             const headers = { ...up.headers };
             // 上游 chunked 头不能带着转发：重编码后由 Node 依 content-length
             // 自选 framing，保留会与显式 content-length 冲突（非法响应，


### PR DESCRIPTION
## 目的
修复 Windows 环境下 dsh-phone 配对端刷新后会话列表为空的问题，关闭 Issue #328。

## 根因
- 内核 Web 服务返回的 JSON 可能已经 gzip，手机桥再次压缩后导致客户端解析失败。
- 局域网明文 HTML 页面无法直接使用 `crypto.randomUUID`，导致部分手机端初始化失败。
- Windows 存在多个虚拟网卡时，二维码可能生成不可达的 VMware、Hyper-V、WSL 或 Docker 地址。

## 变更
- 手机桥向内核请求原始响应，避免重复 gzip。
- 仅对未编码的 JSON 响应执行桥侧 gzip。
- 为明文 HTML 注入 `crypto.randomUUID` 兼容层。
- 优化局域网地址评分，避开常见虚拟网卡并支持 Tailscale 地址。
- 增加 gzip、HTML 兼容层和网卡选择回归测试。

## 影响范围
- 仅涉及 `tauri-shell/sidecar/phone-bridge.ts` 及其定向测试。
- 不改变内核 API、桌面端配对流程、用户数据目录或配置格式。
- 如需回滚，可还原本 PR 的修复提交。

## 验证
- `npm run build`
- `node --test test/phone-bridge.test.ts`
- `npm test`：834 项测试，830 通过，4 项按平台条件跳过，0 失败
- `git diff --check`

## 未验证项
尚未使用真实手机和真实多网卡环境进行现场扫码验证；已通过本地 HTTP 集成测试覆盖响应编码、HTML 注入和地址选择行为。

Closes #328