### PR TITLE
feat(plugins): 收录鲸鱼用量与离线语音插件

### DIFF
--- a/dsh-desktop/assets/SOURCES.json
+++ b/dsh-desktop/assets/SOURCES.json
@@ -1188,6 +1188,56 @@
       }
     },
     {
+      "id": "C046a",
+      "line": "main",
+      "name": "dsh-whale-meter",
+      "type": "plugin",
+      "origin": "contribution",
+      "version": "0.1.0",
+      "path": "dsh-desktop/assets/plugins/dsh-whale-meter",
+      "registryStatus": "注册表默认禁用",
+      "audit": {
+        "verdict": "contributor-origin",
+        "compare": "首次收录",
+        "note": "按会话累计 DSH tokenUsage，提供本地费用估算、可自定义价格及对话/侧栏展示。",
+        "basis": "贡献者仓库源码与 MIT 许可证",
+        "conflict": null
+      },
+      "upstream": {
+        "repository": "https://github.com/ntpzz/dsh-whale-chan-pack",
+        "refType": "commit",
+        "pinnedHead": "9a620f0",
+        "catalogName": null,
+        "catalogEntry": null,
+        "provenance": "贡献者维护仓库 plugins/dsh-whale-meter"
+      }
+    },
+    {
+      "id": "C046b",
+      "line": "main",
+      "name": "dsh-whale-voice",
+      "type": "plugin",
+      "origin": "contribution",
+      "version": "0.2.0",
+      "path": "dsh-desktop/assets/plugins/dsh-whale-voice",
+      "registryStatus": "注册表默认禁用；首次准备模型时下载本地运行库",
+      "audit": {
+        "verdict": "contributor-origin",
+        "compare": "首次收录",
+        "note": "本地 Whisper 语音输入；模型、语言、设备、麦克风及 32×32 自定义图标均在 DSH 设置页配置。",
+        "basis": "贡献者仓库源码与 MIT 许可证",
+        "conflict": null
+      },
+      "upstream": {
+        "repository": "https://github.com/ntpzz/dsh-whale-chan-pack",
+        "refType": "commit",
+        "pinnedHead": "9a620f0",
+        "catalogName": null,
+        "catalogEntry": null,
+        "provenance": "贡献者维护仓库 plugins/dsh-whale-voice"
+      }
+    },
+    {
       "id": "C047",
       "line": "main",
       "name": "picturereader",

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/LICENSE
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dsh-whale-pack contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/README.md
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/README.md
@@ -1,0 +1,13 @@
+# dsh-whale-meter
+
+> EAC 收录版。来源：[ntpzz/dsh-whale-chan-pack](https://github.com/ntpzz/dsh-whale-chan-pack/tree/main/plugins/dsh-whale-meter)，MIT。
+
+DSH Web 客户端费用/用量设置页。
+
+- 从 DSH `tokenUsage` projection 读取各会话服务端统计。
+- 将累计快照持久化到 `~/.dsh/whale-meter/usage.json`，重启不清零。
+- 每日从 DeepSeek 官方价格页刷新一次，失败保留上次价格。
+- 可自定义价格、美元换算系数、显示货币和文案。
+- Node 入口同时导出命名 `apply` 与 `default { apply }`，兼容不同 loader unwrap 行为。
+
+安装前先在备用 profile/端口验证。插件不应在验证完成前加入正在使用的 live profile。

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/cordis.patch.yml
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/cordis.patch.yml
@@ -1,0 +1,4 @@
+# dsh-whale-meter bundle patch
+- insert:
+    - id: whale-meter
+      name: dsh-whale-meter

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/lib/client.js
@@ -1,0 +1,230 @@
+window.__ModuleLoader__.load({
+  id: "dsh-whale-meter",
+  factory: (require) => {
+    const module = { exports: {} };
+    const exports = module.exports;
+    Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+    const React = require("react");
+    const name = "whale-meter";
+    const inject = ["slots"];
+    const URL = "/plugins/dsh-whale-meter/state.json";
+
+    const access = (ctx, key) => {
+      try { const value = typeof ctx.get === "function" ? ctx.get(key) : null; if (value) return value; } catch {}
+      try { return ctx[key] || null; } catch { return null; }
+    };
+    const usageOf = (value) => {
+      if (!value || typeof value !== "object") return null;
+      const keys = ["uncachedInputTokens", "outputTokens", "cacheReadTokens", "cacheWriteTokens"];
+      const out = {};
+      for (const key of keys) out[key] = Math.max(0, Number(value[key]) || 0);
+      return out;
+    };
+    const collectSessions = (ctx) => {
+      const sessions = access(ctx, "sessions");
+      if (!sessions?.list?.getSnapshot) return [];
+      const snapshot = sessions.list.getSnapshot();
+      const rows = [];
+      for (const id of snapshot?.ids || []) {
+        const summary = snapshot.byId?.[id];
+        let usage = usageOf(summary?.projectionValues?.tokenUsage);
+        try {
+          const binding = sessions.binding?.(id);
+          usage ||= usageOf(binding?.session?.projections?.get?.("tokenUsage"));
+        } catch {}
+        if (usage) rows.push({ id: String(id), title: summary?.displayTitle || summary?.title || String(id), usage });
+      }
+      return rows;
+    };
+    const postSnapshots = async (ctx) => {
+      const rows = collectSessions(ctx);
+      if (!rows.length) return null;
+      const response = await fetch(URL, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ sessions: rows }) });
+      return response.ok ? response.json() : null;
+    };
+    const money = (value) => Number(value || 0).toFixed(4);
+    const tokens = (usage) => Object.values(usage || {}).reduce((sum, value) => sum + (Number(value) || 0), 0);
+    const compactTokens = (value) => {
+      const amount = Math.max(0, Number(value) || 0);
+      if (amount >= 1e9) return (amount / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
+      if (amount >= 1e6) return (amount / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+      if (amount >= 1e3) return (amount / 1e3).toFixed(1).replace(/\.0$/, "") + "K";
+      return String(Math.round(amount));
+    };
+    const usageCost = (usage, config) => ((Number(usage?.uncachedInputTokens || 0) * Number(config.cacheMiss || 0) + Number(usage?.cacheReadTokens || 0) * Number(config.cacheHit || 0) + Number(usage?.cacheWriteTokens || 0) * Number(config.cacheMiss || 0) + Number(usage?.outputTokens || 0) * Number(config.output || 0)) / 1e6) * Number(config.usdToCurrency || 0);
+    const formatUsage = (template, usage, config) => {
+      const total = tokens(usage), cost = usageCost(usage, config);
+      return String(template || "").replaceAll("{tokens}", Math.round(total).toLocaleString()).replaceAll("{cost}", money(cost)).replaceAll("{currency}", config.currency || "¥").replaceAll("{input}", Math.round(Number(usage?.uncachedInputTokens || 0) + Number(usage?.cacheReadTokens || 0) + Number(usage?.cacheWriteTokens || 0)).toLocaleString()).replaceAll("{output}", Math.round(Number(usage?.outputTokens || 0)).toLocaleString());
+    };
+
+    // The stock workspace row does not expose a session-row slot.  Keep this
+    // tiny, DOM-only decoration isolated: token data still comes from the
+    // official sessions store above, and a MutationObserver reapplies it when
+    // React rerenders the sidebar.
+    function SidebarTokenLabels() {
+      const ctx = SidebarTokenLabels.ctx;
+      const [, refresh] = React.useState(0);
+      React.useEffect(() => {
+        const sessions = access(ctx, "sessions");
+        const sync = () => refresh((value) => value + 1);
+        let unsubscribe = null;
+        try { unsubscribe = sessions?.list?.subscribe?.(sync) || null; } catch {}
+        const observer = new MutationObserver(sync);
+        try { observer.observe(document.body, { childList: true, subtree: true }); } catch {}
+        const timer = setInterval(sync, 3000);
+        return () => { try { unsubscribe?.(); } catch {} observer.disconnect(); clearInterval(timer); };
+      }, [ctx]);
+      React.useEffect(() => {
+        const byTitle = new Map();
+        for (const row of collectSessions(ctx)) byTitle.set(String(row.title || "").trim(), tokens(row.usage));
+        for (const item of document.querySelectorAll("[role='treeitem']")) {
+          const title = item.querySelector("span[class*='_title']");
+          if (!title) continue;
+          const value = byTitle.get(String(title.textContent || "").trim());
+          let badge = item.querySelector("[data-whale-session-token]");
+          if (value === undefined) { badge?.remove(); continue; }
+          if (!badge) {
+            badge = document.createElement("span");
+            badge.dataset.whaleSessionToken = "";
+            badge.style.cssText = "flex:none;max-width:64px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:20px;margin-right:6px;pointer-events:none;";
+            title.insertAdjacentElement("afterend", badge);
+          }
+          badge.textContent = compactTokens(value);
+          badge.title = `${Math.round(value).toLocaleString()} token`;
+        }
+      });
+      return null;
+    }
+
+    // The composer has no public session-usage slot. Decorate it from the
+    // official session store and persisted meter config, then reapply after
+    // React updates. This never changes message contents or the send action.
+    function ComposerUsageLabel() {
+      const ctx = ComposerUsageLabel.ctx;
+      React.useEffect(() => {
+        let stopped = false;
+        const sync = async () => {
+          try {
+            const saved = await postSnapshots(ctx);
+            const state = saved || await fetch(URL, { cache: "no-store" }).then((r) => r.json());
+            if (stopped || !state?.config) return;
+            const selected = [...document.querySelectorAll("[role='treeitem']")].find((item) => item.getAttribute("aria-selected") === "true" || /(?:^|[ _-])(selected|active)(?:$|[ _-])/i.test(String(item.className || "")));
+            const selectedTitle = selected?.querySelector("span[class*='_title']")?.textContent?.trim();
+            const pageTitle = document.querySelector("main h1, [role='main'] h1")?.textContent?.trim();
+            const row = collectSessions(ctx).find((entry) => String(entry.title || "").trim() === selectedTitle) || collectSessions(ctx).find((entry) => String(entry.title || "").trim() === pageTitle);
+            const old = document.querySelector("[data-whale-composer-usage]");
+            if (!row || state.config.composerPosition === "hidden") { old?.remove(); return; }
+            const editor = document.querySelector("[contenteditable='true'][role='textbox'], [contenteditable='true'][data-lexical-editor], textarea[role='textbox'], textarea");
+            const host = editor?.closest("form, [class*='composer'], [class*='Composer'], [role='toolbar']") || editor?.parentElement;
+            if (!host) return;
+            if (getComputedStyle(host).position === "static") host.style.position = "relative";
+            const badge = old || document.createElement("span");
+            badge.dataset.whaleComposerUsage = "";
+            badge.textContent = formatUsage(state.config.composerText, row.usage, state.config);
+            const position = state.config.composerPosition || "above-right";
+            const css = ["position:absolute", "z-index:3", "pointer-events:none", "font-size:12px", "line-height:20px", "padding:1px 7px", "border-radius:8px", "background:rgba(13,23,37,.92)", "color:#dcecff", "border:1px solid rgba(115,186,255,.45)", "white-space:nowrap"];
+            css.push(position.includes("left") ? "left:8px" : "right:8px");
+            css.push(position.startsWith("above") ? "bottom:calc(100% + 6px)" : "bottom:8px");
+            badge.style.cssText = css.join(";");
+            if (!old) host.appendChild(badge);
+          } catch {}
+        };
+        const observer = new MutationObserver(sync);
+        try { observer.observe(document.body, { childList: true, subtree: true }); } catch {}
+        const timer = setInterval(sync, 3500); sync();
+        return () => { stopped = true; observer.disconnect(); clearInterval(timer); document.querySelector("[data-whale-composer-usage]")?.remove(); };
+      }, [ctx]);
+      return null;
+    }
+
+    function MeterPanel() {
+      const ctx = MeterPanel.ctx;
+      const [state, setState] = React.useState(null);
+      const [draft, setDraft] = React.useState(null);
+      const [message, setMessage] = React.useState("正在读取本地记录…");
+      const load = React.useCallback(async () => {
+        try {
+          await postSnapshots(ctx);
+          const response = await fetch(URL, { cache: "no-store" });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const next = await response.json();
+          setState(next); setDraft({ ...next.config }); setMessage("");
+        } catch (error) { setMessage("费用服务暂不可用：" + String(error?.message || error)); }
+      }, [ctx]);
+      React.useEffect(() => {
+        load();
+        const sessions = access(ctx, "sessions");
+        const sync = () => postSnapshots(ctx).then((next) => next && setState(next)).catch(() => {});
+        let unsubscribe = null;
+        try { unsubscribe = sessions?.list?.subscribe?.(sync) || null; } catch {}
+        const timer = setInterval(sync, 5000);
+        return () => { try { unsubscribe?.(); } catch {} clearInterval(timer); };
+      }, [ctx, load]);
+      const save = async (refreshPrice = false) => {
+        try {
+          setMessage(refreshPrice ? "正在读取 DeepSeek 官方价格…" : "正在保存…");
+          const response = await fetch(URL, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ config: draft, refreshPrice }) });
+          const next = await response.json();
+          if (!response.ok) throw new Error(next.error || `HTTP ${response.status}`);
+          setState(next); setDraft({ ...next.config }); setMessage("已保存到本地文件");
+        } catch (error) { setMessage("保存失败：" + String(error?.message || error)); }
+      };
+      if (!state || !draft) return React.createElement("div", { className: "wm-page" }, message);
+      const total = state.totalTokens || 0;
+      const preview = formatUsage(draft.text, state.totals, draft);
+      const field = (label, key, type = "text", step) => React.createElement("label", { className: "wm-field", key },
+        React.createElement("span", null, label),
+        React.createElement("input", { type, step, value: draft[key], onChange: (event) => setDraft({ ...draft, [key]: type === "number" ? Number(event.target.value) : event.target.value }) })
+      );
+      const rows = Object.values(state.sessions || {}).sort((a, b) => b.updatedAt - a.updatedAt);
+      return React.createElement("div", { className: "wm-page" },
+        React.createElement("style", null, `.wm-page{max-width:920px;padding:8px 4px 40px;color:#edf3ff}.wm-page h2,.wm-page h3,.wm-card b{color:#fff}.wm-cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}.wm-card,.wm-group{border:1px solid #536983;border-radius:14px;padding:16px;background:#151e2a}.wm-card b{display:block;font-size:24px;margin-top:8px}.wm-group{margin-top:14px}.wm-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px}.wm-field{display:flex;flex-direction:column;gap:5px;font-size:13px;color:#f2f6ff}.wm-field input,.wm-field select{padding:8px;border:1px solid #627996;border-radius:8px;background:#101722;color:#f7f9ff;color-scheme:dark}.wm-field select option{background:#101722;color:#f7f9ff}.wm-field input::placeholder{color:#afbed3;opacity:1}.wm-actions{display:flex;gap:8px;margin-top:12px}.wm-actions button{padding:8px 12px;border-radius:8px;border:1px solid #6f89a8;background:#1b2a3b;color:#fff;cursor:pointer}.wm-actions button:hover{background:#27415c}.wm-table{width:100%;border-collapse:collapse;color:#f1f6ff}.wm-table td,.wm-table th{text-align:left;padding:8px;border-bottom:1px solid #3f526a}.wm-muted{color:#c3d0e3;opacity:1;font-size:12px}@media(max-width:700px){.wm-cards,.wm-grid{grid-template-columns:1fr}}`),
+        React.createElement("h2", null, "费用 / 用量"),
+        React.createElement("p", { className: "wm-muted" }, "优先使用 DSH 服务端 tokenUsage；价格为估算值，实际账单以提供商为准。"),
+        React.createElement("div", { className: "wm-cards" },
+          React.createElement("div", { className: "wm-card" }, "累计 Token", React.createElement("b", null, total.toLocaleString())),
+          React.createElement("div", { className: "wm-card" }, "估算费用", React.createElement("b", null, draft.currency + money(state.cost))),
+          React.createElement("div", { className: "wm-card" }, "已记录会话", React.createElement("b", null, rows.length))
+        ),
+        React.createElement("section", { className: "wm-group" }, React.createElement("h3", null, "显示文案"), field("侧边栏/提示模板（支持 {tokens} {currency} {cost} {input} {output}）", "text"), React.createElement("p", null, preview), field("对话框当前会话模板", "composerText"), React.createElement("label", { className: "wm-field" }, React.createElement("span", null, "对话框提示位置"), React.createElement("select", { value: draft.composerPosition, onChange: (event) => setDraft({ ...draft, composerPosition: event.target.value }) }, React.createElement("option", { value: "above-right" }, "输入框上方右侧"), React.createElement("option", { value: "above-left" }, "输入框上方左侧"), React.createElement("option", { value: "inside-right" }, "输入框内右侧"), React.createElement("option", { value: "inside-left" }, "输入框内左侧"), React.createElement("option", { value: "hidden" }, "隐藏"))), React.createElement("p", { className: "wm-muted" }, "模板变量：{tokens} 总 Token；{cost} 估算金额；{currency} 货币；{input}/{output} 输入、输出 Token。")),
+        React.createElement("section", { className: "wm-group" }, React.createElement("h3", null, "计费规则（USD / 1M token）"),
+          React.createElement("div", { className: "wm-grid" }, field("缓存命中输入", "cacheHit", "number", "0.000001"), field("缓存未命中输入", "cacheMiss", "number", "0.000001"), field("输出", "output", "number", "0.000001"), field("美元换算系数", "usdToCurrency", "number", "0.01"), field("显示货币", "currency"), field("模型", "model")),
+          React.createElement("label", { className: "wm-field" }, React.createElement("span", null, "每日自动跟随官方价格"), React.createElement("input", { type: "checkbox", checked: draft.autoUpdatePrice, onChange: (event) => setDraft({ ...draft, autoUpdatePrice: event.target.checked }) })),
+          React.createElement("div", { className: "wm-actions" }, React.createElement("button", { onClick: () => save(false) }, "保存"), React.createElement("button", { onClick: () => save(true) }, "立即更新官方价格")),
+          React.createElement("p", { className: "wm-muted" }, message || `价格来源：${state.pricing?.source || "内置"} · ${state.pricing?.error ? "上次更新失败：" + state.pricing.error : "正常"}`),
+          React.createElement("p", { className: "wm-muted" }, "本地文件：" + state.dataPath)
+        ),
+        React.createElement("section", { className: "wm-group" }, React.createElement("h3", null, "按会话"),
+          React.createElement("table", { className: "wm-table" }, React.createElement("thead", null, React.createElement("tr", null, React.createElement("th", null, "会话"), React.createElement("th", null, "Token"), React.createElement("th", null, "估算费用"))),
+            React.createElement("tbody", null, rows.map((row) => React.createElement("tr", { key: row.id }, React.createElement("td", null, row.title), React.createElement("td", null, tokens(row.usage).toLocaleString()), React.createElement("td", null, draft.currency + money((row.usage.uncachedInputTokens * draft.cacheMiss + row.usage.cacheReadTokens * draft.cacheHit + row.usage.cacheWriteTokens * draft.cacheMiss + row.usage.outputTokens * draft.output) / 1e6 * draft.usdToCurrency))))))
+        )
+      );
+    }
+
+    function apply(ctx) {
+      MeterPanel.ctx = ctx;
+      SidebarTokenLabels.ctx = ctx;
+      ComposerUsageLabel.ctx = ctx;
+      try {
+        ctx.slots.inject("settings.section", () => ctx.slots.register({ name: "settings.section", id: "whale-meter", order: 60, label: "费用 / 用量" }, MeterPanel));
+      } catch (error) {
+        console.warn("[whale-meter] settings section unavailable", error);
+      }
+      try {
+        ctx.slots.inject("sidebar.footer.action", () => ctx.slots.register({ name: "sidebar.footer.action", id: "whale-session-tokens", order: 60 }, SidebarTokenLabels));
+      } catch (error) {
+        console.warn("[whale-meter] sidebar token labels unavailable", error);
+      }
+      try {
+        ctx.slots.inject("sidebar.footer.action", () => ctx.slots.register({ name: "sidebar.footer.action", id: "whale-composer-usage", order: 61 }, ComposerUsageLabel));
+      } catch (error) {
+        console.warn("[whale-meter] composer usage label unavailable", error);
+      }
+    }
+    exports.apply = apply;
+    exports.inject = inject;
+    exports.name = name;
+    exports.default = { apply, inject, name };
+    return module.exports;
+  }
+});

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/lib/index.js
@@ -1,0 +1,245 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const name = "whale-meter";
+const inject = [];
+const ROUTE = "/plugins/dsh-whale-meter/state.json";
+const PRICE_URL = "https://api-docs.deepseek.com/quick_start/pricing/";
+const DATA_PATH = process.env.DSH_WHALE_METER_FILE || join(homedir(), ".dsh", "whale-meter", "usage.json");
+const DAY = 24 * 60 * 60 * 1000;
+
+const DEFAULT_CONFIG = Object.freeze({
+  autoUpdatePrice: true,
+  model: "deepseek-v4-flash",
+  currency: "¥",
+  usdToCurrency: 7.2,
+  cacheHit: 0.014,
+  cacheMiss: 0.44,
+  output: 1.32,
+  text: "🐋 大肥鱼偷吃了你 {tokens} token · ≈{currency}{cost}",
+  composerText: "本会话 {tokens} token · ≈{currency}{cost}",
+  composerPosition: "above-right",
+  sidebarText: "{tokens}"
+});
+
+function blankState() {
+  return { version: 1, config: { ...DEFAULT_CONFIG }, pricing: { source: "built-in", checkedAt: 0, error: "" }, sessions: {} };
+}
+
+function finite(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : fallback;
+}
+
+function normalizeUsage(value) {
+  const input = finite(value?.uncachedInputTokens ?? value?.inputTokens);
+  const output = finite(value?.outputTokens);
+  const cacheRead = finite(value?.cacheReadTokens);
+  const cacheWrite = finite(value?.cacheWriteTokens);
+  return { uncachedInputTokens: input, outputTokens: output, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite };
+}
+
+function normalizeConfig(value) {
+  const source = value && typeof value === "object" ? value : {};
+  return {
+    autoUpdatePrice: source.autoUpdatePrice !== false,
+    model: typeof source.model === "string" && source.model ? source.model.slice(0, 100) : DEFAULT_CONFIG.model,
+    currency: typeof source.currency === "string" && source.currency ? source.currency.slice(0, 8) : DEFAULT_CONFIG.currency,
+    usdToCurrency: finite(source.usdToCurrency, DEFAULT_CONFIG.usdToCurrency),
+    cacheHit: finite(source.cacheHit, DEFAULT_CONFIG.cacheHit),
+    cacheMiss: finite(source.cacheMiss, DEFAULT_CONFIG.cacheMiss),
+    output: finite(source.output, DEFAULT_CONFIG.output),
+    text: typeof source.text === "string" && source.text ? source.text.slice(0, 240) : DEFAULT_CONFIG.text,
+    composerText: typeof source.composerText === "string" && source.composerText ? source.composerText.slice(0, 240) : DEFAULT_CONFIG.composerText,
+    composerPosition: ["above-left", "above-right", "inside-left", "inside-right", "hidden"].includes(source.composerPosition) ? source.composerPosition : DEFAULT_CONFIG.composerPosition,
+    sidebarText: typeof source.sidebarText === "string" && source.sidebarText ? source.sidebarText.slice(0, 120) : DEFAULT_CONFIG.sidebarText
+  };
+}
+
+function normalizeState(raw) {
+  const state = blankState();
+  if (!raw || typeof raw !== "object") return state;
+  state.config = normalizeConfig(raw.config);
+  state.pricing = raw.pricing && typeof raw.pricing === "object" ? { ...state.pricing, ...raw.pricing } : state.pricing;
+  if (raw.sessions && typeof raw.sessions === "object") {
+    for (const [id, row] of Object.entries(raw.sessions)) {
+      if (!id || !row || typeof row !== "object") continue;
+      state.sessions[id.slice(0, 200)] = {
+        id: id.slice(0, 200),
+        title: typeof row.title === "string" ? row.title.slice(0, 200) : id.slice(0, 200),
+        updatedAt: finite(row.updatedAt),
+        usage: normalizeUsage(row.usage)
+      };
+    }
+  }
+  return state;
+}
+
+function calculateCost(usage, config) {
+  const u = normalizeUsage(usage);
+  const c = normalizeConfig(config);
+  const usd = (u.uncachedInputTokens * c.cacheMiss + u.cacheReadTokens * c.cacheHit + u.cacheWriteTokens * c.cacheMiss + u.outputTokens * c.output) / 1_000_000;
+  return usd * c.usdToCurrency;
+}
+
+function totalsOf(sessions) {
+  const total = normalizeUsage({});
+  for (const row of Object.values(sessions || {})) {
+    const usage = normalizeUsage(row?.usage);
+    for (const key of Object.keys(total)) total[key] += usage[key];
+  }
+  return total;
+}
+
+function extractOfficialPrices(html, model = "deepseek-v4-flash") {
+  const source = String(html || "");
+  const modelNames = [...source.matchAll(/<td[^>]*>\s*(deepseek-[^<\s]+)\s*<\/td>/gi)].map((match) => match[1].toLowerCase());
+  const requested = /deepseek-(chat|reasoner)/i.test(model) ? "deepseek-v4-flash" : String(model).toLowerCase();
+  const modelIndex = modelNames.indexOf(requested);
+  const pricingStart = source.search(/PRICING/i);
+  const pricingEnd = source.search(/Concurrency Limit/i);
+  if (modelIndex >= 0 && pricingStart >= 0) {
+    const rowStart = source.lastIndexOf("<tr", pricingStart);
+    const table = source.slice(rowStart >= 0 ? rowStart : pricingStart, pricingEnd > pricingStart ? pricingEnd : undefined);
+    const prices = {};
+    let bucket = "";
+    for (const match of table.matchAll(/<tr[^>]*>([\s\S]*?)<\/tr>/gi)) {
+      const row = match[1].replace(/<[^>]+>/g, " ").replace(/&nbsp;|&#xA0;/gi, " ").replace(/\s+/g, " ").trim();
+      if (/CACHE HIT/i.test(row)) bucket = "cacheHit";
+      else if (/CACHE MISS/i.test(row)) bucket = "cacheMiss";
+      else if (/OUTPUT TOKENS/i.test(row)) bucket = "output";
+      const values = [...row.matchAll(/\$\s*(\d+(?:\.\d+)?)/g)].map((item) => Number(item[1]));
+      if (bucket && /\bPEAK\b/i.test(row) && !/OFF-PEAK/i.test(row) && Number.isFinite(values[modelIndex])) prices[bucket] = values[modelIndex];
+    }
+    if ([prices.cacheHit, prices.cacheMiss, prices.output].every(Number.isFinite)) return prices;
+  }
+  const text = source.replace(/<[^>]+>/g, " ").replace(/&nbsp;|&#xA0;/gi, " ").replace(/\s+/g, " ");
+  const start = text.toLowerCase().indexOf(model.toLowerCase());
+  const area = start >= 0 ? text.slice(start, start + 10000) : text;
+  const numbers = [...area.matchAll(/\$\s*(\d+(?:\.\d+)?)/g)].map((match) => Number(match[1]));
+  if (numbers.length < 3) return null;
+  // The current table may contain off-peak and peak rows. Prefer the peak triplet
+  // for a conservative estimate; with a single row, use its first triplet.
+  const candidate = numbers.length >= 6 ? numbers.slice(3, 6) : numbers.slice(0, 3);
+  if (!candidate.every(Number.isFinite)) return null;
+  return { cacheHit: candidate[0], cacheMiss: candidate[1], output: candidate[2] };
+}
+
+async function readState() {
+  try { return normalizeState(JSON.parse(await readFile(DATA_PATH, "utf8"))); }
+  catch { return blankState(); }
+}
+
+async function saveState(state) {
+  await mkdir(dirname(DATA_PATH), { recursive: true });
+  const temp = `${DATA_PATH}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(temp, JSON.stringify(normalizeState(state), null, 2) + "\n", "utf8");
+  await rename(temp, DATA_PATH);
+}
+
+async function refreshPrice(state, force = false) {
+  if (!state.config.autoUpdatePrice && !force) return state;
+  if (!force && Date.now() - finite(state.pricing.checkedAt) < DAY) return state;
+  try {
+    const response = await fetch(PRICE_URL, { headers: { "user-agent": "dsh-whale-meter/0.1" }, signal: AbortSignal.timeout(12000) });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const prices = extractOfficialPrices(await response.text(), state.config.model);
+    if (!prices) throw new Error("price table format not recognized");
+    state.config = { ...state.config, ...prices };
+    state.pricing = { source: PRICE_URL, checkedAt: Date.now(), error: "" };
+  } catch (error) {
+    state.pricing = { ...state.pricing, checkedAt: Date.now(), error: String(error?.message || error) };
+  }
+  await saveState(state);
+  return state;
+}
+
+async function readBody(req, limit = 1024 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > limit) throw new Error("body too large");
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+}
+
+function json(res, status, value) {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
+  res.end(JSON.stringify(value));
+}
+
+function publicState(state) {
+  const totals = totalsOf(state.sessions);
+  return { ...state, totals, totalTokens: Object.values(totals).reduce((sum, value) => sum + value, 0), cost: calculateCost(totals, state.config), dataPath: DATA_PATH };
+}
+
+function createHandler() {
+  return async (req, res) => {
+    try {
+      let state = await readState();
+      if (req.method === "GET" || req.method === "HEAD") {
+        state = await refreshPrice(state, false);
+        return json(res, 200, publicState(state));
+      }
+      if (req.method === "PUT") {
+        const body = await readBody(req);
+        state.config = normalizeConfig({ ...state.config, ...(body.config || {}) });
+        if (body.refreshPrice === true) state.pricing.checkedAt = 0;
+        await saveState(state);
+        state = await refreshPrice(state, body.refreshPrice === true);
+        return json(res, 200, publicState(state));
+      }
+      if (req.method === "POST") {
+        const body = await readBody(req);
+        for (const row of Array.isArray(body.sessions) ? body.sessions : []) {
+          if (!row || typeof row.id !== "string" || !row.id) continue;
+          const id = row.id.slice(0, 200);
+          const next = normalizeUsage(row.usage);
+          const previous = state.sessions[id]?.usage;
+          // Session projections are cumulative. Never regress persisted counters.
+          if (previous) for (const key of Object.keys(next)) next[key] = Math.max(next[key], finite(previous[key]));
+          state.sessions[id] = { id, title: typeof row.title === "string" ? row.title.slice(0, 200) : id, updatedAt: Date.now(), usage: next };
+        }
+        await saveState(state);
+        return json(res, 200, publicState(state));
+      }
+      return json(res, 405, { ok: false, error: "method not allowed" });
+    } catch (error) {
+      return json(res, 500, { ok: false, error: String(error?.message || error) });
+    }
+  };
+}
+
+function apply(ctx) {
+  ctx.effect(() => {
+    const handler = createHandler();
+    let disposed = false;
+    let routeDisposer = null;
+    let attempts = 0;
+    const tryRegister = () => {
+      if (disposed) return true;
+      let webServer = null;
+      try { webServer = typeof ctx.get === "function" ? ctx.get("webServer") : null; } catch {}
+      try { webServer ||= ctx.webServer || null; } catch {}
+      if (!webServer || typeof webServer.register !== "function") return false;
+      routeDisposer = webServer.register({ kind: "exact", path: ROUTE, handler });
+      return true;
+    };
+    const timer = tryRegister() ? null : setInterval(() => {
+      attempts += 1;
+      if (tryRegister() || attempts >= 20) clearInterval(timer);
+    }, 500);
+    return () => {
+      disposed = true;
+      if (timer) clearInterval(timer);
+      try { routeDisposer?.(); } catch {}
+    };
+  }, "whale-meter: local persistence route");
+}
+
+const plugin = { apply, inject, name };
+export { DEFAULT_CONFIG, apply, calculateCost, extractOfficialPrices, inject, name, normalizeConfig, normalizeUsage, totalsOf };
+export default plugin;

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/package.json
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dsh-whale-meter",
+  "version": "0.1.0",
+  "description": "Persistent per-session token usage and cost estimates for DeepSeek Harness.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "files": ["lib", "cordis.patch.yml", "README.md"],
+  "scripts": { "test": "node tests/smoke-test.mjs" },
+  "dsh": {
+    "bundle": { "patch": "./cordis.patch.yml" },
+    "client": {
+      "platform": "web",
+      "inject": ["@deepseek-ai/dsh-client-ui-settings", "@deepseek-ai/dsh-client-ui-sidebar"],
+      "immediately": true
+    }
+  },
+  "license": "MIT"
+}

--- a/dsh-desktop/assets/plugins/dsh-whale-meter/tests/smoke-test.mjs
+++ b/dsh-desktop/assets/plugins/dsh-whale-meter/tests/smoke-test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import plugin, { apply, calculateCost, extractOfficialPrices, normalizeUsage, totalsOf } from "../lib/index.js";
+
+assert.equal(plugin.apply, apply);
+assert.equal(typeof plugin.apply, "function");
+assert.deepEqual(normalizeUsage({ inputTokens: 3, outputTokens: 4 }), { uncachedInputTokens: 3, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0 });
+assert.deepEqual(totalsOf({ a: { usage: { inputTokens: 3 } }, b: { usage: { outputTokens: 4 } } }), { uncachedInputTokens: 3, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0 });
+assert.equal(calculateCost({ uncachedInputTokens: 1_000_000 }, { cacheMiss: 1, usdToCurrency: 7 }), 7);
+assert.deepEqual(extractOfficialPrices("deepseek-v4-flash $0.01 $0.2 $0.6 $0.02 $0.4 $1.2"), { cacheHit: 0.02, cacheMiss: 0.4, output: 1.2 });
+const matrix = `<table><tr><td>MODEL</td><td>deepseek-v4-flash</td><td>deepseek-v4-pro</td></tr><tr><td rowspan="6">PRICING</td><td>CACHE HIT</td><td>OFF-PEAK</td><td>$0.007</td><td>$0.022</td></tr><tr><td>PEAK</td><td>$0.014</td><td>$0.044</td></tr><tr><td>CACHE MISS</td><td>OFF-PEAK</td><td>$0.22</td><td>$0.66</td></tr><tr><td>PEAK</td><td>$0.44</td><td>$1.32</td></tr><tr><td>OUTPUT TOKENS</td><td>OFF-PEAK</td><td>$0.66</td><td>$1.98</td></tr><tr><td>PEAK</td><td>$1.32</td><td>$3.96</td></tr><tr><td>Concurrency Limit</td></tr></table>`;
+assert.deepEqual(extractOfficialPrices(matrix, "deepseek-v4-flash"), { cacheHit: 0.014, cacheMiss: 0.44, output: 1.32 });
+assert.deepEqual(extractOfficialPrices(matrix, "deepseek-v4-pro"), { cacheHit: 0.044, cacheMiss: 1.32, output: 3.96 });
+
+let effectCleanup;
+const registered = [];
+apply({
+  get(key) { return key === "webServer" ? { register(spec) { registered.push(spec); return () => registered.push("disposed"); } } : null; },
+  effect(callback) { effectCleanup = callback(); }
+});
+assert.equal(registered[0].path, "/plugins/dsh-whale-meter/state.json");
+effectCleanup();
+assert.equal(registered[1], "disposed");
+console.log("dsh-whale-meter smoke tests passed");

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/LICENSE
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dsh-whale-pack contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/README.md
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/README.md
@@ -1,0 +1,12 @@
+# dsh-whale-voice
+
+> EAC 收录版。来源：[ntpzz/dsh-whale-chan-pack](https://github.com/ntpzz/dsh-whale-chan-pack/tree/main/plugins/dsh-whale-voice)，MIT。
+
+DSH 左侧「语音」设置页与本地 Whisper 语音输入插件。
+
+- 设置 Whisper 模型、识别语言、运行设备、麦克风、模型缓存目录和按钮图标。
+- 可上传 PNG、JPG、WebP 或 GIF 作为麦克风按钮图标；文件会内嵌保存在配置中，并固定以 32 × 32 像素显示。
+- 配置持久化至 `~/.dsh/whale-voice/config.json`，重启后保留。
+- 识别使用本机 DSH host 的 Whisper 管线；麦克风音频只会发送给本机回环地址。
+- 初始安装不下载 Whisper 运行库；默认选用 `tiny`。只有点击「保存并下载运行库和模型」后，插件才会下载运行库和所选模型到本机。
+- Node 与客户端入口同时提供命名 `apply` 和 `default { apply }`。

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/cordis.patch.yml
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/cordis.patch.yml
@@ -1,0 +1,4 @@
+# dsh-whale-voice bundle patch
+- insert:
+    - id: whale-voice
+      name: dsh-whale-voice

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/lib/client.js
@@ -1,0 +1,178 @@
+window.__ModuleLoader__.load({
+  id: "dsh-whale-voice",
+  factory: (require) => {
+    const module = { exports: {} };
+    const exports = module.exports;
+    Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+    const React = require("react");
+    const name = "whale-voice";
+    const inject = ["slots"];
+    const URL = "/plugins/dsh-whale-voice/config.json";
+    const PREPARE_URL = "/plugins/dsh-whale-voice/prepare.json";
+    const TRANSCRIBE_URL = "/plugins/dsh-whale-voice/transcribe.json";
+
+    const LABELS = {
+      models: {
+        "onnx-community/whisper-tiny": "tiny · 最快，约 40MB",
+        "onnx-community/whisper-base": "base · 更准确，约 150MB",
+        "onnx-community/whisper-small": "small · 最准确但较慢，约 460MB"
+      },
+      languages: { auto: "自动判断", zh: "中文（推荐，避免翻译成英文）", en: "English", ja: "日本語", ko: "한국어" },
+      devices: { cpu: "CPU（稳定默认）", wasm: "WASM", gpu: "GPU（不可用时自动回落 CPU）" }
+    };
+
+    function VoicePanel() {
+      const [payload, setPayload] = React.useState(null);
+      const [draft, setDraft] = React.useState(null);
+      const [status, setStatus] = React.useState("正在读取本地设置…");
+      const [microphones, setMicrophones] = React.useState([]);
+      const refreshMicrophones = React.useCallback(async () => {
+        try {
+          if (!navigator.mediaDevices?.enumerateDevices) throw new Error("当前浏览器不支持设备枚举");
+          const devices = await navigator.mediaDevices.enumerateDevices();
+          setMicrophones(devices.filter((device) => device.kind === "audioinput").map((device, index) => ({ id: device.deviceId, label: device.label || `麦克风 ${index + 1}（首次授权后可显示名称）` })));
+        } catch (error) { setStatus("读取麦克风失败：" + String(error?.message || error)); }
+      }, []);
+      React.useEffect(() => {
+        fetch(URL, { cache: "no-store" }).then((response) => {
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return response.json();
+        }).then((next) => { setPayload(next); setDraft({ ...next.config }); setStatus(""); }).catch((error) => setStatus("语音设置服务不可用：" + String(error?.message || error)));
+      }, []);
+      React.useEffect(() => { refreshMicrophones(); }, [refreshMicrophones]);
+      const save = async (prepareModel) => {
+        try {
+          setStatus(prepareModel ? "保存中，正在准备本地模型…" : "正在保存…");
+          const response = await fetch(URL, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ config: draft }) });
+          const next = await response.json();
+          if (!response.ok) throw new Error(next.error || `HTTP ${response.status}`);
+          setDraft({ ...next.config });
+          if (prepareModel) {
+            const prepared = await fetch(PREPARE_URL, { method: "POST" });
+            const body = await prepared.json();
+            if (!prepared.ok) throw new Error(body.error || "模型准备失败");
+          }
+          setStatus(prepareModel ? "模型已准备好，设置已生效" : "设置已保存并生效");
+        } catch (error) { setStatus("保存失败：" + String(error?.message || error)); }
+      };
+      if (!payload || !draft) return React.createElement("div", { className: "wv-page" }, status);
+      const select = (label, key, options, labels) => React.createElement("label", { className: "wv-field", key }, React.createElement("span", null, label), React.createElement("select", { value: draft[key], onChange: (event) => setDraft({ ...draft, [key]: event.target.value }) }, options.map((value) => React.createElement("option", { value, key: value }, labels[value] || value))));
+      const pickDirectory = async () => {
+        if (!window.whaleVoice?.pickDir) return setStatus("请直接输入已有的本地目录路径");
+        const value = await window.whaleVoice.pickDir();
+        if (value) setDraft({ ...draft, cacheDir: value });
+      };
+      const chooseIcon = (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        if (!/^image\/(png|jpeg|webp|gif)$/i.test(file.type) || file.size > 256 * 1024) {
+          event.target.value = "";
+          setStatus("图标仅支持 PNG、JPG、WebP 或 GIF，文件不能超过 256 KB");
+          return;
+        }
+        const reader = new FileReader();
+        reader.onerror = () => setStatus("读取图标失败，请换一张图片");
+        reader.onload = () => {
+          setDraft({ ...draft, micIcon: String(reader.result || "") });
+          setStatus("图标已选好，点击“保存”后生效");
+        };
+        reader.readAsDataURL(file);
+      };
+      return React.createElement("div", { className: "wv-page" },
+        React.createElement("style", null, `.wv-page{max-width:760px;padding:8px 4px 40px;color:#edf3ff}.wv-page h2,.wv-page h3{color:#fff}.wv-group{border:1px solid #536983;border-radius:14px;padding:18px;background:#151e2a}.wv-field{display:flex;flex-direction:column;gap:6px;margin:13px 0;font-size:13px;color:#f2f6ff}.wv-field select,.wv-field input{padding:9px;border:1px solid #627996;border-radius:8px;background:#101722;color:#f7f9ff;color-scheme:dark}.wv-field select option{background:#101722;color:#f7f9ff}.wv-field input::placeholder{color:#afbed3;opacity:1}.wv-field select:focus,.wv-field input:focus{outline:2px solid #73baff;outline-offset:1px}.wv-row{display:flex;gap:8px;align-items:center}.wv-row input{flex:1}.wv-actions{display:flex;gap:8px;margin-top:16px}.wv-actions button,.wv-row button{padding:8px 12px;border-radius:8px;border:1px solid #6f89a8;background:#1b2a3b;color:#fff;cursor:pointer}.wv-actions button:hover,.wv-row button:hover{background:#27415c}.wv-muted{color:#c3d0e3;opacity:1;font-size:12px}.wv-icon-preview{width:32px;height:32px;object-fit:cover;border-radius:50%;border:1px solid #627996;background:#101722}`),
+        React.createElement("h2", null, "语音输入"),
+        React.createElement("p", { className: "wv-muted" }, "识别在本机 DSH host 中运行；音频和文字不会为了识别发送到云端。"),
+        React.createElement("section", { className: "wv-group" },
+            select("Whisper 模型", "model", payload.models, LABELS.models),
+            select("识别语言", "language", payload.languages, LABELS.languages),
+            React.createElement("label", { className: "wv-check" }, React.createElement("input", { type: "checkbox", checked: draft.simplifyChinese !== false, disabled: draft.language !== "zh", onChange: (event) => setDraft({ ...draft, simplifyChinese: event.target.checked }) }), React.createElement("span", null, "识别结果自动转为简体中文（仅中文可用）")),
+            select("运行设备", "device", payload.devices, LABELS.devices),
+          React.createElement("label", { className: "wv-field" }, React.createElement("span", null, "输入麦克风"), React.createElement("div", { className: "wv-row" }, React.createElement("select", { value: draft.microphoneId || "", onChange: (event) => setDraft({ ...draft, microphoneId: event.target.value }) }, React.createElement("option", { value: "" }, "系统默认麦克风"), microphones.map((device) => React.createElement("option", { value: device.id, key: device.id }, device.label))), React.createElement("button", { type: "button", onClick: refreshMicrophones }, "刷新"))),
+          React.createElement("label", { className: "wv-field" }, React.createElement("span", null, "麦克风图标（固定显示为 32 × 32 像素）"), React.createElement("div", { className: "wv-row" }, draft.micIcon ? React.createElement("img", { className: "wv-icon-preview", src: draft.micIcon, alt: "当前图标" }) : React.createElement("span", { className: "wv-icon-preview", "aria-hidden": "true" }), React.createElement("input", { type: "file", accept: "image/png,image/jpeg,image/webp,image/gif", onChange: chooseIcon }), React.createElement("button", { type: "button", onClick: () => setDraft({ ...draft, micIcon: "" }) }, "恢复默认")), React.createElement("span", { className: "wv-muted" }, "支持 PNG、JPG、WebP、GIF；最大 256 KB。图片作为本地设置保存，不会上传。")),
+          React.createElement("label", { className: "wv-field" }, React.createElement("span", null, "模型存放目录（留空使用默认缓存）"), React.createElement("div", { className: "wv-row" }, React.createElement("input", { value: draft.cacheDir, placeholder: "默认缓存目录", onChange: (event) => setDraft({ ...draft, cacheDir: event.target.value }) }), React.createElement("button", { type: "button", onClick: pickDirectory }, "浏览…"))),
+          React.createElement("div", { className: "wv-actions" }, React.createElement("button", { onClick: () => save(false) }, "保存"), React.createElement("button", { onClick: () => save(true) }, "保存并下载运行库和模型")),
+          React.createElement("p", { className: "wv-muted" }, status || "配置保存在本机 DSH 数据目录。")
+        )
+      );
+    }
+
+    function installMic() {
+      let stopped = false;
+      const state = { listening: false, ctx: null, source: null, processor: null, stream: null, chunks: [] };
+      const editable = () => document.querySelector('[contenteditable="true"][role="textbox"], [contenteditable="true"], textarea[role="textbox"], textarea');
+      const appendText = (text) => {
+        const el = editable(); if (!el || !text) return;
+        el.focus();
+        if (el.isContentEditable) document.execCommand("insertText", false, " " + text);
+        else { el.value = el.value ? el.value.replace(/\s+$/, "") + " " + text : text; el.dispatchEvent(new Event("input", { bubbles: true })); }
+      };
+      const stopStream = () => { try { state.processor?.disconnect(); state.source?.disconnect(); state.stream?.getTracks().forEach((track) => track.stop()); state.ctx?.close(); } catch {} };
+      const resample = async (flat, rate) => {
+        const length = Math.ceil(flat.length / rate * 16000);
+        const context = new OfflineAudioContext(1, length, 16000);
+        const buffer = context.createBuffer(1, flat.length, rate);
+        buffer.copyToChannel(Float32Array.from(flat), 0);
+        const source = context.createBufferSource(); source.buffer = buffer; source.connect(context.destination); source.start();
+        return (await context.startRendering()).getChannelData(0);
+      };
+      const setButtonAppearance = (button, mode, icon) => {
+        button.replaceChildren();
+        if (mode === "idle" && icon) {
+          const image = document.createElement("img"); image.src = icon; image.alt = "";
+          image.style.cssText = "display:block;width:32px;height:32px;object-fit:cover;border-radius:50%;";
+          button.appendChild(image);
+        } else button.textContent = mode === "recording" ? "⏹" : mode === "working" ? "⏳" : "🎤";
+      };
+      const attach = () => {
+        if (stopped || document.querySelector("[data-whale-voice-mic]")) return;
+        const input = editable(); if (!input) return;
+        const host = input.closest("form, [class*=composer], [class*=Composer], [role=toolbar]") || input.parentElement;
+        if (!host) return;
+        const button = document.createElement("button");
+        let micIcon = "";
+        button.type = "button"; setButtonAppearance(button, "idle", micIcon); button.title = "本地 Whisper 语音输入"; button.setAttribute("data-whale-voice-mic", "1");
+        button.style.cssText = "margin:0 4px;width:36px;height:36px;padding:1px;border-radius:50%;border:1px solid rgba(128,128,128,.45);background:transparent;cursor:pointer;font-size:15px;line-height:1;overflow:hidden;";
+        button.onclick = async () => {
+          if (state.listening) {
+            const rate = state.ctx?.sampleRate || 16000; stopStream(); state.listening = false; setButtonAppearance(button, "working"); button.title = "正在识别…";
+            try {
+              const flat = state.chunks.flatMap((chunk) => Array.from(chunk)); state.chunks = [];
+              const pcm = await resample(flat, rate);
+              const response = await fetch(TRANSCRIBE_URL, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ samples: Array.from(pcm) }) });
+              const body = await response.json(); if (!response.ok) throw new Error(body.error || "识别失败"); appendText(body.text);
+              button.title = body.text ? "本地 Whisper 语音输入" : "未识别到内容";
+            } catch (error) { button.title = "识别失败：" + String(error?.message || error); }
+            setButtonAppearance(button, "idle", micIcon); return;
+          }
+          try {
+            const configResponse = await fetch(URL, { cache: "no-store" }); const config = (await configResponse.json()).config || {}; micIcon = config.micIcon || ""; setButtonAppearance(button, "idle", micIcon);
+            const constraints = config.microphoneId ? { audio: { deviceId: { exact: config.microphoneId } } } : { audio: true };
+            const stream = await navigator.mediaDevices.getUserMedia(constraints);
+            const Audio = window.AudioContext || window.webkitAudioContext; const context = new Audio(); const source = context.createMediaStreamSource(stream); const processor = context.createScriptProcessor(4096, 1, 1);
+            processor.onaudioprocess = (event) => state.chunks.push(new Float32Array(event.inputBuffer.getChannelData(0)));
+            source.connect(processor); processor.connect(context.destination); Object.assign(state, { listening: true, ctx: context, source, processor, stream, chunks: [] }); setButtonAppearance(button, "recording"); button.title = "正在录音，点击停止并识别";
+          } catch (error) { button.title = "麦克风不可用：" + String(error?.message || error); }
+        };
+        const buttons = host.querySelectorAll("button, [role=button]"); const send = [...buttons].find((node) => /发送|send/i.test((node.getAttribute("aria-label") || "") + " " + node.textContent));
+        if (send?.parentNode) send.parentNode.insertBefore(button, send); else host.appendChild(button);
+      };
+      const timer = window.setInterval(attach, 1200); attach();
+      return () => { stopped = true; window.clearInterval(timer); stopStream(); };
+    }
+
+    function apply(ctx) {
+      try {
+        ctx.slots.inject("settings.section", () => ctx.slots.register({ name: "settings.section", id: "whale-voice", order: 61, label: "语音" }, VoicePanel));
+      } catch (error) {
+        console.warn("[whale-voice] settings section unavailable", error);
+      }
+      if (typeof ctx.effect === "function") ctx.effect(() => installMic(), "whale-voice: microphone button");
+      else installMic();
+    }
+    exports.apply = apply;
+    exports.inject = inject;
+    exports.name = name;
+    exports.default = { apply, inject, name };
+    return module.exports;
+  }
+});

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/lib/index.js
@@ -1,0 +1,240 @@
+import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const name = "whale-voice";
+const inject = [];
+const ROUTE = "/plugins/dsh-whale-voice/config.json";
+const PREPARE_ROUTE = "/plugins/dsh-whale-voice/prepare.json";
+const TRANSCRIBE_ROUTE = "/plugins/dsh-whale-voice/transcribe.json";
+const CONFIG_PATH = process.env.DSH_WHALE_VOICE_FILE || join(homedir(), ".dsh", "whale-voice", "config.json");
+const LEGACY_PATH = process.env.APPDATA ? join(process.env.APPDATA, "dsh-whale-chan-client", "whale-voice.json") : "";
+const RUNTIME_DIR = process.env.DSH_WHALE_VOICE_RUNTIME_DIR || join(homedir(), ".dsh", "whale-voice", "runtime");
+const RUNTIME_PACKAGES = ["@huggingface/transformers@3.0.0", "opencc-js@1.4.2"];
+const MODELS = ["onnx-community/whisper-tiny", "onnx-community/whisper-base", "onnx-community/whisper-small"];
+const LANGUAGES = ["auto", "zh", "en", "ja", "ko"];
+const DEVICES = ["cpu", "wasm", "gpu"];
+const DEFAULT_CONFIG = Object.freeze({ model: MODELS[0], language: "zh", device: "cpu", cacheDir: "", microphoneId: "", simplifyChinese: true, micIcon: "" });
+const LANGUAGE_NAMES = { auto: undefined, zh: "chinese", en: "english", ja: "japanese", ko: "korean" };
+let pipelinePromise = null;
+let pipelineKey = "";
+let runtimePromise = null;
+let transformersPromise = null;
+let openCCPromise = null;
+
+function normalizeConfig(value) {
+  const source = value && typeof value === "object" ? value : {};
+  const icon = typeof source.micIcon === "string" ? source.micIcon : "";
+  return {
+    model: MODELS.includes(source.model) ? source.model : DEFAULT_CONFIG.model,
+    language: LANGUAGES.includes(source.language) ? source.language : DEFAULT_CONFIG.language,
+    device: DEVICES.includes(source.device) ? source.device : DEFAULT_CONFIG.device,
+    cacheDir: typeof source.cacheDir === "string" ? source.cacheDir.trim().slice(0, 1000) : "",
+    microphoneId: typeof source.microphoneId === "string" ? source.microphoneId.slice(0, 500) : "",
+    simplifyChinese: source.simplifyChinese !== false,
+    // Keep the icon self-contained and prevent arbitrary URL schemes from being
+    // injected into the client. 256 KiB is ample for a 32 px button asset.
+    micIcon: /^data:image\/(?:png|jpeg|webp|gif);base64,[A-Za-z0-9+/=]+$/i.test(icon) && icon.length <= 350000 ? icon : ""
+  };
+}
+
+async function readConfig() {
+  try { return normalizeConfig(JSON.parse(await readFile(CONFIG_PATH, "utf8"))); }
+  catch {
+    if (LEGACY_PATH) {
+      try {
+        const migrated = normalizeConfig(JSON.parse(await readFile(LEGACY_PATH, "utf8")));
+        await saveConfig(migrated);
+        return migrated;
+      } catch {}
+    }
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+async function saveConfig(config) {
+  const value = normalizeConfig(config);
+  await mkdir(dirname(CONFIG_PATH), { recursive: true });
+  const temp = `${CONFIG_PATH}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(temp, JSON.stringify(value, null, 2) + "\n", "utf8");
+  await rename(temp, CONFIG_PATH);
+  return value;
+}
+
+async function readBody(req, limit = 64 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > limit) throw new Error("body too large");
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+}
+
+function json(res, status, value) {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" });
+  res.end(JSON.stringify(value));
+}
+
+function isLoopback(req) {
+  const address = req.socket?.remoteAddress;
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
+
+function cacheDir(config) {
+  return config.cacheDir || join(homedir(), ".dsh", "whale-voice", "models");
+}
+
+async function fileExists(file) {
+  try { await access(file); return true; } catch { return false; }
+}
+
+function npmInstallRuntime() {
+  return new Promise((resolve, reject) => {
+    const command = process.platform === "win32" ? "npm.cmd" : "npm";
+    const child = spawn(command, ["install", "--prefix", RUNTIME_DIR, "--omit=dev", "--no-package-lock", "--no-save", ...RUNTIME_PACKAGES], { stdio: "pipe", windowsHide: true });
+    let output = "";
+    child.stdout?.on("data", (chunk) => { output = (output + chunk).slice(-4000); });
+    child.stderr?.on("data", (chunk) => { output = (output + chunk).slice(-4000); });
+    const timeout = setTimeout(() => child.kill(), 10 * 60 * 1000);
+    child.once("error", (error) => { clearTimeout(timeout); reject(error); });
+    child.once("exit", (code) => { clearTimeout(timeout); code === 0 ? resolve() : reject(new Error(`Whisper 运行库下载失败（npm 退出码 ${code}）：${output.trim()}`)); });
+  });
+}
+
+async function ensureRuntime(download = false) {
+  if (runtimePromise) return runtimePromise;
+  runtimePromise = (async () => {
+    const transformers = join(RUNTIME_DIR, "node_modules", "@huggingface", "transformers", "package.json");
+    const opencc = join(RUNTIME_DIR, "node_modules", "opencc-js", "package.json");
+    if (!await fileExists(transformers) || !await fileExists(opencc)) {
+      if (!download) throw new Error("Whisper 运行库尚未准备，请先在语音设置中点击“保存并准备模型”");
+      await npmInstallRuntime();
+    }
+    if (!await fileExists(transformers) || !await fileExists(opencc)) throw new Error("Whisper 运行库下载未完成");
+  })();
+  try { return await runtimePromise; } catch (error) { runtimePromise = null; throw error; }
+}
+
+async function importRuntimePackage(parts) {
+  const packageDir = join(RUNTIME_DIR, "node_modules", ...parts);
+  const manifest = JSON.parse(await readFile(join(packageDir, "package.json"), "utf8"));
+  const entry = manifest.module || manifest.main || "index.js";
+  return import(pathToFileURL(join(packageDir, entry)).href);
+}
+
+async function getTransformers(download = false) {
+  await ensureRuntime(download);
+  transformersPromise ||= importRuntimePackage(["@huggingface", "transformers"]);
+  return transformersPromise;
+}
+
+async function toSimplifiedChinese(text) {
+  await ensureRuntime(false);
+  openCCPromise ||= importRuntimePackage(["opencc-js"]);
+  const opencc = await openCCPromise;
+  const Converter = opencc.Converter || opencc.default?.Converter;
+  return typeof Converter === "function" ? Converter({ from: "tw", to: "cn" })(text) : text;
+}
+
+async function getPipeline(config, download = false) {
+  const key = `${config.model}\0${config.device}\0${cacheDir(config)}`;
+  if (pipelinePromise && pipelineKey === key) return pipelinePromise;
+  pipelineKey = key;
+  pipelinePromise = (async () => {
+    const transformers = await getTransformers(download);
+    transformers.env.cacheDir = cacheDir(config);
+    try { return await transformers.pipeline("automatic-speech-recognition", config.model, { device: config.device }); }
+    catch { return transformers.pipeline("automatic-speech-recognition", config.model, { device: "cpu" }); }
+  })();
+  try { return await pipelinePromise; }
+  catch (error) { pipelinePromise = null; pipelineKey = ""; throw error; }
+}
+
+async function transcribe(samples) {
+  if (!Array.isArray(samples) || samples.length < 1600 || samples.length > 960000) throw new Error("invalid PCM audio");
+  const config = await readConfig();
+  const pcm = Float32Array.from(samples, (sample) => Number.isFinite(Number(sample)) ? Math.max(-1, Math.min(1, Number(sample))) : 0);
+  const pipe = await getPipeline(config);
+  const output = await pipe(pcm, { language: LANGUAGE_NAMES[config.language], task: "transcribe", return_timestamps: false });
+  const raw = String(output?.text || output?.[0]?.text || "").trim();
+  const text = config.language === "zh" && config.simplifyChinese !== false ? await toSimplifiedChinese(raw) : raw;
+  return { text };
+}
+
+function createHandler() {
+  return async (req, res) => {
+    try {
+      if (!isLoopback(req)) return json(res, 403, { ok: false, error: "loopback only" });
+      if (req.method === "GET" || req.method === "HEAD") return json(res, 200, { config: await readConfig(), models: MODELS, languages: LANGUAGES, devices: DEVICES });
+      if (req.method === "PUT" || req.method === "POST") {
+        const body = await readBody(req);
+        return json(res, 200, { ok: true, config: await saveConfig(body.config ?? body), dataPath: CONFIG_PATH });
+      }
+      return json(res, 405, { ok: false, error: "method not allowed" });
+    } catch (error) {
+      return json(res, 500, { ok: false, error: String(error?.message || error) });
+    }
+  };
+}
+
+function createPrepareHandler() {
+  return async (req, res) => {
+    try {
+      if (!isLoopback(req) || req.method !== "POST") return json(res, 405, { ok: false, error: "POST from loopback required" });
+      await ensureRuntime(true);
+      await getPipeline(await readConfig(), false);
+      return json(res, 200, { ok: true });
+    } catch (error) { return json(res, 500, { ok: false, error: String(error?.message || error) }); }
+  };
+}
+
+function createTranscribeHandler() {
+  return async (req, res) => {
+    try {
+      if (!isLoopback(req) || req.method !== "POST") return json(res, 405, { ok: false, error: "POST from loopback required" });
+      const body = await readBody(req, 12 * 1024 * 1024);
+      return json(res, 200, { ok: true, ...(await transcribe(body.samples)) });
+    } catch (error) { return json(res, 500, { ok: false, error: String(error?.message || error) }); }
+  };
+}
+
+function apply(ctx) {
+  ctx.effect(() => {
+    const handler = createHandler();
+    const prepareHandler = createPrepareHandler();
+    const transcribeHandler = createTranscribeHandler();
+    let disposed = false;
+    let routeDisposer = null;
+    let attempts = 0;
+    const tryRegister = () => {
+      if (disposed) return true;
+      let webServer = null;
+      try { webServer = typeof ctx.get === "function" ? ctx.get("webServer") : null; } catch {}
+      try { webServer ||= ctx.webServer || null; } catch {}
+      if (!webServer || typeof webServer.register !== "function") return false;
+      routeDisposer = [
+        webServer.register({ kind: "exact", path: ROUTE, handler }),
+        webServer.register({ kind: "exact", path: PREPARE_ROUTE, handler: prepareHandler }),
+        webServer.register({ kind: "exact", path: TRANSCRIBE_ROUTE, handler: transcribeHandler })
+      ];
+      return true;
+    };
+    const timer = tryRegister() ? null : setInterval(() => {
+      attempts += 1;
+      if (tryRegister() || attempts >= 20) clearInterval(timer);
+    }, 500);
+    return () => {
+      disposed = true;
+      if (timer) clearInterval(timer);
+      for (const dispose of routeDisposer || []) try { dispose?.(); } catch {}
+    };
+  }, "whale-voice: shared config route");
+}
+
+const plugin = { apply, inject, name };
+export { CONFIG_PATH, DEFAULT_CONFIG, DEVICES, LANGUAGES, MODELS, apply, inject, name, normalizeConfig, transcribe };
+export default plugin;

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/package.json
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dsh-whale-voice",
+  "version": "0.2.0",
+  "description": "Offline local Whisper voice input for DeepSeek Harness.",
+  "type": "module",
+  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./client": "./lib/client.js",
+    "./package.json": "./package.json"
+  },
+  "files": ["lib", "cordis.patch.yml", "README.md"],
+  "scripts": { "test": "node tests/smoke-test.mjs" },
+  "dsh": {
+    "bundle": { "patch": "./cordis.patch.yml" },
+    "client": {
+      "platform": "web",
+      "inject": ["@deepseek-ai/dsh-client-ui-settings"],
+      "immediately": true
+    }
+  },
+  "license": "MIT"
+}

--- a/dsh-desktop/assets/plugins/dsh-whale-voice/tests/smoke-test.mjs
+++ b/dsh-desktop/assets/plugins/dsh-whale-voice/tests/smoke-test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import plugin, { apply, normalizeConfig } from "../lib/index.js";
+
+assert.equal(plugin.apply, apply);
+assert.equal(typeof plugin.apply, "function");
+assert.deepEqual(normalizeConfig({ model: "bad", language: "bad", device: "bad", cacheDir: 2 }), { model: "onnx-community/whisper-tiny", language: "zh", device: "cpu", cacheDir: "", microphoneId: "", simplifyChinese: true, micIcon: "" });
+assert.deepEqual(normalizeConfig({ model: "onnx-community/whisper-base", language: "en", device: "gpu", cacheDir: "  D:/models  ", microphoneId: "mic-a", simplifyChinese: false, micIcon: "data:image/png;base64,aGVsbG8=" }), { model: "onnx-community/whisper-base", language: "en", device: "gpu", cacheDir: "D:/models", microphoneId: "mic-a", simplifyChinese: false, micIcon: "data:image/png;base64,aGVsbG8=" });
+assert.equal(normalizeConfig({ micIcon: "file:///C:/secret.png" }).micIcon, "");
+
+let cleanup;
+const registered = [];
+apply({ get(key) { return key === "webServer" ? { register(spec) { registered.push(spec); return () => registered.push("disposed"); } } : null; }, effect(callback) { cleanup = callback(); } });
+assert.equal(registered[0].path, "/plugins/dsh-whale-voice/config.json");
+assert.equal(registered[1].path, "/plugins/dsh-whale-voice/prepare.json");
+assert.equal(registered[2].path, "/plugins/dsh-whale-voice/transcribe.json");
+cleanup();
+assert.deepEqual(registered.slice(3), ["disposed", "disposed", "disposed"]);
+console.log("dsh-whale-voice smoke tests passed");

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -201,6 +201,12 @@ export const COMPANION_PLUGINS: CompanionPluginDef[] = [
   // DeepSeek 余额小鲸鱼挂件（MeteorNOX/DeepSeek-Balance-Whale-Widget，MIT）。
   // 默认关闭：用户到「设置 → 插件 → 管理」或「增强功能」分区自行启用（需 DEEPSEEK_API_KEY 凭据）。
   { id: 'dsh-whale-widget', name: 'dsh-whale-widget', dir: 'dsh-whale-widget', disabled: true },
+  // 会话 Token 与费用估算：本地累计快照、可自定义定价和对话/侧栏显示。
+  // 默认关闭，避免未经选择就在会话页面增加统计信息。
+  { id: 'whale-meter', name: 'dsh-whale-meter', dir: 'dsh-whale-meter', disabled: true },
+  // 本地 Whisper 语音输入：默认 tiny；仅在用户点击「保存并下载运行库和模型」
+  // 后下载运行库与模型，初始安装包不包含大型 AI 运行时。
+  { id: 'whale-voice', name: 'dsh-whale-voice', dir: 'dsh-whale-voice', disabled: true },
   // 多智能体团队协作（NanmiCoder/dsh-agent-teams，MIT）：队长 + 子代理成员 +
   // 依赖感知任务 DAG + 活动面板。5.3.1 起默认启用（EAC 适配版；对话框
   // composer dock 有可见入口，设置「增强功能」分区保留停用开关）。


### PR DESCRIPTION
## 目的

收录两个由 ntpzz/dsh-whale-chan-pack 维护的可选内置插件：

- dsh-whale-meter：按会话累计 Token，用本地价格规则估算费用；可在侧栏/对话区显示。
- dsh-whale-voice：本地 Whisper 语音输入，支持模型、语言、设备、麦克风与 32×32 自定义图标。

## 架构与范围

- 新增两个 vendored DSH 插件包、MIT 许可证与来源说明。
- 在 COMPANION_PLUGINS 注册为默认关闭的可选插件。
- 更新 SOURCES.json 来源台账。
- 语音插件初始不携带大型运行库；默认 tiny，用户点击“保存并下载运行库和模型”后才按需下载本地运行库和模型。

## 风险与兼容

- 不修改 DSH 内核、Tauri 壳或用户既有配置。
- 两插件默认关闭，用户明确启用后才写入 profile。
- 配置保存于 ~/.dsh/whale-meter 和 ~/.dsh/whale-voice；删除插件不会自动删除用户数据。

## 验证

- [x] dsh-whale-meter smoke test
- [x] dsh-whale-voice smoke test
- [x] 两插件 host/client 脚本语法检查
- [x] SOURCES.json JSON 解析
- [x] 注册表与 vendored package 配对检查
- [x] git diff --check
- [ ] EAC npm run build / 全量测试：本地投稿克隆未安装 TypeScript，命令在 tsc not recognized 处阻断，交由 CI 复验。

## 配置与迁移

无迁移；插件首次启用创建自身配置文件。

## 回退方式

在“设置 → 插件 → 管理”停用对应插件即可；如需完全移除，可删除 profile 中对应的内置插件行，用户配置文件保持不动。