### PR TITLE
fix(aio): 修复动态岛错位与顶部提示遮挡

### DIFF
--- a/assets/plugins/dsh-composer-dynamic-island/EAC-VENDOR.json
+++ b/assets/plugins/dsh-composer-dynamic-island/EAC-VENDOR.json
@@ -4,13 +4,18 @@
   "tag": "v2.1.0",
   "commit": "2ccd12ff807c3bc983defd2177e15be1a416106f",
   "upstreamClientSha256": "22ea2dff2002dfd012d54aec8fd3c91d1d62544d5f54c10de755bdb05fc20f78",
-  "vendoredClientSha256": "8a1cf97bde44a6dc9edc4483cf6ec61280814e45530ac6b6472aee227c14cd1a",
+  "vendoredClientSha256": "07f5a0415ef58db60483d10d39d349739f4bbc4f8974cfbd3c4e4c4286479be3",
   "vendoredClientSha256Encoding": "UTF-8 with LF line endings",
   "localPatches": [
     "cancel queued animation frames and reject layout after disposal",
     "keep the island open while a descendant retains keyboard focus",
     "remove aria-controls ownership of the empty visual backdrop",
     "describe selection separately from viewport-dependent placement",
-    "correct the documented host entry path"
+    "correct the documented host entry path",
+    "convert viewport positions for frosted containing blocks without moving React controls",
+    "refresh popup placement on open and captured scroll, with teardown cleanup",
+    "support identity entrance transforms and measure overflowing button bounds",
+    "keep popup placement within the composer column when side panels are open",
+    "close hover-open popups on Escape after restoring trigger focus"
   ]
 }

--- a/assets/plugins/dsh-composer-dynamic-island/lib/client.js
+++ b/assets/plugins/dsh-composer-dynamic-island/lib/client.js
@@ -345,12 +345,32 @@ window.__ModuleLoader__.load({
     }
 
     function fixedPositionIsReliable(node) {
-      for (let parent = node.parentElement; parent !== null && parent !== document.body; parent = parent.parentElement) {
+      for (let parent = node.parentElement; parent !== null; parent = parent.parentElement) {
         const style = window.getComputedStyle(parent);
-        if (style.transform !== "none" || style.filter !== "none" || style.perspective !== "none") return false;
+        if (style.transform !== "none" && style.transform !== "matrix(1, 0, 0, 1, 0, 0)") return false;
+        if (style.filter !== "none" || style.perspective !== "none") return false;
+        if ((style.scale && style.scale !== "none") || (style.rotate && style.rotate !== "none") || (style.translate && style.translate !== "none")) return false;
         if (/\b(?:paint|strict|content)\b/.test(style.contain)) return false;
       }
       return true;
+    }
+
+    function fixedPositionOrigin(node) {
+      // Frosted skins establish a fixed containing block without a transform.
+      // Keep React-owned controls in place and convert viewport coordinates.
+      for (let parent = node.parentElement; parent !== null; parent = parent.parentElement) {
+        const style = window.getComputedStyle(parent);
+        if (style.transform !== "none"
+          || (style.backdropFilter && style.backdropFilter !== "none")
+          || (style.webkitBackdropFilter && style.webkitBackdropFilter !== "none")
+          || /\b(?:transform|filter|perspective|backdrop-filter)\b/.test(style.willChange)
+          || /\blayout\b/.test(style.contain)
+          || style.contentVisibility === "auto") {
+          const rect = parent.getBoundingClientRect();
+          return { left: rect.left + parent.clientLeft - parent.scrollLeft, top: rect.top + parent.clientTop - parent.scrollTop };
+        }
+      }
+      return { left: 0, top: 0 };
     }
 
     function discoverCandidates(parts) {
@@ -449,10 +469,11 @@ window.__ModuleLoader__.load({
 
     function measureCandidate(candidate) {
       const rect = candidate.node.getBoundingClientRect();
+      const controlRect = buttonControlOf(candidate.node)?.getBoundingClientRect();
       return {
         candidate,
         node: candidate.node,
-        width: Math.max(24, Math.ceil(rect.width || candidate.node.offsetWidth || 28)),
+        width: Math.max(24, Math.ceil(Math.max(rect.width || candidate.node.offsetWidth || 28, controlRect?.width || 0))),
         height: Math.max(24, Math.ceil(rect.height || candidate.node.offsetHeight || 28)),
       };
     }
@@ -487,7 +508,9 @@ window.__ModuleLoader__.load({
       const panelWidth = Math.max(58, Math.min(maxWidth, contentRight + padding));
       const panelHeight = Math.max(48, Math.min(maxHeight, y + rowHeight + padding));
       const anchorCenter = triggerRect.left + triggerRect.width / 2;
-      const left = Math.max(8, Math.min(anchorCenter - panelWidth / 2, window.innerWidth - panelWidth - 8));
+      const leftEdge = Math.max(8, rowRect.left);
+      const rightEdge = Math.min(window.innerWidth - 8, rowRect.right);
+      const left = Math.max(leftEdge, Math.min(anchorCenter - panelWidth / 2, rightEdge - panelWidth));
       const top = opensUp
         ? Math.max(8, triggerRect.top - panelHeight - 8)
         : Math.min(window.innerHeight - panelHeight - 8, triggerRect.bottom + 8);
@@ -535,7 +558,10 @@ window.__ModuleLoader__.load({
         row.dataset.dshIslandOpen = open ? "true" : "false";
         trigger.setAttribute("aria-expanded", open ? "true" : "false");
       };
-      const open = () => setOpen(true);
+      const open = () => {
+        layout();
+        setOpen(true);
+      };
       const schedulePointerClose = () => {
         window.clearTimeout(closeTimer);
         closeTimer = window.setTimeout(() => {
@@ -559,8 +585,8 @@ window.__ModuleLoader__.load({
       const onKeyDown = (event) => {
         if (event.defaultPrevented || event.key !== "Escape" || row.dataset.dshIslandOpen !== "true") return;
         pinned = false;
-        setOpen(false);
         trigger.focus();
+        setOpen(false);
       };
       const onDocumentPointerDown = (event) => {
         if (!pinned || row.contains(event.target)) return;
@@ -591,8 +617,9 @@ window.__ModuleLoader__.load({
           if (placedNodes.has(item.node)) item.node.setAttribute(ITEM_ATTR, item.candidate.id);
           else item.node.removeAttribute(ITEM_ATTR);
         }
-        panel.style.setProperty("--dshi-panel-left", `${packed.left}px`);
-        panel.style.setProperty("--dshi-panel-top", `${packed.top}px`);
+        const panelOrigin = fixedPositionOrigin(panel);
+        panel.style.setProperty("--dshi-panel-left", `${packed.left - panelOrigin.left}px`);
+        panel.style.setProperty("--dshi-panel-top", `${packed.top - panelOrigin.top}px`);
         panel.style.setProperty("--dshi-panel-width", `${packed.panelWidth}px`);
         panel.style.setProperty("--dshi-panel-height", `${packed.panelHeight}px`);
         panel.dataset.dshiDirection = packed.direction;
@@ -600,8 +627,9 @@ window.__ModuleLoader__.load({
           const { item, x, y } = placement;
           const itemLeft = packed.left + x;
           const itemTop = packed.top + y;
-          item.node.style.setProperty("--dshi-item-left", `${itemLeft}px`);
-          item.node.style.setProperty("--dshi-item-top", `${itemTop}px`);
+          const itemOrigin = fixedPositionOrigin(item.node);
+          item.node.style.setProperty("--dshi-item-left", `${itemLeft - itemOrigin.left}px`);
+          item.node.style.setProperty("--dshi-item-top", `${itemTop - itemOrigin.top}px`);
           if (item.node.classList.contains("team-seat")) {
             const menu = item.node.querySelector(".team-pop");
             const menuWidth = menu instanceof HTMLElement ? Math.max(1, menu.offsetWidth) : 330;
@@ -640,8 +668,9 @@ window.__ModuleLoader__.load({
         item.node.addEventListener("click", scheduleItemLayout);
       }
       row.addEventListener("focusout", scheduleFocusClose);
-      row.addEventListener("keydown", onKeyDown);
+      document.addEventListener("keydown", onKeyDown);
       document.addEventListener("pointerdown", onDocumentPointerDown, true);
+      document.addEventListener("scroll", scheduleItemLayout, true);
       window.addEventListener("resize", layout);
       const resizeObserver = new ResizeObserver(layout);
       resizeObserver.observe(card);
@@ -688,8 +717,9 @@ window.__ModuleLoader__.load({
           panel.style.removeProperty("--dshi-panel-width");
           panel.style.removeProperty("--dshi-panel-height");
           row.removeEventListener("focusout", scheduleFocusClose);
-          row.removeEventListener("keydown", onKeyDown);
+          document.removeEventListener("keydown", onKeyDown);
           document.removeEventListener("pointerdown", onDocumentPointerDown, true);
+          document.removeEventListener("scroll", scheduleItemLayout, true);
           delete card.dataset.dshIslandReady;
           row.removeAttribute("data-dsh-island-row");
           row.removeAttribute("data-dsh-island-open");

--- a/docs/aio-plugin-layout-fix.md
+++ b/docs/aio-plugin-layout-fix.md
@@ -1,0 +1,41 @@
+# AIO 插件布局修复
+
+## 动态岛
+
+毛玻璃输入框的 `backdrop-filter` 会建立固定定位包含块。插件原来直接把视口坐标写给仍留在 React 原树中的控件，造成菜单及按钮偏移到右下方。
+
+修复在每个控件自身的包含块中换算坐标，保留 React 节点归属、皮肤和原生模型选择器。完成入场动画留下的单位矩阵也按包含块处理。菜单在打开、滚动和尺寸变化时重新定位，卸载时释放监听器。
+
+测量包括被收缩容器包裹的按钮宽度，横向定位限制在输入框所在列内，避免伸入右侧面板。
+
+## 顶部完成胶囊
+
+受控脚本 `scripts/patch-done-pill.cjs` 针对 `@dsh-external/dsh-webui@0.5.1` 的 `DonePill` 源码区段。它校验版本、源码指纹及替换次数；重复执行会验证已应用内容，未知构建不会被盲目改写。
+
+定位避让顶部会话工具栏，处理默认位置、历史锚点、拖动、缩放和窗口变化。空间不足时隐藏胶囊，避免覆盖操作按钮；恢复空间后自动显示。不写回自动避让产生的临时坐标。
+
+`tauri-app/scripts/stage.ts` 在复制离线 seed 后只修改 staging 副本，失败会中止打包。原始 seed 保持不变。
+
+## 已安装用户
+
+离线 seed 只在首次启动时复制，因此已有 profile 不会因替换 seed 自动获得顶部补丁。应先退出 AIO 并备份目标插件的 `lib/client.js`，然后从仓库执行：
+
+```powershell
+$plugin = Join-Path $env:APPDATA 'com.deepseek.dsh.desktop.aio\dsh-home\profiles\web-desktop\node_modules\@dsh-external\dsh-webui'
+node scripts/patch-done-pill.cjs $plugin
+node scripts/patch-done-pill.cjs --write $plugin
+```
+
+便携版请改用实际 profile 路径。再次启动 AIO 后验收；不要在运行中的插件加载过程中替换文件。回退时退出 AIO，再恢复所备份的单个文件。
+
+动态岛使用仓库内置包分发及现有 companion 同步机制。本文不要求修改 `settings.yaml`、模型、密钥、会话或插件启停选择。
+
+## 验证
+
+```powershell
+node --test test/composer-island-position.test.mjs test/composer-dynamic-island-builtin.test.mjs test/done-pill-layout.test.mjs
+```
+
+真实 WebUI 区段测试会从本机安装目录读取只读样本；CI 可设置 `DSH_DONE_PILL_TEST_PACKAGE` 指向审核后的包。没有样本时该项明确跳过，不能解释成真实插件验证通过。
+
+手工验收应覆盖毛玻璃皮肤、原生皮肤、长会话、历史胶囊拖拽位置、右侧面板、窄窗口、缩放，以及动态岛按钮点击、滚动后定位、关闭与卸载。

--- a/scripts/patch-done-pill.cjs
+++ b/scripts/patch-done-pill.cjs
@@ -1,0 +1,291 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const VERSION = '0.5.1';
+const NAME = '@dsh-external/dsh-webui';
+const REGION = '\t\t//#region src/client/done-pill.tsx';
+const END = '\t\t//#endregion';
+const MARKER = '// EAC_DONE_PILL_LAYOUT_V3';
+const SOURCE_HASH = '07ea83bb68b66cd1a21f73ca64313b66d168ae681a929b4afc34f77a790d459d';
+const HEADER_SELECTOR = '[data-slot="conversation.session.header"]';
+const TOOLBAR_SELECTOR = '[role="toolbar"]';
+
+// Reserve the entire top band so width/left transitions cannot cross controls.
+function placeDonePill(x, y, w, h, viewport, obstacles) {
+  const margin = 8;
+  const gap = 16; // Includes the wrapper's 8px hover padding at normal scale.
+  const width = Math.max(1, w);
+  const height = Math.max(1, h);
+  const hoverPad = height * 8 / 30;
+  const clearance = Math.max(gap, hoverPad + margin);
+  let floor = margin + hoverPad;
+  for (const rect of obstacles) {
+    if (rect.width > 0 && rect.height > 0 && rect.bottom > 0 &&
+        rect.top < viewport.height && rect.right > 0 && rect.left < viewport.width) {
+      floor = Math.max(floor, rect.bottom + clearance);
+    }
+  }
+  const maxY = viewport.height - height - margin - hoverPad;
+  return {
+    x: Math.round(Math.max(margin, Math.min(x, viewport.width - width - margin))),
+    y: Math.ceil(Math.max(floor, Math.min(y, maxY))),
+    hidden: maxY < floor || width > viewport.width - margin * 2
+  };
+}
+
+function donePillLayoutGroups() {
+  const groups = [];
+  for (const el of document.querySelectorAll(
+    '[data-slot="conversation.session.header"],[data-slot="conversation.session.header.utilities"],[role="toolbar"],#__dsh_desktop_chrome__'
+  )) {
+    if (el.closest('.dsh-done-pill')) continue;
+    const chrome = el.id === '__dsh_desktop_chrome__';
+    const toolbar = el.matches('[role="toolbar"]');
+    const elements = new Set([el]);
+    if (!chrome) {
+      // Slot hosts use display:contents; measure their actual layout and controls.
+      if (!toolbar) {
+        const ancestor = el.closest('header,[class*="titleRow"]');
+        if (ancestor) elements.add(ancestor);
+      }
+      for (const child of el.children) elements.add(child);
+      for (const child of el.querySelectorAll(
+        'header,[class*="titleRow"],[data-slot],button,[role="button"],[role="tab"],[role="tablist"],a'
+      )) elements.add(child);
+    }
+    groups.push({ toolbar, elements });
+  }
+  return groups;
+}
+
+function donePillObstacles() {
+  const result = [];
+  const rawHeight = Number(document.documentElement.getAttribute('data-dsh-title-bar-height'));
+  const chromeHeight = Number.isFinite(rawHeight) && rawHeight > 0 ? rawHeight : 0;
+  if (chromeHeight > 0) result.push({
+    left: 0, right: window.innerWidth, top: 0, bottom: chromeHeight,
+    width: window.innerWidth, height: chromeHeight
+  });
+  for (const group of donePillLayoutGroups()) {
+    const rects = [];
+    for (const el of group.elements) {
+      if (el.closest('.dsh-done-pill')) continue;
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden' ||
+          style.visibility === 'collapse') continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0 && rect.bottom > 0 &&
+          rect.top < window.innerHeight && rect.right > 0 && rect.left < window.innerWidth) {
+        rects.push(rect);
+      }
+    }
+    if (rects.length === 0) continue;
+    const left = Math.min(...rects.map((rect) => rect.left));
+    const right = Math.max(...rects.map((rect) => rect.right));
+    const top = Math.min(...rects.map((rect) => rect.top));
+    const bottom = Math.max(...rects.map((rect) => rect.bottom));
+    // Coordinates already include the native chrome offset; never add it twice.
+    if (group.toolbar && top >= Math.max(100, chromeHeight + 68)) continue;
+    result.push({ left, right, top, bottom, width: right - left, height: bottom - top });
+  }
+  return result;
+}
+
+function updateDonePillClearance() {
+  const obstacles = donePillObstacles();
+  for (const wrapper of document.querySelectorAll('.dsh-done-pill')) {
+    const shell = wrapper.querySelector('.dsh-done-pill-shell');
+    if (!shell) continue;
+    const rect = shell.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    const bound = placeDonePill(8, 0, rect.width, rect.height,
+      { width: window.innerWidth, height: window.innerHeight }, obstacles);
+    // Do not enter React's state/layout-effect cycle or rewrite identical styles.
+    for (const [key, value] of [
+      ['--eac-done-pill-floor', `${bound.y}px`],
+      ['--eac-done-pill-visibility', bound.hidden ? 'hidden' : 'visible']
+    ]) {
+      if (wrapper.style.getPropertyValue(key) !== value) wrapper.style.setProperty(key, value);
+    }
+  }
+}
+
+function watchDonePillLayout(sync) {
+  let frame = null;
+  let disposed = false;
+  const observed = new Set();
+  const schedule = () => {
+    if (disposed || frame !== null) return;
+    frame = window.requestAnimationFrame(() => {
+      frame = null;
+      sync();
+    });
+  };
+  const resize = new ResizeObserver(schedule);
+  const refresh = () => {
+    const next = new Set(donePillLayoutGroups().flatMap((group) => [...group.elements]));
+    for (const wrapper of document.querySelectorAll('.dsh-done-pill')) next.add(wrapper);
+    next.add(document.documentElement);
+    for (const el of observed) {
+      if (!next.has(el)) {
+        resize.unobserve(el);
+        observed.delete(el);
+      }
+    }
+    for (const el of next) {
+      if (!observed.has(el)) {
+        observed.add(el);
+        resize.observe(el);
+      }
+    }
+  };
+  const mutations = new MutationObserver((records) => {
+    if (!records.some((record) => {
+      const el = record.target.nodeType === 1 ? record.target : record.target.parentElement;
+      return !el?.closest('.dsh-done-pill');
+    })) return;
+    refresh();
+    schedule();
+  });
+  refresh();
+  mutations.observe(document.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['class', 'style', 'hidden', 'data-sidebar-collapsed',
+      'data-dsh-sidebar-collapsed', 'data-dsh-title-bar-height', 'data-slot', 'role']
+  });
+  window.addEventListener('scroll', schedule, true);
+  window.addEventListener('resize', schedule);
+  window.visualViewport?.addEventListener('resize', schedule);
+  return () => {
+    disposed = true;
+    if (frame !== null) window.cancelAnimationFrame(frame);
+    resize.disconnect();
+    mutations.disconnect();
+    window.removeEventListener('scroll', schedule, true);
+    window.removeEventListener('resize', schedule);
+    window.visualViewport?.removeEventListener('resize', schedule);
+  };
+}
+
+function startDonePillClearance() {
+  updateDonePillClearance();
+  const stop = watchDonePillLayout(updateDonePillClearance);
+  return () => {
+    stop();
+    for (const wrapper of document.querySelectorAll('.dsh-done-pill')) {
+      wrapper.style.removeProperty('--eac-done-pill-floor');
+      wrapper.style.removeProperty('--eac-done-pill-visibility');
+    }
+  };
+}
+
+const helpers = '\n' + MARKER + '\n' + [
+  placeDonePill, donePillLayoutGroups, donePillObstacles, updateDonePillClearance,
+  watchDonePillLayout, startDonePillClearance
+].map((fn) => fn.toString()).join('\n') + '\n';
+const edits = [
+  [REGION, REGION + helpers],
+  [
+    '\t\t\t\ttop: defaultShellTop(),',
+    '\t\t\t\ttop: `max(${defaultShellTop()}px, var(--eac-done-pill-floor, 0px))`,'
+  ],
+  [
+    '\t\t\t\ttop: pos.y,',
+    '\t\t\t\ttop: `max(${pos.y}px, var(--eac-done-pill-floor, 0px))`,'
+  ],
+  ['\t\t\tzIndex: 9400,', '\t\t\tzIndex: 9400,\n\t\t\tvisibility: "var(--eac-done-pill-visibility, hidden)",'],
+  [
+    '\t\tfunction applyDonePill(ctx) {\n\t\t\tensurePillKeyframes();',
+    '\t\tfunction applyDonePill(ctx) {\n\t\t\tensurePillKeyframes();\n\t\t\tctx.effect(() => startDonePillClearance(), "webui: done-pill layout clearance");'
+  ]
+];
+
+function replaceStrict(source, before, after, expected = 1) {
+  const parts = source.split(before);
+  if (parts.length !== expected + 1) {
+    throw new Error(`DonePill patch anchor mismatch: expected ${expected}, got ${parts.length - 1}: ${before.slice(0, 100)}`);
+  }
+  return parts.join(after);
+}
+
+function hash(source) {
+  return crypto.createHash('sha256').update(source).digest('hex');
+}
+
+function transform(source, metadata) {
+  if (metadata?.name !== NAME || metadata?.version !== VERSION) {
+    throw new Error(`Unsupported DonePill package: ${metadata?.name}@${metadata?.version}; expected ${NAME}@${VERSION}`);
+  }
+  if (typeof source !== 'string') throw new TypeError('client source must be a string');
+  const eol = source.includes('\r\n') ? '\r\n' : '\n';
+  const normalized = source.replace(/\r\n/g, '\n');
+  if (normalized.split(REGION).length !== 2) throw new Error('Expected exactly one DonePill source region');
+  const start = normalized.indexOf(REGION);
+  const end = normalized.indexOf(END, start);
+  if (end < 0) throw new Error('Missing DonePill region terminator');
+  const region = normalized.slice(start, end);
+  if (region.includes('// EAC_DONE_PILL_LAYOUT_V') && !region.includes(MARKER)) {
+    throw new Error('Unsupported older DonePill patch; restore the verified original client.js before applying V3');
+  }
+  let original = region;
+  const alreadyPatched = region.includes(MARKER);
+  if (alreadyPatched) {
+    for (const [before, after, count] of [...edits].reverse()) {
+      original = replaceStrict(original, after, before, count);
+    }
+  }
+  if (hash(original) !== SOURCE_HASH) {
+    throw new Error('Unsupported DonePill source fingerprint (modified or unknown build)');
+  }
+  if (alreadyPatched) return { source, changed: false };
+  let patched = original;
+  for (const [before, after, count] of edits) {
+    patched = replaceStrict(patched, before, after, count);
+  }
+  const result = normalized.slice(0, start) + patched + normalized.slice(end);
+  return { source: eol === '\r\n' ? result.replace(/\n/g, '\r\n') : result, changed: true };
+}
+
+// A dry run by default. The caller must explicitly authorize a filesystem write.
+function apply(packageDir, { write = false } = {}) {
+  const metadata = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+  const clientPath = path.join(packageDir, 'lib', 'client.js');
+  const result = transform(fs.readFileSync(clientPath, 'utf8'), metadata);
+  if (write && result.changed) {
+    const temp = `${clientPath}.eac-${process.pid}-${crypto.randomBytes(6).toString('hex')}.tmp`;
+    try {
+      fs.writeFileSync(temp, result.source, { flag: 'wx' });
+      fs.renameSync(temp, clientPath);
+    } finally {
+      if (fs.existsSync(temp)) fs.unlinkSync(temp);
+    }
+  }
+  return { ...result, clientPath };
+}
+
+module.exports = { transform, apply, placeDonePill, watchDonePillLayout,
+  donePillLayoutGroups, donePillObstacles, updateDonePillClearance, startDonePillClearance,
+  VERSION, NAME, MARKER, SOURCE_HASH, HEADER_SELECTOR, TOOLBAR_SELECTOR };
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const write = args[0] === '--write';
+  const packageDir = args[write ? 1 : 0];
+  if (!packageDir || args.length !== (write ? 2 : 1)) {
+    console.error('Usage: node patch-done-pill.cjs [--write] <dsh-webui-package-directory>');
+    process.exitCode = 1;
+  } else {
+    try {
+      const result = apply(path.resolve(packageDir), { write });
+      console.log(result.changed ? (write ? 'DonePill patched' : 'DonePill patch validated (dry run)') : 'DonePill already patched and verified');
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/tauri-app/scripts/stage.ts
+++ b/tauri-app/scripts/stage.ts
@@ -309,6 +309,13 @@ function main() {
     process.exit(1);
   }
   copyTree(PROFILE_SEED, path.join(RESOURCES, 'profile-seed'));
+  // Patch only the staged copy; unknown plugin builds must stop packaging.
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-done-pill.cjs'),
+    '--write',
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', '@dsh-external', 'dsh-webui'),
+  ], { stdio: 'inherit' });
   console.log('[stage] 当前 web-desktop 插件与技能快照完成');
 
   // 2) 生产依赖闭包

--- a/test/composer-island-position.test.mjs
+++ b/test/composer-island-position.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../assets/plugins/dsh-composer-dynamic-island/lib/client.js', import.meta.url), 'utf8');
+const functions = source.slice(source.indexOf('    function fixedPositionIsReliable('), source.indexOf('    function discoverCandidates('));
+const { fixedPositionOrigin, fixedPositionIsReliable } = vm.runInNewContext(`${functions}; ({fixedPositionOrigin, fixedPositionIsReliable})`, {
+  window: { getComputedStyle: (node) => node.style },
+});
+const node = (style = {}, parentElement = null, rect = { left: 120, top: 300 }) => ({
+  parentElement,
+  style: { transform: 'none', filter: 'none', perspective: 'none', contain: 'none', backdropFilter: 'none', willChange: 'auto', ...style },
+  clientLeft: 1, clientTop: 2, scrollLeft: 0, scrollTop: 0,
+  getBoundingClientRect: () => rect,
+});
+
+test('ordinary ancestors retain viewport coordinates', () => {
+  const child = node({}, node());
+  assert.equal(fixedPositionOrigin(child).left, 0);
+  assert.equal(fixedPositionOrigin(child).top, 0);
+  assert.equal(fixedPositionIsReliable(child), true);
+});
+
+test('frosted composer offsets use padding edge and account for scrolling', () => {
+  const card = node({ backdropFilter: 'blur(16px)' });
+  card.scrollLeft = 3;
+  card.scrollTop = 7;
+  const child = node({}, card);
+  assert.equal(fixedPositionIsReliable(child), true);
+  assert.equal(fixedPositionOrigin(child).left, 118);
+  assert.equal(fixedPositionOrigin(child).top, 295);
+});
+
+test('each contribution uses its nearest containing block', () => {
+  const outer = node({ backdropFilter: 'blur(16px)' });
+  const inner = node({ backdropFilter: 'blur(4px)' }, outer, { left: 180, top: 350 });
+  assert.equal(fixedPositionOrigin(node({}, inner)).left, 181);
+  assert.equal(fixedPositionOrigin(node({}, outer)).left, 121);
+});
+
+test('other non-transform containing blocks and root ancestors are handled', () => {
+  for (const style of [{ webkitBackdropFilter: 'blur(4px)' }, { willChange: 'transform' }, { contain: 'layout' }, { contentVisibility: 'auto' }]) {
+    assert.equal(fixedPositionOrigin(node({}, node(style))).top, 302);
+  }
+  for (const style of [{ transform: 'matrix(1,0,0,1,2,3)' }, { scale: '0.9' }, { rotate: '2deg' }, { translate: '2px' }, { contain: 'paint' }]) {
+    assert.equal(fixedPositionIsReliable(node({}, node(style))), false);
+  }
+});
+
+test('completed entrance animation retains its identity containing block', () => {
+  const child = node({}, node({ transform: 'matrix(1, 0, 0, 1, 0, 0)' }));
+  assert.equal(fixedPositionIsReliable(child), true);
+  assert.equal(fixedPositionOrigin(child).top, 302);
+});
+
+test('scroll listener is removed on teardown and opening refreshes position', () => {
+  assert.match(source, /document\.addEventListener\("scroll", scheduleItemLayout, true\)/);
+  assert.match(source, /document\.removeEventListener\("scroll", scheduleItemLayout, true\)/);
+  assert.match(source, /const open = \(\) => \{\s+layout\(\);\s+setOpen\(true\)/);
+});
+
+test('button bounds are included when a toolbar wrapper shrinks', () => {
+  const measureSource = source.slice(source.indexOf('    function measureCandidate('), source.indexOf('    function packItems('));
+  const measure = vm.runInNewContext(`${measureSource}; measureCandidate`, {
+    buttonControlOf: () => ({ getBoundingClientRect: () => ({ width: 101, height: 28 }) }),
+  });
+  assert.equal(measure({ node: { getBoundingClientRect: () => ({ width: 28, height: 28 }) } }).width, 101);
+});
+
+test('popup remains within the composer column when a side panel is open', () => {
+  const packSource = source.slice(source.indexOf('    function packItems('), source.indexOf('    function stateIsCurrent('));
+  const pack = vm.runInNewContext(`${packSource}; packItems`, { MAX_PANEL_WIDTH: 520, window: { innerWidth: 1280, innerHeight: 800 } });
+  const packed = pack([{ width: 200, height: 28 }], { left: 300, right: 880, width: 580 }, { left: 840, top: 700, bottom: 730, width: 38 });
+  assert.ok(packed.left >= 300);
+  assert.ok(packed.left + packed.panelWidth <= 880);
+});
+
+test('Escape closes a hover-open popup even when returning focus fires open', () => {
+  const start = source.indexOf('      const onKeyDown = ');
+  const end = source.indexOf('      const onDocumentPointerDown = ', start);
+  const row = { dataset: { dshIslandOpen: 'true' } };
+  let focused = false;
+  const handler = vm.runInNewContext(`let pinned = true;\n${source.slice(start, end)}; onKeyDown`, {
+    row,
+    trigger: { focus() { focused = true; row.dataset.dshIslandOpen = 'true'; } },
+    setOpen: open => { row.dataset.dshIslandOpen = String(open); },
+  });
+  handler({ key: 'Escape', defaultPrevented: false });
+  assert.equal(focused, true);
+  assert.equal(row.dataset.dshIslandOpen, 'false');
+  assert.match(source, /document\.addEventListener\("keydown", onKeyDown\)/);
+  assert.match(source, /document\.removeEventListener\("keydown", onKeyDown\)/);
+});

--- a/test/done-pill-layout.test.mjs
+++ b/test/done-pill-layout.test.mjs
@@ -1,0 +1,355 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { transform, apply, placeDonePill, watchDonePillLayout, donePillObstacles,
+  donePillLayoutGroups, updateDonePillClearance, startDonePillClearance,
+  NAME, VERSION, MARKER } = require('../scripts/patch-done-pill.cjs');
+const metadata = { name: NAME, version: VERSION };
+const viewport = { width: 1000, height: 700 };
+const header = { left: 100, right: 900, top: 20, bottom: 90, width: 800, height: 70 };
+
+function fakeLayoutElement(rect = header, { toolbar = false, display = 'block',
+  visibility = 'visible', children = [], ancestor = null } = {}) {
+  return {
+    id: '', children, display, visibility,
+    matches: () => toolbar,
+    closest: (selector) => selector === '.dsh-done-pill' ? null : ancestor,
+    querySelectorAll: () => children,
+    getBoundingClientRect: () => rect
+  };
+}
+
+test('default position, legacy anchor and dragged positions avoid header', () => {
+  for (const x of [0, 200, 900]) {
+    const pos = placeDonePill(x, 40, 500, 30, viewport, [header]);
+    assert.equal(pos.y, 106);
+    assert.ok(pos.x >= 8 && pos.x + 500 <= 992);
+    assert.equal(pos.hidden, false);
+  }
+});
+
+test('resize, header growth and scale include hover hit area', () => {
+  const pos = placeDonePill(800, 40, 500, 48, { width: 600, height: 400 },
+    [{ ...header, bottom: 130 }]);
+  assert.ok(pos.y - 48 * 8 / 30 >= 138);
+  assert.equal(pos.x, 92);
+  assert.equal(pos.hidden, false);
+});
+
+test('hidden/offscreen/empty headers do not reserve space; safe manual position survives', () => {
+  const pos = placeDonePill(200, 300, 200, 30, viewport, [
+    { ...header, width: 0 }, { ...header, left: 1200, right: 1400 }
+  ]);
+  assert.deepEqual(pos, { x: 200, y: 300, hidden: false });
+});
+
+test('impossible viewport hides instead of clamping pill back over toolbar', () => {
+  const pos = placeDonePill(0, 40, 200, 30, { width: 300, height: 110 }, [header]);
+  assert.equal(pos.hidden, true);
+  assert.ok(pos.y > header.bottom);
+});
+
+test('unknown metadata and unrecognized source fail closed', () => {
+  assert.throws(() => transform('', { ...metadata, version: '0.5.2' }), /Unsupported/);
+  assert.throws(() => transform('', metadata), /region/);
+});
+
+test('staging applies after copying seed and propagates patch failure', () => {
+  const stage = fs.readFileSync(new URL('../tauri-app/scripts/stage.ts', import.meta.url), 'utf8');
+  const copy = stage.indexOf("copyTree(PROFILE_SEED, path.join(RESOURCES, 'profile-seed'));");
+  const patch = stage.indexOf("path.join(REPO_ROOT, 'scripts', 'patch-done-pill.cjs')");
+  assert.ok(copy >= 0 && patch > copy);
+  assert.match(stage.slice(copy, patch), /execFileSync\(process\.execPath/);
+  assert.match(stage.slice(patch, patch + 350), /'--write'/);
+  assert.match(stage.slice(patch, patch + 350), /path\.join\(RESOURCES, 'profile-seed'/);
+});
+
+test('observer coalesces changes, ignores pill mutations and cleans up', () => {
+  const previous = { window: globalThis.window, document: globalThis.document,
+    ResizeObserver: globalThis.ResizeObserver, MutationObserver: globalThis.MutationObserver };
+  let mutationCallback;
+  let resizeCallback;
+  let queued;
+  let calls = 0;
+  let disconnected = 0;
+  const listeners = new Set();
+  const realHeaderChild = fakeLayoutElement();
+  let headers = [fakeLayoutElement(undefined, { display: 'contents', children: [realHeaderChild] })];
+  const observed = new Set();
+  globalThis.document = { body: {}, documentElement: {},
+    querySelectorAll: (selector) => selector === '.dsh-done-pill' ? [] : headers };
+  globalThis.window = {
+    requestAnimationFrame: (fn) => { queued = fn; return 1; },
+    cancelAnimationFrame: () => { queued = null; },
+    addEventListener: (name) => listeners.add(name),
+    removeEventListener: (name) => listeners.delete(name)
+  };
+  globalThis.ResizeObserver = class {
+    constructor(fn) { resizeCallback = fn; }
+    observe(el) { observed.add(el); }
+    unobserve(el) { observed.delete(el); }
+    disconnect() { disconnected++; }
+  };
+  globalThis.MutationObserver = class {
+    constructor(fn) { mutationCallback = fn; }
+    observe() {}
+    disconnect() { disconnected++; }
+  };
+  try {
+    const stop = watchDonePillLayout(() => calls++);
+    assert.equal(observed.has(realHeaderChild), true, 'observe real layout children, not only slot hosts');
+    mutationCallback([{ target: { nodeType: 1, closest: () => true } }]);
+    assert.equal(queued, undefined);
+    resizeCallback();
+    const first = queued;
+    resizeCallback();
+    assert.equal(queued, first);
+    first();
+    assert.equal(calls, 1);
+    const oldHeader = headers[0];
+    headers = [fakeLayoutElement()];
+    mutationCallback([{ target: { nodeType: 1, closest: () => false } }]);
+    assert.equal(observed.has(oldHeader), false);
+    assert.equal(observed.has(realHeaderChild), false);
+    assert.equal(observed.has(headers[0]), true);
+    stop();
+    assert.equal(queued, null);
+    assert.equal(disconnected, 2);
+    assert.equal(listeners.size, 0);
+  } finally {
+    Object.assign(globalThis, previous);
+  }
+});
+
+test('obstacle scan excludes composer toolbar and hidden header', () => {
+  const previous = { document: globalThis.document, window: globalThis.window };
+  const make = (toolbar, top, visibility = 'visible') =>
+    fakeLayoutElement({ ...header, top, bottom: top + header.height }, { toolbar, visibility });
+  globalThis.document = { documentElement: { getAttribute: () => null }, querySelectorAll: () => [
+    make(false, 20), make(true, 12), make(true, 600), make(false, 20, 'hidden')
+  ] };
+  globalThis.window = { innerWidth: 1000, innerHeight: 800,
+    getComputedStyle: (el) => ({ display: el.display, visibility: el.visibility }) };
+  try {
+    assert.equal(donePillObstacles().length, 2);
+  } finally {
+    Object.assign(globalThis, previous);
+  }
+});
+
+test('display:contents resolves actual header, ancestor titleRow and button union', () => {
+  const previous = { document: globalThis.document, window: globalThis.window };
+  const zero = { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
+  const actual = fakeLayoutElement({ ...header, top: 32, bottom: 82, height: 50 });
+  const contents = fakeLayoutElement(zero, { display: 'contents', children: [actual] });
+  const utilities = fakeLayoutElement(zero, { display: 'contents', ancestor: actual });
+  const leftButton = fakeLayoutElement({ left: 600, right: 700, top: 42, bottom: 70, width: 100, height: 28 });
+  const rightButton = fakeLayoutElement({ left: 710, right: 800, top: 42, bottom: 86, width: 90, height: 44 });
+  const buttonsOnly = fakeLayoutElement(zero, { display: 'contents', children: [leftButton, rightButton] });
+  globalThis.document = {
+    documentElement: { getAttribute: () => '32' },
+    querySelectorAll: () => [contents, utilities, buttonsOnly]
+  };
+  globalThis.window = { innerWidth: 1000, innerHeight: 800,
+    getComputedStyle: (el) => ({ display: el.display, visibility: el.visibility }) };
+  try {
+    const rects = donePillObstacles();
+    assert.deepEqual(rects.map((rect) => rect.bottom), [32, 82, 82, 86]);
+    const pos = placeDonePill(250, 40, 500, 30, viewport, rects);
+    assert.equal(pos.y, 102, 'max absolute bottom + clearance, without adding 32 twice');
+    assert.ok(pos.y - 8 > 86, 'hover wrapper also clears buttons');
+    assert.ok(donePillLayoutGroups().some((group) => group.elements.has(actual)));
+  } finally {
+    Object.assign(globalThis, previous);
+  }
+});
+
+test('clearance updates CSS only, skips identical writes and restores visibility', () => {
+  const previous = { document: globalThis.document, window: globalThis.window };
+  const values = new Map();
+  let writes = 0;
+  const wrapper = {
+    querySelector: () => ({ getBoundingClientRect: () => ({ width: 500, height: 30 }) }),
+    style: {
+      getPropertyValue: (key) => values.get(key) || '',
+      setProperty: (key, value) => { writes++; values.set(key, value); }
+    }
+  };
+  globalThis.document = {
+    documentElement: { getAttribute: () => '32' },
+    querySelectorAll: (selector) => selector === '.dsh-done-pill' ? [wrapper] : [fakeLayoutElement()]
+  };
+  globalThis.window = { innerWidth: 1000, innerHeight: 700,
+    getComputedStyle: (el) => ({ display: el.display, visibility: el.visibility }) };
+  try {
+    updateDonePillClearance();
+    assert.equal(values.get('--eac-done-pill-floor'), '106px');
+    assert.equal(values.get('--eac-done-pill-visibility'), 'visible');
+    assert.equal(writes, 2);
+    for (let i = 0; i < 100; i++) updateDonePillClearance();
+    assert.equal(writes, 2, 'unchanged observations must produce zero DOM writes');
+    globalThis.window.innerHeight = 110;
+    updateDonePillClearance();
+    assert.equal(values.get('--eac-done-pill-visibility'), 'hidden');
+    globalThis.window.innerHeight = 700;
+    updateDonePillClearance();
+    assert.equal(values.get('--eac-done-pill-visibility'), 'visible');
+  } finally {
+    Object.assign(globalThis, previous);
+  }
+});
+
+const playwrightPath = process.env.DSH_DONE_PILL_PLAYWRIGHT ||
+  (process.env.USERPROFILE ? path.join(process.env.USERPROFILE, '.cache', 'codex-runtimes',
+    'codex-primary-runtime', 'dependencies', 'node', 'node_modules', 'playwright') : '');
+
+test('headless DOM: contents slots, native chrome and real child resize avoid overlap',
+  { skip: !playwrightPath || !fs.existsSync(playwrightPath), timeout: 30000 }, async () => {
+    const { chromium } = require(playwrightPath);
+    const browser = await chromium.launch({ channel: 'msedge', headless: true });
+    try {
+      const page = await browser.newPage({ viewport: { width: 1000, height: 700 } });
+      const errors = [];
+      page.on('pageerror', (error) => errors.push(error.message));
+      for (const chrome of [0, 32, 36]) {
+        await page.setContent(`
+          <style>
+            body { margin: 0; }
+            [data-slot] { display: contents; }
+            #__dsh_desktop_chrome__ { position: fixed; inset: 0 0 auto; height: ${chrome}px; }
+            header { position: fixed; top: ${chrome}px; left: 200px; right: 0; height: 54px; }
+            .titleRow { display: flex; align-items: center; justify-content: end; height: 100%; }
+            button { height: 30px; }
+            [role=toolbar] { position: fixed; top: 600px; height: 40px; }
+            .dsh-done-pill { position:fixed; left:250px;
+              top:max(40px,var(--eac-done-pill-floor,0px)); padding:8px 0; margin-top:-8px;
+              visibility:var(--eac-done-pill-visibility,hidden); }
+            .dsh-done-pill-shell { width:500px; height:30px; }
+          </style>
+          <div id="__dsh_desktop_chrome__"></div>
+          <div data-slot="conversation.session.header">
+            <header><div class="titleRow">
+              <span data-slot="conversation.session.header.utilities">
+                <button>Session log</button><button>Conversation</button><button>Trace</button>
+              </span>
+            </div></header>
+          </div>
+          <div role="toolbar"><button>Composer</button></div>
+          <div class="dsh-done-pill"><div class="dsh-done-pill-shell"></div></div>
+        `);
+        await page.evaluate((height) => document.documentElement.setAttribute(
+          'data-dsh-title-bar-height', String(height)), chrome);
+        await page.addScriptTag({ content: [placeDonePill, donePillLayoutGroups,
+          donePillObstacles, updateDonePillClearance, watchDonePillLayout,
+          startDonePillClearance].map((fn) => fn.toString()).join('\n') });
+        const initial = await page.evaluate(() => {
+          window.stopLayoutWatch?.();
+          const sync = () => {
+            window.pillPosition = placeDonePill(250, 40, 500, 30,
+              { width: innerWidth, height: innerHeight }, donePillObstacles());
+          };
+          window.stopLayoutWatch = watchDonePillLayout(sync);
+          window.stopClearance = startDonePillClearance();
+          sync();
+          return {
+            slotHeight: document.querySelector('[data-slot]').getBoundingClientRect().height,
+            headerBottom: document.querySelector('header').getBoundingClientRect().bottom,
+            position: window.pillPosition,
+            shellTop: document.querySelector('.dsh-done-pill-shell').getBoundingClientRect().top,
+            visibility: getComputedStyle(document.querySelector('.dsh-done-pill')).visibility
+          };
+        });
+        assert.equal(initial.slotHeight, 0);
+        assert.equal(initial.position.y, initial.headerBottom + 16);
+        assert.equal(initial.position.hidden, false);
+        assert.equal(initial.shellTop, initial.headerBottom + 16);
+        assert.equal(initial.visibility, 'visible');
+        await page.evaluate(() => { document.querySelector('header').style.height = '96px'; });
+        await page.waitForFunction((y) => window.pillPosition.y === y, chrome + 96 + 16);
+        // No header/titleRow layout boxes remain: button union is the fallback.
+        const union = await page.evaluate((height) => {
+          document.querySelector('header').style.display = 'contents';
+          document.querySelector('.titleRow').style.display = 'contents';
+          const buttons = [...document.querySelectorAll('header button')];
+          buttons.forEach((button, i) => Object.assign(button.style, {
+            position: 'fixed', left: `${500 + i * 100}px`, top: `${height + 12}px`,
+            height: i === 2 ? '44px' : '30px'
+          }));
+          const bottom = Math.max(...buttons.map((el) => el.getBoundingClientRect().bottom));
+          return { bottom, position: placeDonePill(250, 40, 500, 30,
+            { width: innerWidth, height: innerHeight }, donePillObstacles()) };
+        }, chrome);
+        assert.equal(union.position.y, union.bottom + 16);
+        assert.ok(union.position.y - 8 > union.bottom);
+        const chromeOnly = await page.evaluate(() => {
+          document.querySelector('header').style.display = 'none';
+          return placeDonePill(250, 8, 500, 30,
+            { width: innerWidth, height: innerHeight }, donePillObstacles());
+        });
+        assert.equal(chromeOnly.y, chrome > 0 ? chrome + 16 : 16);
+        await page.evaluate(() => { window.stopLayoutWatch(); window.stopClearance(); });
+      }
+      assert.deepEqual(errors, []);
+    } finally {
+      await browser.close();
+    }
+  });
+
+const installed = process.env.DSH_DONE_PILL_TEST_PACKAGE ||
+  (process.env.APPDATA ? path.join(process.env.APPDATA, 'com.deepseek.dsh.desktop.aio',
+    'dsh-home', 'profiles', 'web-desktop', 'node_modules', '@dsh-external', 'dsh-webui') : '');
+
+test('real installed bundle: strict transform, syntax, idempotence and isolated apply',
+  { skip: !installed || !fs.existsSync(path.join(installed, 'lib', 'client.js')) }, () => {
+    const original = fs.readFileSync(path.join(installed, 'lib', 'client.js'), 'utf8');
+    const realMetadata = JSON.parse(fs.readFileSync(path.join(installed, 'package.json'), 'utf8'));
+    const result = transform(original, realMetadata);
+    assert.equal(result.changed, !original.includes(MARKER));
+    assert.ok(result.source.includes(MARKER));
+    new vm.Script(result.source);
+    assert.deepEqual(transform(result.source, realMetadata), { source: result.source, changed: false });
+    const crlf = original.replace(/\r?\n/g, '\r\n');
+    const crlfPatched = transform(crlf, realMetadata).source;
+    assert.ok(!/(?<!\r)\n/.test(crlfPatched));
+    assert.equal(transform(crlfPatched, realMetadata).changed, false);
+    assert.throws(() => transform(original.replace('const SHELL_MAX_W = 720;', 'const SHELL_MAX_W = 721;'),
+      realMetadata), /fingerprint/);
+    assert.throws(() => transform(result.source.replace('const gap = 16;', 'const gap = 17;'),
+      realMetadata), /mismatch|fingerprint/);
+    assert.throws(() => transform(result.source.replace(MARKER, '// EAC_DONE_PILL_LAYOUT_V1'),
+      realMetadata), /restore the verified original/);
+    const regionStart = original.indexOf('//#region src/client/done-pill.tsx');
+    const regionEnd = original.indexOf('//#endregion', regionStart);
+    assert.equal(result.source.slice(0, regionStart), original.slice(0, regionStart));
+    assert.ok(result.source.endsWith(original.slice(regionEnd)));
+    const component = (source) => {
+      const start = source.indexOf('\t\tfunction DonePill(props) {');
+      const end = source.indexOf('\t\tfunction applyDonePill(ctx) {', start);
+      assert.ok(start > 0 && end > start);
+      return source.slice(start, end);
+    };
+    assert.equal(component(result.source), component(original),
+      'all original React hooks, state setters, dragging and saved anchors remain byte-identical');
+    assert.ok(result.source.includes('top: `max(${pos.y}px, var(--eac-done-pill-floor, 0px))`'));
+    assert.ok(result.source.includes('ctx.effect(() => startDonePillClearance()'));
+    assert.ok(!result.source.includes('watchDonePillLayout(syncPosition)'));
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'done-pill-test-'));
+    try {
+      fs.mkdirSync(path.join(temp, 'lib'));
+      fs.writeFileSync(path.join(temp, 'package.json'), JSON.stringify(realMetadata));
+      fs.writeFileSync(path.join(temp, 'lib', 'client.js'), original);
+      assert.equal(apply(temp).changed, result.changed);
+      assert.equal(fs.readFileSync(path.join(temp, 'lib', 'client.js'), 'utf8'), original);
+      assert.equal(apply(temp, { write: true }).changed, result.changed);
+      assert.equal(apply(temp, { write: true }).changed, false);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+    assert.equal(fs.readFileSync(path.join(installed, 'lib', 'client.js'), 'utf8'), original);
+  });


### PR DESCRIPTION
## 问题与修复

- 修复输入动态岛在毛玻璃皮肤中向右下方偏移：按各自固定定位包含块换算坐标，兼容完成入场动画后的单位矩阵，不移动 React 所有的控件。
- 重新测量被压缩容器内的真实按钮宽度，限制菜单在输入框所在列内，并在滚动、打开及尺寸变化后更新位置。
- 修复悬停打开菜单后 Esc 无法关闭，以及焦点恢复导致菜单重新打开的问题。
- 修复 `@dsh-external/dsh-webui@0.5.1` 顶部完成胶囊遮挡 Session log / 对话 / 轨迹。测量 `display: contents` 插槽的实际工具栏及桌面标题栏，仅通过 CSS 约束避让，不改 React 拖拽状态或用户保存的锚点。
- 新增版本、源码指纹和替换次数校验的幂等补丁脚本；staging 只修改复制后的 seed，未知构建中止打包。

## 范围

- 目标分支：`aio-v1`。
- 基于已包含 #336 滚动修复的 `2e591837c64434e05756fe3a113434b258fd699a` 创建远端提交，保留其全部改动。
- 不修改模型、密钥、会话内容、插件启停设置或内核滚动补丁。
- 已有 profile 不会自动重拷 seed；现有安装的受控应用步骤见 `docs/aio-plugin-layout-fix.md`。

## 验证

- [x] 27 项定向测试通过，无失败、无跳过。
- [x] 真实 WebUI 文件：严格变换、语法检查、重复应用与未知构建拒绝。
- [x] 桌面/窄屏 Chromium 布局测试，包含毛玻璃、插槽零尺寸、标题栏、缩放与不足空间。
- [x] 本机实际安装版 AIO 冷启动，原会话恢复；顶部避让、菜单边界、按钮点击区域、滚动后定位和 Esc 关闭通过。
- [x] 原插件文件已备份，本机已应用并恢复非调试启动；没有上传用户截图或配置。
- [x] 入口语法检查与 `git diff --check`。
- [ ] 全量测试未通过：新工作树缺少 `js-yaml` 及构建好的 sidecar，相关旧测试失败/超时；未把它们计为通过。
- [ ] 未重新生成安装包或执行完整升级验收，分发验证为 partial。

本 PR 仅提交修复和测试，不自动合并、不发布安装包。
