### PR TITLE
fix(runtime): 外部 DSH 启动失败时隔离 overlay 并回退内置版本

### DIFF
--- a/dsh-desktop/lib/desktop/runtime-paths.ts
+++ b/dsh-desktop/lib/desktop/runtime-paths.ts
@@ -6,7 +6,9 @@
 
 import path = require('node:path');
 import fs = require('node:fs');
+import cp = require('node:child_process');
 import { nodeExecutableName } from './platform';
+import { writeJsonAtomic } from '../atomic-json';
 
 // 应用根目录（本模块位于 <root>/lib/desktop/ 下）。
 export const APP_ROOT = path.resolve(__dirname, '..', '..');
@@ -38,7 +40,11 @@ const updater = require('../../updater') as {
 };
 
 let ctx!: RuntimePathsCtx;
-export function init(d: RuntimePathsCtx): void { ctx = d; }
+let overlayRejected = false;
+export function init(d: RuntimePathsCtx): void {
+  ctx = d;
+  overlayRejected = false;
+}
 // 壳环境注入缺省时按开发态处理（保持原防御语义）。
 function isPackaged(): boolean {
   return typeof ctx.isPackaged === 'function' ? !!ctx.isPackaged() : false;
@@ -87,16 +93,97 @@ export function updCtx(): UpdCtx {
   };
 }
 
+interface OverlayHealthMarker {
+  version: string;
+  validatedAt: string;
+}
+
+function overlayDir(): string { return path.join(ctx.getUserDataDir(), 'agent'); }
+function overlayHealthPath(): string { return path.join(overlayDir(), '.eac-agent-health.json'); }
+
+function hasHealthyOverlayMarker(version: string | null): boolean {
+  if (!version) return false;
+  try {
+    const marker = JSON.parse(fs.readFileSync(overlayHealthPath(), 'utf8')) as OverlayHealthMarker;
+    return marker.version === version && typeof marker.validatedAt === 'string';
+  } catch { return false; }
+}
+
+function writeHealthyOverlayMarker(version: string): void {
+  writeJsonAtomic(overlayHealthPath(), { version, validatedAt: new Date().toISOString() });
+}
+
+function nextBrokenOverlayDir(): string {
+  const base = path.join(ctx.getUserDataDir(), 'agent-broken-' + Date.now());
+  let candidate = base;
+  let suffix = 0;
+  while (fs.existsSync(candidate)) candidate = base + '-' + (++suffix);
+  return candidate;
+}
+
+/**
+ * 在 overlay 首次参与启动前用内置 Node 做一次真实 CLI 加载探测。
+ * npm 退出码为 0、入口文件存在仍可能留下缺 peer dependency 的运行时；
+ * `--version` 会加载 dsh 的实际入口，能在触碰用户 profile 前暴露这类错误。
+ */
+export async function ensureHealthyOverlay(timeoutMs = 20_000): Promise<{ source: 'overlay' | 'bundled'; reason?: string }> {
+  const c = updCtx();
+  const bin = updater.overlayBinPath(c);
+  const version = updater.overlayVersion(c);
+  const bundled = updater.bundledVersion();
+  if (!bin || !fs.existsSync(bin) || !version) return { source: 'bundled', reason: 'missing' };
+  if (bundled && updater.compareVersions(version, bundled) < 0) return { source: 'bundled', reason: 'older-than-bundled' };
+  if (hasHealthyOverlayMarker(version)) return { source: 'overlay' };
+
+  const smokeHome = path.join(ctx.getUserDataDir(), '.agent-health-check-' + process.pid);
+  try {
+    fs.mkdirSync(smokeHome, { recursive: true });
+    await new Promise<void>((resolve, reject) => {
+      cp.execFile(nodeExe(), [bin, '--version'], {
+        cwd: overlayDir(),
+        env: { ...process.env, DSH_HOME: smokeHome },
+        windowsHide: true,
+        timeout: timeoutMs,
+        maxBuffer: 2 * 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        if (!err) return resolve();
+        const lines = String(stderr || stdout || err.message).split(/\r?\n/).filter(Boolean);
+        const diagnostic = lines.find((line) => /Cannot find|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND/.test(line));
+        const summary = [diagnostic, ...lines.slice(-4)].filter(Boolean).join(' | ');
+        reject(new Error(summary || err.message));
+      });
+    });
+    writeHealthyOverlayMarker(version);
+    ctx.log('update', `Agent overlay ${version} 启动探测通过`);
+    return { source: 'overlay' };
+  } catch (err) {
+    overlayRejected = true;
+    const reason = String((err as Error).message || err);
+    try {
+      const broken = nextBrokenOverlayDir();
+      fs.renameSync(overlayDir(), broken);
+      ctx.log('update', `Agent overlay ${version} 启动探测失败，已隔离到 ${broken}，改用内置版本：${reason}`);
+    } catch (moveErr) {
+      ctx.log('update', `Agent overlay ${version} 启动探测失败且无法隔离，本次运行强制改用内置版本：${reason}；隔离错误：${String((moveErr as Error).message || moveErr)}`);
+    }
+    return { source: 'bundled', reason };
+  } finally {
+    try { await fs.promises.rm(smokeHome, { recursive: true, force: true, maxRetries: 3 }); } catch { /* 尽力清理 */ }
+  }
+}
+
 // Updated overlay takes precedence over the bundled copy — 除非 overlay 比
 // 随包内置内核旧（应用升级后，过时的官方更新 overlay 不得遮蔽更新的内置内核；
-// 平局仍取 overlay，保持既有语义）。
+// 平局仍取 overlay，保持既有语义）。未经首次 CLI 探测确认的 overlay 不得
+// 参与启动，避免损坏的用户目录副本遮蔽健康的内置内核。
 function effectiveOverlay(): string | null {
   const c = updCtx();
   const ov = updater.overlayBinPath(c);
-  if (!ov || !fs.existsSync(ov)) return null;
+  if (overlayRejected || !ov || !fs.existsSync(ov)) return null;
   const ovVer = updater.overlayVersion(c);
   const bundled = updater.bundledVersion();
   if (ovVer && bundled && updater.compareVersions(ovVer, bundled) < 0) return null;
+  if (!hasHealthyOverlayMarker(ovVer)) return null;
   return ov;
 }
 
@@ -115,3 +202,5 @@ export function dshVersion(): string {
 export function dshVersionSource(): string {
   return effectiveOverlay() ? '用户目录（已更新）' : '内置';
 }
+
+export function isUsingOverlay(): boolean { return effectiveOverlay() !== null; }

--- a/dsh-desktop/lib/desktop/runtime-paths.ts
+++ b/dsh-desktop/lib/desktop/runtime-paths.ts
@@ -6,9 +6,7 @@
 
 import path = require('node:path');
 import fs = require('node:fs');
-import cp = require('node:child_process');
 import { nodeExecutableName } from './platform';
-import { writeJsonAtomic } from '../atomic-json';
 
 // 应用根目录（本模块位于 <root>/lib/desktop/ 下）。
 export const APP_ROOT = path.resolve(__dirname, '..', '..');
@@ -37,6 +35,7 @@ const updater = require('../../updater') as {
   overlayVersion(c: UpdCtx): string | null;
   bundledVersion(): string | null;
   compareVersions(a: string, b: string): number;
+  rollback(c: UpdCtx): string | null;
 };
 
 let ctx!: RuntimePathsCtx;
@@ -93,89 +92,29 @@ export function updCtx(): UpdCtx {
   };
 }
 
-interface OverlayHealthMarker {
-  version: string;
-  validatedAt: string;
-}
-
-function overlayDir(): string { return path.join(ctx.getUserDataDir(), 'agent'); }
-function overlayHealthPath(): string { return path.join(overlayDir(), '.eac-agent-health.json'); }
-
-function hasHealthyOverlayMarker(version: string | null): boolean {
-  if (!version) return false;
-  try {
-    const marker = JSON.parse(fs.readFileSync(overlayHealthPath(), 'utf8')) as OverlayHealthMarker;
-    return marker.version === version && typeof marker.validatedAt === 'string';
-  } catch { return false; }
-}
-
-function writeHealthyOverlayMarker(version: string): void {
-  writeJsonAtomic(overlayHealthPath(), { version, validatedAt: new Date().toISOString() });
-}
-
-function nextBrokenOverlayDir(): string {
-  const base = path.join(ctx.getUserDataDir(), 'agent-broken-' + Date.now());
-  let candidate = base;
-  let suffix = 0;
-  while (fs.existsSync(candidate)) candidate = base + '-' + (++suffix);
-  return candidate;
-}
-
 /**
- * 在 overlay 首次参与启动前用内置 Node 做一次真实 CLI 加载探测。
- * npm 退出码为 0、入口文件存在仍可能留下缺 peer dependency 的运行时；
- * `--version` 会加载 dsh 的实际入口，能在触碰用户 profile 前暴露这类错误。
+ * 真正的 dsh web 启动失败后隔离 overlay，并让本进程后续强制选内置内核。
+ * 不缓存“曾经健康”的结论：overlay 每次都先乐观参与真实启动，失败才回退。
  */
-export async function ensureHealthyOverlay(timeoutMs = 20_000): Promise<{ source: 'overlay' | 'bundled'; reason?: string }> {
-  const c = updCtx();
-  const bin = updater.overlayBinPath(c);
-  const version = updater.overlayVersion(c);
-  const bundled = updater.bundledVersion();
-  if (!bin || !fs.existsSync(bin) || !version) return { source: 'bundled', reason: 'missing' };
-  if (bundled && updater.compareVersions(version, bundled) < 0) return { source: 'bundled', reason: 'older-than-bundled' };
-  if (hasHealthyOverlayMarker(version)) return { source: 'overlay' };
-
-  const smokeHome = path.join(ctx.getUserDataDir(), '.agent-health-check-' + process.pid);
+export function quarantineBrokenOverlay(reason: unknown): { quarantined: boolean; path?: string; error?: string } {
+  const version = updater.overlayVersion(updCtx()) || '未知';
+  overlayRejected = true;
   try {
-    fs.mkdirSync(smokeHome, { recursive: true });
-    await new Promise<void>((resolve, reject) => {
-      cp.execFile(nodeExe(), [bin, '--version'], {
-        cwd: overlayDir(),
-        env: { ...process.env, DSH_HOME: smokeHome },
-        windowsHide: true,
-        timeout: timeoutMs,
-        maxBuffer: 2 * 1024 * 1024,
-      }, (err, stdout, stderr) => {
-        if (!err) return resolve();
-        const lines = String(stderr || stdout || err.message).split(/\r?\n/).filter(Boolean);
-        const diagnostic = lines.find((line) => /Cannot find|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND/.test(line));
-        const summary = [diagnostic, ...lines.slice(-4)].filter(Boolean).join(' | ');
-        reject(new Error(summary || err.message));
-      });
-    });
-    writeHealthyOverlayMarker(version);
-    ctx.log('update', `Agent overlay ${version} 启动探测通过`);
-    return { source: 'overlay' };
+    const broken = updater.rollback(updCtx());
+    if (!broken) return { quarantined: false };
+    ctx.log('update', `Agent overlay ${version} 真实启动失败，已隔离并改用内置版本：${String((reason as Error)?.message || reason)}`);
+    return { quarantined: true, path: broken };
   } catch (err) {
-    overlayRejected = true;
-    const reason = String((err as Error).message || err);
-    try {
-      const broken = nextBrokenOverlayDir();
-      fs.renameSync(overlayDir(), broken);
-      ctx.log('update', `Agent overlay ${version} 启动探测失败，已隔离到 ${broken}，改用内置版本：${reason}`);
-    } catch (moveErr) {
-      ctx.log('update', `Agent overlay ${version} 启动探测失败且无法隔离，本次运行强制改用内置版本：${reason}；隔离错误：${String((moveErr as Error).message || moveErr)}`);
-    }
-    return { source: 'bundled', reason };
-  } finally {
-    try { await fs.promises.rm(smokeHome, { recursive: true, force: true, maxRetries: 3 }); } catch { /* 尽力清理 */ }
+    const message = String((err as Error).message || err);
+    ctx.log('update', `Agent overlay ${version} 启动失败且无法隔离，本次运行强制改用内置版本：${message}`);
+    return { quarantined: false, error: message };
   }
 }
 
 // Updated overlay takes precedence over the bundled copy — 除非 overlay 比
 // 随包内置内核旧（应用升级后，过时的官方更新 overlay 不得遮蔽更新的内置内核；
-// 平局仍取 overlay，保持既有语义）。未经首次 CLI 探测确认的 overlay 不得
-// 参与启动，避免损坏的用户目录副本遮蔽健康的内置内核。
+// 平局仍取 overlay，保持既有语义）。真实启动失败后，本进程拒绝该 overlay，
+// 并由启动编排隔离目录后重试内置内核。
 function effectiveOverlay(): string | null {
   const c = updCtx();
   const ov = updater.overlayBinPath(c);
@@ -183,7 +122,6 @@ function effectiveOverlay(): string | null {
   const ovVer = updater.overlayVersion(c);
   const bundled = updater.bundledVersion();
   if (ovVer && bundled && updater.compareVersions(ovVer, bundled) < 0) return null;
-  if (!hasHealthyOverlayMarker(ovVer)) return null;
   return ov;
 }
 

--- a/dsh-desktop/test/runtime-overlay-health.test.ts
+++ b/dsh-desktop/test/runtime-overlay-health.test.ts
@@ -4,8 +4,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
+const testDir = path.dirname(fileURLToPath(import.meta.url));
 const runtimePaths = require('../lib/desktop/runtime-paths.js') as {
   init(ctx: {
     log(tag: string, message: string): void;
@@ -15,7 +17,7 @@ const runtimePaths = require('../lib/desktop/runtime-paths.js') as {
     appRoot(): string;
     platform: NodeJS.Platform;
   }): void;
-  ensureHealthyOverlay(timeoutMs?: number): Promise<{ source: 'overlay' | 'bundled'; reason?: string }>;
+  quarantineBrokenOverlay(reason: unknown): { quarantined: boolean; path?: string; error?: string };
   dshBin(): string;
 };
 
@@ -43,33 +45,46 @@ function init(userDataDir: string, logs: string[]): void {
   });
 }
 
-test('健康 overlay 首次探测成功后写入标记并参与启动', async () => {
+test('overlay 无需健康缓存，直接乐观参与真实启动', () => {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-health-ok-'));
   const logs: string[] = [];
   const bin = makeOverlay(userDataDir, '9.9.9', "console.log('9.9.9');\n");
   init(userDataDir, logs);
 
-  assert.notEqual(runtimePaths.dshBin(), bin, '未经探测的 overlay 不得直接参与启动');
-  assert.deepEqual(await runtimePaths.ensureHealthyOverlay(5_000), { source: 'overlay' });
   assert.equal(runtimePaths.dshBin(), bin);
-  const marker = JSON.parse(fs.readFileSync(path.join(userDataDir, 'agent', '.eac-agent-health.json'), 'utf8'));
-  assert.equal(marker.version, '9.9.9');
-  assert.ok(logs.some((line) => line.includes('启动探测通过')));
+  assert.equal(fs.existsSync(path.join(userDataDir, 'agent', '.eac-agent-health.json')), false);
   fs.rmSync(userDataDir, { recursive: true, force: true });
 });
 
-test('缺失运行时依赖的 overlay 被隔离并自动回退内置版本', async () => {
+test('曾经可用的 overlay 损坏后仍可被隔离并回退内置版本', () => {
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-health-bad-'));
   const logs: string[] = [];
-  makeOverlay(userDataDir, '9.9.9', "require('@deepseek-ai/definitely-missing');\n");
+  const bin = makeOverlay(userDataDir, '9.9.9', "console.log('9.9.9');\n");
   init(userDataDir, logs);
 
-  const result = await runtimePaths.ensureHealthyOverlay(5_000);
-  assert.equal(result.source, 'bundled');
-  assert.match(result.reason || '', /definitely-missing|Cannot find module|MODULE_NOT_FOUND/);
+  assert.equal(runtimePaths.dshBin(), bin, '第一次启动应直接选择 overlay');
+  fs.writeFileSync(bin, "require('@deepseek-ai/definitely-missing');\n");
+  const result = runtimePaths.quarantineBrokenOverlay(new Error('ERR_MODULE_NOT_FOUND'));
+  assert.equal(result.quarantined, true);
   assert.equal(fs.existsSync(path.join(userDataDir, 'agent')), false);
   assert.ok(fs.readdirSync(userDataDir).some((name) => name.startsWith('agent-broken-')));
   assert.ok(!runtimePaths.dshBin().includes(userDataDir), '隔离后必须回退随包内核');
-  assert.ok(logs.some((line) => line.includes('启动探测失败')));
+  assert.ok(logs.some((line) => line.includes('真实启动失败')));
   fs.rmSync(userDataDir, { recursive: true, force: true });
+});
+
+test('sidecar 在真实启动失败后停止残留进程、隔离 overlay 并重试内置版本', () => {
+  const server = fs.readFileSync(path.join(testDir, '..', '..', 'tauri-shell', 'sidecar', 'server.ts'), 'utf8');
+  const start = server.indexOf('async function guardedStartAndWait');
+  const end = server.indexOf('recoveryCenter.init', start);
+  const guarded = server.slice(start, end);
+
+  assert.ok(start >= 0 && end > start, '必须能定位 guardedStartAndWait 实现');
+  assert.match(guarded, /const startedWithOverlay = .*isUsingOverlay/);
+  assert.match(guarded, /catch \(overlayError\)[\s\S]*if \(!startedWithOverlay\) throw overlayError/);
+  const stopAt = guarded.indexOf('bootMod.stopServer');
+  const quarantineAt = guarded.indexOf('pathsMod.quarantineBrokenOverlay');
+  const retryAt = guarded.indexOf('bootMod.startAndWait', quarantineAt);
+  assert.ok(stopAt >= 0 && stopAt < quarantineAt && quarantineAt < retryAt, '失败后必须先停进程，再隔离，最后重试');
+  assert.doesNotMatch(server, /ensureHealthyOverlay|\.eac-agent-health\.json/);
 });

--- a/dsh-desktop/test/runtime-overlay-health.test.ts
+++ b/dsh-desktop/test/runtime-overlay-health.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const runtimePaths = require('../lib/desktop/runtime-paths.js') as {
+  init(ctx: {
+    log(tag: string, message: string): void;
+    getUserDataDir(): string;
+    isPackaged(): boolean;
+    resourcesPath(): string;
+    appRoot(): string;
+    platform: NodeJS.Platform;
+  }): void;
+  ensureHealthyOverlay(timeoutMs?: number): Promise<{ source: 'overlay' | 'bundled'; reason?: string }>;
+  dshBin(): string;
+};
+
+function makeOverlay(userDataDir: string, version: string, binSource: string): string {
+  const pkg = path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh');
+  fs.mkdirSync(path.join(pkg, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version }));
+  const bin = path.join(pkg, 'lib', 'bin.js');
+  fs.writeFileSync(bin, binSource);
+  return bin;
+}
+
+function init(userDataDir: string, logs: string[]): void {
+  const appRoot = path.join(userDataDir, 'app-root');
+  const runtimeDir = path.join(appRoot, 'vendor', 'node');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  fs.copyFileSync(process.execPath, path.join(runtimeDir, process.platform === 'win32' ? 'node.exe' : 'node'));
+  runtimePaths.init({
+    log: (tag, message) => logs.push(`[${tag}] ${message}`),
+    getUserDataDir: () => userDataDir,
+    isPackaged: () => false,
+    resourcesPath: () => '',
+    appRoot: () => appRoot,
+    platform: process.platform,
+  });
+}
+
+test('健康 overlay 首次探测成功后写入标记并参与启动', async () => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-health-ok-'));
+  const logs: string[] = [];
+  const bin = makeOverlay(userDataDir, '9.9.9', "console.log('9.9.9');\n");
+  init(userDataDir, logs);
+
+  assert.notEqual(runtimePaths.dshBin(), bin, '未经探测的 overlay 不得直接参与启动');
+  assert.deepEqual(await runtimePaths.ensureHealthyOverlay(5_000), { source: 'overlay' });
+  assert.equal(runtimePaths.dshBin(), bin);
+  const marker = JSON.parse(fs.readFileSync(path.join(userDataDir, 'agent', '.eac-agent-health.json'), 'utf8'));
+  assert.equal(marker.version, '9.9.9');
+  assert.ok(logs.some((line) => line.includes('启动探测通过')));
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+});
+
+test('缺失运行时依赖的 overlay 被隔离并自动回退内置版本', async () => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-health-bad-'));
+  const logs: string[] = [];
+  makeOverlay(userDataDir, '9.9.9', "require('@deepseek-ai/definitely-missing');\n");
+  init(userDataDir, logs);
+
+  const result = await runtimePaths.ensureHealthyOverlay(5_000);
+  assert.equal(result.source, 'bundled');
+  assert.match(result.reason || '', /definitely-missing|Cannot find module|MODULE_NOT_FOUND/);
+  assert.equal(fs.existsSync(path.join(userDataDir, 'agent')), false);
+  assert.ok(fs.readdirSync(userDataDir).some((name) => name.startsWith('agent-broken-')));
+  assert.ok(!runtimePaths.dshBin().includes(userDataDir), '隔离后必须回退随包内核');
+  assert.ok(logs.some((line) => line.includes('启动探测失败')));
+  fs.rmSync(userDataDir, { recursive: true, force: true });
+});

--- a/tauri-shell/sidecar/server.ts
+++ b/tauri-shell/sidecar/server.ts
@@ -573,14 +573,36 @@ async function guardedStartAndWait(overlays: string[]): Promise<{ webUrl: string
     reportIncident(t: string, d: string): { ok: boolean };
   })();
   const snap = g.snapshot('boot');
+  const startedWithOverlay = (pathsMod.isUsingOverlay as () => boolean)();
   try {
-    const r = await (bootMod.startAndWait as (o: string[]) => Promise<{ webUrl: string; port: number }>)(overlays);
+    let r: { webUrl: string; port: number };
+    try {
+      r = await (bootMod.startAndWait as (o: string[]) => Promise<{ webUrl: string; port: number }>)(overlays);
+    } catch (overlayError) {
+      if (!startedWithOverlay) throw overlayError;
+
+      // 乐观优先：overlay 不做启动前探测，也不缓存历史健康结论。只有真实
+      // dsh web 启动失败后才停止残留进程、隔离 overlay，并用内置内核重试一次。
+      try { await (bootMod.stopServer as () => Promise<void>)(); }
+      catch (stopError) { log('update', '停止失败 overlay 的残留进程失败: ' + String(((stopError as Error).message) || stopError)); }
+      const quarantine = (pathsMod.quarantineBrokenOverlay as (reason: unknown) => { quarantined: boolean; path?: string; error?: string })(overlayError);
+      log('update', '外部 DSH 启动失败，正在使用内置 DSH 重试' + (quarantine.path ? `（问题副本：${quarantine.path}）` : ''));
+      try {
+        r = await (bootMod.startAndWait as (o: string[]) => Promise<{ webUrl: string; port: number }>)(overlays);
+      } catch (bundledError) {
+        throw new Error(
+          '外部 DSH 启动失败，切换内置 DSH 后仍无法启动。' +
+          `外部错误：${String(((overlayError as Error).message) || overlayError)}；` +
+          `内置错误：${String(((bundledError as Error).message) || bundledError)}`,
+        );
+      }
+    }
     if (snap) g.markGood(snap.id);
     // agent-previous 备份生命周期：更新后的首次健康启动即清理上一版备份
     // （5.3.2 及以前 confirmPreviousAgentHealthy 零调用，数百 MB 备份永滞）。
     // 只有新版 overlay 自己完成健康启动，才可删除它对应的 previous。
     // 坏 overlay 被隔离后由 bundled 兜底成功，不代表 previous 可以丢弃。
-    if (!agentPreviousConfirmed && (pathsMod.isUsingOverlay as () => boolean)()) {
+    if (!agentPreviousConfirmed && startedWithOverlay && (pathsMod.isUsingOverlay as () => boolean)()) {
       agentPreviousConfirmed = true;
       // 两个「确认健康后的清理」都【严禁】在 boot.start 关键路径上同步执行：
       // backups/<ts> 全量镜像与 agent-previous 覆盖层可达数百 MB～数 GB，
@@ -663,9 +685,6 @@ const methods: Record<string, (p: RpcParams) => unknown> = {
   // ---- boot.*（P2：dsh web 服务编排，Rust 壳的启动主链路） ----
   'boot.start': async (p): Promise<RpcResult> => {
     const overlays = Array.isArray(p && p.overlays) ? (p!.overlays as string[]) : [];
-    // 用户目录中的 Agent 会遮蔽随包内核。首次参与启动前必须先做真实 CLI
-    // 加载探测；缺失 peer dependency 等损坏会被隔离并自动回退到内置版本。
-    await (pathsMod.ensureHealthyOverlay as () => Promise<unknown>)();
     // 打包态捆绑依赖完整性校验（issue #7，= Electron startAndShowGuarded 前置）：
     // 空壳包以明确文案提示重装，用户选「仍然启动」才继续。
     await (previewMod.verifyBundledModules as () => Promise<void>)();

--- a/tauri-shell/sidecar/server.ts
+++ b/tauri-shell/sidecar/server.ts
@@ -578,7 +578,9 @@ async function guardedStartAndWait(overlays: string[]): Promise<{ webUrl: string
     if (snap) g.markGood(snap.id);
     // agent-previous 备份生命周期：更新后的首次健康启动即清理上一版备份
     // （5.3.2 及以前 confirmPreviousAgentHealthy 零调用，数百 MB 备份永滞）。
-    if (!agentPreviousConfirmed) {
+    // 只有新版 overlay 自己完成健康启动，才可删除它对应的 previous。
+    // 坏 overlay 被隔离后由 bundled 兜底成功，不代表 previous 可以丢弃。
+    if (!agentPreviousConfirmed && (pathsMod.isUsingOverlay as () => boolean)()) {
       agentPreviousConfirmed = true;
       // 两个「确认健康后的清理」都【严禁】在 boot.start 关键路径上同步执行：
       // backups/<ts> 全量镜像与 agent-previous 覆盖层可达数百 MB～数 GB，
@@ -661,6 +663,9 @@ const methods: Record<string, (p: RpcParams) => unknown> = {
   // ---- boot.*（P2：dsh web 服务编排，Rust 壳的启动主链路） ----
   'boot.start': async (p): Promise<RpcResult> => {
     const overlays = Array.isArray(p && p.overlays) ? (p!.overlays as string[]) : [];
+    // 用户目录中的 Agent 会遮蔽随包内核。首次参与启动前必须先做真实 CLI
+    // 加载探测；缺失 peer dependency 等损坏会被隔离并自动回退到内置版本。
+    await (pathsMod.ensureHealthyOverlay as () => Promise<unknown>)();
     // 打包态捆绑依赖完整性校验（issue #7，= Electron startAndShowGuarded 前置）：
     // 空壳包以明确文案提示重装，用户选「仍然启动」才继续。
     await (previewMod.verifyBundledModules as () => Promise<void>)();


### PR DESCRIPTION
## 背景

用户目录中的 DSH overlay 会优先于随包内核启动。即使 overlay 曾经成功启动，之后仍可能因文件损坏、依赖丢失等原因失效；因此不能使用健康标记缓存过去的检查结果。

PR #341 已负责在更新切换前验证依赖闭包与 CLI。本 PR 补充运行时兜底，处理安装后再次损坏以及历史遗留坏 overlay。

## 修改内容

- 移除启动前 `dsh --version` 探测和 `.eac-agent-health.json` 健康缓存。
- 保持乐观优先：符合版本条件的外部 DSH 直接参与真实 `dsh web` 启动，健康路径没有额外进程或等待。
- 外部 DSH 真实启动失败后，先停止残留服务进程，再将 overlay 隔离为 `agent-broken-*`。
- 隔离后自动使用随包内置 DSH 重试一次。
- 若内置 DSH 仍无法启动，错误中同时保留外部与内置两次失败原因。
- 只有 overlay 自身成功启动后才清理 `agent-previous`；内置版本兜底成功不会误删上一版本备份。
- 隔离失败时，本次进程仍会强制拒绝该 overlay 并尝试内置版本。

## 为什么这样修

健康缓存只能证明 overlay 曾经可用，无法覆盖“第一次可用、第二次损坏”的情况。以真实启动结果为准可以持续发现损坏；正常情况下没有性能损失，只有失败时会多进行一次内置版本启动，而且损坏副本隔离后不会在后续启动中重复拖慢。

## 测试

- TypeScript 类型检查通过。
- 乐观选择、二次损坏后的隔离回退、sidecar 失败重试顺序测试 3/3 通过。
- overlay 与上一版本备份相关测试 8/8 通过。
- `git diff --check` 通过。

## 影响范围

- 健康 overlay 的启动路径不增加额外探测开销。
- 损坏 overlay 首次失败时会经历一次失败启动和一次内置版本重试。
- 问题副本不会直接删除，保留在 `agent-broken-*` 中供诊断。