### PR TITLE
fix(updater): 切换版本前验证 Agent 依赖闭包与 CLI

### DIFF
--- a/dsh-desktop/test/update-mirror-chain.test.ts
+++ b/dsh-desktop/test/update-mirror-chain.test.ts
@@ -30,6 +30,15 @@ function makeFakeNpmCli(dir, behavior) {
   fs.writeFileSync(cli, `
     const args = process.argv.slice(2);
     if (args[0] === 'config') { process.stdout.write('https://registry.npmjs.org\\n'); process.exit(0); }
+    if (args[0] === 'view') {
+      const reg = args.find((a) => a.startsWith('--registry='));
+      const key = reg ? reg.slice('--registry='.length).replace(/\\/+$/, '') : '(default)';
+      const behavior = ${JSON.stringify(behavior)};
+      const out = behavior[key] || behavior['(default)'];
+      if (out === 'ok') { process.stdout.write('0.1.0-rc.9\\n'); process.exit(0); }
+      process.stderr.write('EINTEGRITY fetch failed\\n'); process.exit(1);
+    }
+    if (args[0] === 'ls') { process.stdout.write('dependency closure ok\\n'); process.exit(0); }
     const reg = args.find((a) => a.startsWith('--registry='));
     const key = reg ? reg.slice('--registry='.length).replace(/\\/+$/, '') : '(default)';
     const behavior = ${JSON.stringify(behavior)};
@@ -40,7 +49,9 @@ function makeFakeNpmCli(dir, behavior) {
       const path = require('node:path');
       const bin = path.join(prefixArg || '.', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js');
       fs.mkdirSync(path.dirname(bin), { recursive: true });
-      fs.writeFileSync(bin, 'module.exports = {};\\n');
+      const requested = args.find((a) => a.startsWith('@deepseek-ai/dsh@')).slice('@deepseek-ai/dsh@'.length);
+      fs.writeFileSync(path.join(path.dirname(path.dirname(bin)), 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: requested }));
+      fs.writeFileSync(bin, 'console.log(' + JSON.stringify(requested) + ');\\n');
       process.stdout.write('0.1.0-rc.9\\n');
       process.exit(0);
     }
@@ -88,6 +99,26 @@ test('applyUpdate: first registry fails -> automatically switches to mirror and 
   assert.ok(events.some((e) => e.stage === 'done'), '成功阶段应上报');
   assert.ok(logs.some((l) => l.includes('自动切换镜像源')), '日志应记录切换');
   assert.ok(fs.existsSync(path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')));
+  assert.equal(fs.existsSync(path.join(userDataDir, 'agent-previous')), false, '首次安装不能生成假的上一版本');
+  const settings = JSON.parse(fs.readFileSync(path.join(userDataDir, 'settings.json'), 'utf8'));
+  assert.equal(settings.previousAgent, null);
+  rmRetry(userDataDir);
+});
+
+test('applyUpdate: 备份记录旧 overlay 的真实版本而不是目标版本', async () => {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'upd-previous-version-'));
+  const cli = makeFakeNpmCli(userDataDir, { 'https://registry.npmjs.org': 'ok' });
+  const oldPkg = path.join(userDataDir, 'agent', 'node_modules', '@deepseek-ai', 'dsh');
+  fs.mkdirSync(path.join(oldPkg, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(oldPkg, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.1.0-rc.8' }));
+  fs.writeFileSync(path.join(oldPkg, 'lib', 'bin.js'), "console.log('0.1.0-rc.8');");
+  const { ctx } = makeCtx(cli, userDataDir);
+
+  await updater.applyUpdate(ctx, '0.1.0-rc.9', {});
+  const settings = JSON.parse(fs.readFileSync(path.join(userDataDir, 'settings.json'), 'utf8'));
+  assert.equal(settings.previousAgent.version, '0.1.0-rc.8');
+  const previousPkg = JSON.parse(fs.readFileSync(path.join(userDataDir, 'agent-previous', 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), 'utf8'));
+  assert.equal(previousPkg.version, '0.1.0-rc.8');
   rmRetry(userDataDir);
 });
 
@@ -133,12 +164,14 @@ test('applyUpdate: npm install 必须携带 --ignore-scripts（阻断 node-pty n
     const args = process.argv.slice(2);
     // 记录真实 argv 到脚本自身目录，供断言 --ignore-scripts（路径经
     // path.join 注入，避免任何转义歧义）。
-    fs.writeFileSync(path.join(path.dirname(process.argv[1]), 'npm-args.json'), JSON.stringify(args));
+    if (args[0] === 'install') fs.writeFileSync(path.join(path.dirname(process.argv[1]), 'npm-args.json'), JSON.stringify(args));
     if (args.includes('config')) { console.log('https://registry.npmjs.org'); process.exit(0); }
+    if (args[0] === 'ls') { console.log('dependency closure ok'); process.exit(0); }
     const prefix = args[args.indexOf('--prefix') + 1];
     const bin = path.join(prefix, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js');
     fs.mkdirSync(path.dirname(bin), { recursive: true });
-    fs.writeFileSync(bin, 'module.exports = {};');
+    fs.writeFileSync(path.join(path.dirname(path.dirname(bin)), 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.1.0-rc.9' }));
+    fs.writeFileSync(bin, "console.log('0.1.0-rc.9');");
     console.log('0.1.0-rc.9');
     process.exit(0);
   `);
@@ -148,5 +181,34 @@ test('applyUpdate: npm install 必须携带 --ignore-scripts（阻断 node-pty n
   assert.ok(argsLog.includes('--ignore-scripts'),
     '必须跳过生命周期脚本（node-pty install/prebuild 会触发 node-gyp，网络受限环境卡死）');
   assert.ok(argsLog.some((a) => a.startsWith('--registry=')), '镜像源参数应保留');
+  rmRetry(dir);
+});
+
+test('applyUpdate: npm 成功但 CLI 缺运行时依赖时拒绝切换', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'upd-bad-runtime-'));
+  const cli = path.join(dir, 'fake-npm.js');
+  fs.writeFileSync(cli, `
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const args = process.argv.slice(2);
+    if (args[0] === 'config') { console.log('https://registry.npmjs.org'); process.exit(0); }
+    if (args[0] === 'ls') { console.log('dependency closure ok'); process.exit(0); }
+    const prefix = args[args.indexOf('--prefix') + 1];
+    const pkg = path.join(prefix, 'node_modules', '@deepseek-ai', 'dsh');
+    fs.mkdirSync(path.join(pkg, 'lib'), { recursive: true });
+    fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.1.0-rc.9' }));
+    fs.writeFileSync(path.join(pkg, 'lib', 'bin.js'), "require('@deepseek-ai/definitely-missing');\\n");
+    process.exit(0);
+  `);
+  const oldBin = path.join(dir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js');
+  fs.mkdirSync(path.dirname(oldBin), { recursive: true });
+  fs.writeFileSync(path.join(path.dirname(path.dirname(oldBin)), 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh', version: '0.1.0-rc.8' }));
+  fs.writeFileSync(oldBin, "console.log('old');");
+  const { ctx } = makeCtx(cli, dir);
+
+  await assert.rejects(updater.applyUpdate(ctx, '0.1.0-rc.9', {}), /CLI 加载失败/);
+  const current = JSON.parse(fs.readFileSync(path.join(dir, 'agent', 'node_modules', '@deepseek-ai', 'dsh', 'package.json'), 'utf8'));
+  assert.equal(current.version, '0.1.0-rc.8', '验证失败不得替换旧 overlay');
+  assert.equal(fs.existsSync(path.join(dir, 'agent-staging')), false);
   rmRetry(dir);
 });

--- a/dsh-desktop/test/updater-backup.test.ts
+++ b/dsh-desktop/test/updater-backup.test.ts
@@ -49,7 +49,17 @@ test('previousAgentInfo returns null without settings or directory', () => {
   writeSettings(ctx, { previousAgent: { version: '1.0.0' } });
   assert.equal(previousAgentInfo(ctx), null, 'settings alone must not suffice');
   fs.mkdirSync(path.join(ctx.userDataDir, 'agent-previous'), { recursive: true });
-  assert.ok(previousAgentInfo(ctx), 'settings + directory must be reported');
+  assert.equal(previousAgentInfo(ctx), null, '空目录不能伪装成可回退 Agent');
+  makeFakePackage(path.join(ctx.userDataDir, 'agent-previous'), '1.0.0');
+  assert.ok(previousAgentInfo(ctx), '元数据、package 与 bin 全部匹配时才可回退');
+});
+
+test('previousAgentInfo rejects a backup whose real version differs from metadata', () => {
+  const { ctx } = makeCtx();
+  makeFakePackage(path.join(ctx.userDataDir, 'agent-previous'), '1.0.0');
+  writeSettings(ctx, { previousAgent: { version: '1.1.0', dir: 'agent-previous' } });
+  assert.equal(previousAgentInfo(ctx), null);
+  assert.equal(rollbackToPrevious(ctx), null, '无效备份不得覆盖当前 Agent');
 });
 
 test('confirmPreviousAgentHealthy clears the backup and the setting', async () => {

--- a/dsh-desktop/updater.ts
+++ b/dsh-desktop/updater.ts
@@ -242,6 +242,50 @@ function runNpm(ctx: UpdaterCtx, args: string[], { timeoutMs = 30 * 60 * 1000, l
   });
 }
 
+async function validateStagedAgent(ctx: UpdaterCtx, staging: string, expectedVersion: string, logStream: fs.WriteStream): Promise<void> {
+  const actualVersion = agentVersionIn(staging);
+  const bin = agentBinPath(staging);
+  if (actualVersion !== expectedVersion) {
+    throw new Error(`实际安装版本 ${actualVersion || '未知'} 与目标版本 ${expectedVersion} 不一致`);
+  }
+  if (!fs.existsSync(bin)) throw new Error('未找到 dsh 入口文件');
+
+  ctx.log('update', '开始验证生产依赖闭包: ' + PKG + '@' + expectedVersion);
+  await runNpm(ctx, ['ls', '--prefix', staging, '--all', '--omit=dev'], {
+    timeoutMs: 2 * 60 * 1000,
+    logStream,
+  });
+
+  const smokeHome = path.join(staging, '.eac-smoke-home');
+  fs.mkdirSync(smokeHome, { recursive: true });
+  ctx.log('update', '开始加载 staged dsh CLI: ' + bin + ' --version');
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const proc = cp.execFile(ctx.nodeExe(), [bin, '--version'], {
+        cwd: staging,
+        env: { ...process.env, DSH_HOME: smokeHome },
+        windowsHide: true,
+        timeout: 20_000,
+        maxBuffer: 2 * 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        activeProcs.delete(proc);
+        const output = String(stdout || '') + String(stderr || '');
+        if (output) logStream.write(output.endsWith('\n') ? output : output + '\n');
+        if (!err) return resolve();
+        const lines = output.split(/\r?\n/).filter(Boolean);
+        const diagnostic = lines.find((line) => /Cannot find|MODULE_NOT_FOUND|ERR_MODULE_NOT_FOUND/.test(line));
+        const summary = [diagnostic, ...lines.slice(-4)].filter(Boolean).join(' | ');
+        reject(new Error('CLI 加载失败' + (summary ? '：' + summary.slice(-1000) : '：' + err.message)));
+      });
+      activeProcs.add(proc);
+      proc.once('error', () => activeProcs.delete(proc));
+    });
+  } finally {
+    try { await fs.promises.rm(smokeHome, { recursive: true, force: true, maxRetries: 3 }); } catch { /* staging 会在失败路径整体清理 */ }
+  }
+  ctx.log('update', 'staged Agent 依赖闭包与 CLI 加载验证通过');
+}
+
 // 当前生效的 registry（.npmrc / NPM_CONFIG_REGISTRY），供镜像源链去重与提示。
 async function currentRegistry(ctx: UpdaterCtx): Promise<string | null> {
   try {
@@ -291,11 +335,26 @@ async function checkLatest(ctx: UpdaterCtx): Promise<string> {
 
 function previousAgentDir(ctx: UpdaterCtx): string { return path.join(ctx.userDataDir, 'agent-previous'); }
 
+function agentPackagePath(dir: string): string { return path.join(dir, 'node_modules', PKG, 'package.json'); }
+function agentBinPath(dir: string): string { return path.join(dir, 'node_modules', PKG, 'lib', 'bin.js'); }
+function agentVersionIn(dir: string): string | null {
+  try {
+    const pkg = readJsonFile(agentPackagePath(dir));
+    return pkg && typeof pkg.version === 'string' ? pkg.version : null;
+  } catch { return null; }
+}
+
+function validAgentDir(dir: string, expectedVersion?: string | null): boolean {
+  const version = agentVersionIn(dir);
+  if (!version || !fs.existsSync(agentBinPath(dir))) return false;
+  return !expectedVersion || version === expectedVersion;
+}
+
 // 上一版本备份是否可用（供启动失败对话框选择「回退到上一版本」）。
 function previousAgentInfo(ctx: UpdaterCtx): Record<string, any> | null {
   const settings = loadSettings(ctx);
   if (!settings.previousAgent || !settings.previousAgent.version) return null;
-  if (!fs.existsSync(previousAgentDir(ctx))) return null;
+  if (!validAgentDir(previousAgentDir(ctx), settings.previousAgent.version)) return null;
   return settings.previousAgent;
 }
 
@@ -303,10 +362,11 @@ function previousAgentInfo(ctx: UpdaterCtx): Record<string, any> | null {
 //   { stage: 'fetch', count, elapsed, registry }   —— 下载依赖中（按 npm 输出
 //     统计已获取的包/元数据项数）
 //   { stage: 'install', registry }                  —— 进入解包安装阶段
-//   { stage: 'done' }                               —— npm 安装成功，即将切换版本
+//   { stage: 'verify' }                             —— 审计依赖闭包并加载 CLI
+//   { stage: 'done' }                               —— 验证完成并已切换版本
 //   { stage: 'mirror', registry }                   —— 源停滞/失败，已切换镜像源
 interface UpdateProgress {
-  stage: 'fetch' | 'install' | 'done' | 'mirror';
+  stage: 'fetch' | 'install' | 'verify' | 'done' | 'mirror';
   count?: number;
   elapsed?: string;
   registry?: string | null;
@@ -345,9 +405,7 @@ async function applyUpdate(ctx: UpdaterCtx, version: string, { onProgress = null
       lastPush = now;
       if (!onProgress) return;
       try {
-        onProgress(sawAdded
-          ? { stage: 'done' }
-          : { stage: sawReify ? 'install' : 'fetch', count: fetchCount, elapsed: fmt(now - started), registry });
+        onProgress({ stage: (sawAdded || sawReify) ? 'install' : 'fetch', count: fetchCount, elapsed: fmt(now - started), registry });
       } catch {}
     };
     const onOutput = (chunk: Buffer) => {
@@ -370,7 +428,6 @@ async function applyUpdate(ctx: UpdaterCtx, version: string, { onProgress = null
       ];
       if (registry) args.push('--registry=' + registry);
       await runNpm(ctx, args, { timeoutMs: 30 * 60 * 1000, logStream, onOutput, stallMs });
-      if (onProgress) { try { onProgress({ stage: 'done' }); } catch {} }
       installErr = null;
       break;
     } catch (err) {
@@ -382,17 +439,21 @@ async function applyUpdate(ctx: UpdaterCtx, version: string, { onProgress = null
       }
     }
   }
-  logStream.end();
   if (installErr) {
+    logStream.end();
     fs.rmSync(staging, { recursive: true, force: true });
     throw new Error(installErr.message + '（已尝试镜像源：' + errors.join('；') + '；日志: ' + logPath + '）');
   }
 
-  const bin = path.join(staging, 'node_modules', PKG, 'lib', 'bin.js');
-  if (!fs.existsSync(bin)) {
+  try {
+    if (onProgress) { try { onProgress({ stage: 'verify' }); } catch {} }
+    await validateStagedAgent(ctx, staging, version, logStream);
+  } catch (err) {
+    logStream.end();
     fs.rmSync(staging, { recursive: true, force: true });
-    throw new Error('安装完成但未找到 dsh 入口文件（日志: ' + logPath + '）');
+    throw new Error('安装结果验证失败：' + String((err as Error).message || err) + '（旧版本未变；日志: ' + logPath + '）');
   }
+  logStream.end();
 
   // Atomic swap: old overlay -> backup, staging -> overlay.
   // M4 修复：两处重命名都纳入 try，失败时回滚并清理 staging 残留。
@@ -401,13 +462,14 @@ async function applyUpdate(ctx: UpdaterCtx, version: string, { onProgress = null
   // 启动失败时用户可一键回退到上一版本。
   const overlay = overlayDir(ctx);
   const backup = path.join(ctx.userDataDir, 'agent-old-' + Date.now());
-  // V4.3 PR（独有价值，review 保留项）：配置全量快照 + profile 精简。
-  // swap 前把关键配置文件拷到 backup/config/ 目录；backup 随后会被
-  // rename 到 agent-previous（固定名），快照也随之保留到健康确认前；
-  // 若 swap 失败，backup 目录最终会被 overlay 回滚 + 删除，快照随之丢弃，
-  // 不污染 userData。
+  const oldVersion = overlayVersion(ctx);
+  const hadValidOldOverlay = validAgentDir(overlay, oldVersion);
+  // 配置快照必须与 Agent 目录备份分离。旧实现预先创建 backup/config，随后
+  // 又尝试把旧 agent 重命名到已存在的 backup，Windows 上会直接 EPERM；
+  // 首次安装还会把只有 config 的目录误记成 agent-previous。
   try {
-    const cfgDir = path.join(backup, 'config');
+    const cfgDir = path.join(ctx.userDataDir, 'agent-config-backup');
+    fs.rmSync(cfgDir, { recursive: true, force: true });
     fs.mkdirSync(cfgDir, { recursive: true });
     // 1) userData/settings.json（桌面端配置：端口、皮肤、已跳过版本等）
     const setSrc = settingsPath(ctx);
@@ -449,18 +511,27 @@ async function applyUpdate(ctx: UpdaterCtx, version: string, { onProgress = null
   // 新备份以固定名保留。
   const prevDir = previousAgentDir(ctx);
   if (fs.existsSync(prevDir)) fs.rmSync(prevDir, { recursive: true, force: true });
-  if (fs.existsSync(backup)) {
+  let previousPreserved = false;
+  if (hadValidOldOverlay && fs.existsSync(backup)) {
     try { fs.renameSync(backup, prevDir); } catch (err) {
       ctx.log('update', '保留上一版本备份失败: ' + (err as Error).message);
       fs.rmSync(backup, { recursive: true, force: true });
     }
+    previousPreserved = fs.existsSync(prevDir);
+  } else if (fs.existsSync(backup)) {
+    // 原 overlay 结构不完整时不能伪装成可回退版本；保留为 broken 仅供诊断。
+    try { fs.renameSync(backup, path.join(ctx.userDataDir, 'agent-broken-' + Date.now())); }
+    catch { fs.rmSync(backup, { recursive: true, force: true }); }
   }
 
   const settings = loadSettings(ctx);
-  settings.previousAgent = { version, dir: 'agent-previous', at: new Date().toISOString() };
+  settings.previousAgent = previousPreserved && oldVersion
+    ? { version: oldVersion, dir: 'agent-previous', at: new Date().toISOString() }
+    : null;
   settings.skipVersion = null;
   saveSettings(ctx, settings);
-  ctx.log('update', '更新完成: ' + PKG + '@' + version + '（上一版本备份保留至确认健康）');
+  if (onProgress) { try { onProgress({ stage: 'done' }); } catch {} }
+  ctx.log('update', '更新完成: ' + PKG + '@' + version + (previousPreserved ? '（上一版本备份保留至确认健康）' : ''));
   return { version, logPath };
 }
 
@@ -490,8 +561,8 @@ function rollbackToPrevious(ctx: UpdaterCtx): string | null {
   const settings = loadSettings(ctx);
   const prevDir = previousAgentDir(ctx);
   const overlay = overlayDir(ctx);
-  const prev = settings.previousAgent;
-  if (!prev || !fs.existsSync(prevDir)) return null;
+  const prev = previousAgentInfo(ctx);
+  if (!prev) return null;
   try {
     if (fs.existsSync(overlay)) {
       fs.renameSync(overlay, path.join(ctx.userDataDir, 'agent-broken-' + Date.now()));


### PR DESCRIPTION
## 背景

当前 Agent 更新流程在 `npm install` 返回 0 且 `lib/bin.js` 存在后，就会直接将 staging 切换为正式 overlay。这无法识别“安装完成但运行时依赖不完整”的情况。本次事故中 npm 显示安装成功，但新 Agent 启动时因缺少 `@deepseek-ai/cordis-plugin-group` 立即退出。

检查还发现现有备份流程存在两个问题：配置快照预先占用 `agent-old-*` 目录，导致 Windows 重命名旧 Agent 时可能报 `EPERM`；首次安装 overlay 时还可能把只有配置快照的目录误记成 `agent-previous`，并将目标新版本写成上一版本。

## 修改内容

### 更新结果验证

在 staging 切换为正式 overlay 前增加三道验证：

1. 确认 staging 中实际安装的 DSH 版本与请求版本一致；
2. 执行 `npm ls --all --omit=dev`，验证生产依赖闭包；
3. 使用应用内置 Node 执行 staging 中的 `dsh --version`，验证真实 CLI 入口可以加载。

CLI 探测使用 staging 内的临时 `DSH_HOME`，设置 20 秒超时，并将输出写入更新日志。任一验证失败时清理 staging、保留当前 Agent，并明确提示旧版本未变。

更新进度新增 `verify` 阶段；只有验证和目录交换都完成后才发送 `done`，不再把 npm 的 `added N packages` 当作更新完成。

### 修正上一版本备份

- 将配置快照移动到独立的 `agent-config-backup`，不再占用 Agent 目录备份路径。
- 更新前读取并保存旧 overlay 的真实版本。
- 只有旧目录同时具备有效 package、入口文件且版本匹配时，才生成 `agent-previous`。
- `previousAgent.version` 记录旧版本，而不是目标新版本。
- 首次安装时将 `previousAgent` 设为 `null`。
- 结构不完整的旧 overlay 保留为 `agent-broken-*`，不能用于回滚。
- 回滚前验证 package、bin 和元数据版本一致。

## 为什么这样修

`npm install` 成功只表示 npm 完成了解析和写入，不代表 Node 可以加载最终入口。依赖闭包审计负责发现未满足的生产依赖，CLI smoke test 负责验证最终运行行为，两者共同作为正式切换前的门禁。

本修复不使用 `--legacy-peer-deps`，因为该参数会忽略 peer dependency 问题，使损坏的运行时更容易通过安装阶段。

## 测试

回归测试覆盖：

- npm 返回 0，但 CLI 缺少运行时依赖时拒绝更新；
- 验证失败时旧 overlay 保持不变；
- 首次安装不生成假的 `agent-previous`；
- previous 元数据记录旧版本；
- 空目录或版本不匹配的备份不能用于回滚；
- 原有镜像切换、下载停滞和 `--ignore-scripts` 行为保持正常。

验证结果：

- TypeScript 编译通过；
- 更新器及回滚定向测试 14/14 通过；
- 完整现有测试命令退出码为 0；
- `git diff --check` 通过。

## 行为变化与兼容性

- 依赖闭包不完整的 DSH npm 版本将不再被安装为活动 overlay，这是有意的 fail-closed 行为。
- 更新验证会额外执行一次 `npm ls` 和一次轻量 CLI 加载。
- 当前版本只有在新版本完成全部验证后才会被替换。
- 不修改用户 DSH 配置、profile 或凭据。