### PR TITLE
docs(readme): 从源码构建补充 fetch-kernel 前置步骤并修正路径与失效引用

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -216,17 +216,20 @@ To report a bug or suggest a feature, visit [https://eac.dtyg123.dpdns.org/](htt
 
 ```powershell
 cd dsh-desktop
-npm install
-npm run fetch-runtime    # bundle node.exe + npm CLI
-npm run dist             # build portable + NSIS installer -> dist/
+npm install -g pnpm@11.7.0       # kernel build toolchain (version pinned by the upstream packageManager field)
+node scripts/fetch-kernel.js     # required on first run: build kernel tarballs from upstream source (vendor/ is not committed; a proxy is needed on restricted networks)
+npm install                      # install dependencies only after the kernel tarballs are in place
+npm run fetch-runtime            # bundle node.exe + npm CLI
+node ../tauri-shell/stage-resources.mjs   # assemble the sidecar + dsh-desktop runtime tree
+cd ../tauri-shell
+npx -y @tauri-apps/cli@2 build   # release build + NSIS installer
+node make-portable.mjs           # portable zip (optional) -> target/release/portable/
 ```
-
-> Behind a firewall? Use the Electron mirror `$env:ELECTRON_MIRROR='https://npmmirror.com/mirrors/electron/'` and the builder toolchain mirror `$env:ELECTRON_BUILDER_BINARIES_MIRROR='https://npmmirror.com/mirrors/electron-builder-binaries/'`.
 
 Run tests:
 
 ```powershell
-npm test                 # node --test test/*.test.mjs
+npm test                 # node --test test/*.test.ts
 ```
 
 ### Architecture

--- a/README.md
+++ b/README.md
@@ -231,16 +231,16 @@
 
 ## 开发者文档
 
-完整的当前分支开发参考见 [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)，包括 Tauri 三层架构、L2 模块边界、开发/测试/打包命令、运行时数据目录、桥接契约和排障清单。
-
 ### 从源码构建（Tauri 壳，v5.0 默认）
 
 ```powershell
 cd dsh-desktop
-npm install
+npm install -g pnpm@11.7.0       # 内核构建依赖（版本由上游 packageManager 钉定）
+node scripts/fetch-kernel.js     # 首次必须：自上游源码构建内核 tarball（vendor/ 不入库；网络受限环境需自行配置代理）
+npm install                      # 内核 tarball 就位后依赖才能安装
 npm run fetch-runtime            # 内置 node.exe + npm CLI
-node tauri-shell/stage-resources.mjs   # 装配打包资源（sidecar + dsh-desktop 运行树）
-cd tauri-shell
+node ../tauri-shell/stage-resources.mjs   # 装配打包资源（sidecar + dsh-desktop 运行树）
+cd ../tauri-shell
 npx -y @tauri-apps/cli@2 build   # release 构建 + NSIS 安装包
 node make-portable.mjs           # 便携 zip（可选）→ target/release/portable/
 
@@ -255,6 +255,8 @@ node make-portable.mjs           # 便携 zip（可选）→ target/release/port
 
 ```powershell
 cd dsh-desktop
+npm install -g pnpm@11.7.0
+node scripts/fetch-kernel.js     # 网络受限环境需自行配置代理
 npm install
 npm run fetch-runtime
 # 打包（Tauri 三段链，产出入 tauri-shell/target/release/）
@@ -270,7 +272,7 @@ node make-portable.mjs                      # → portable/*-portable.zip + SHA2
 
 ```powershell
 cd dsh-desktop
-npm test                 # node --test test/*.test.mjs（pretest 含 tsc 全量类型检查）
+npm test                 # node --test test/*.test.ts（pretest 含 tsc 全量类型检查）
 node ../gui-smoke.js     # Tauri 壳 GUI 冒烟（18 项，需先 cargo build）
 node ../update-smoke.js  # 自更新链路冒烟（mock 发布源 + 目录树交换）
 ```


### PR DESCRIPTION
## 目的

修复「从源码构建」指引在新 clone 上不可执行的问题。

`dsh-desktop/package.json` 中全部 `@deepseek-ai/*` 内核依赖均指向
`file:vendor/kernel/<version>/*.tgz`，而 `vendor/` 被 .gitignore 排除
（tarball 由 `fetch-kernel` 自上游源码现场构建，设计上不入库）。因此全新
clone 后直接执行 README 现有的 `npm install` 必然失败：

```
npm error path ...\dsh-desktop\vendor\kernel\0.1.3-alpha.1\deepseek-ai-schemastery-3.18.2.tgz
npm error enoent ENOENT: no such file or directory
```

完整安装流程目前仅存在于 CI（ci.yml 的「安装 pnpm」→「生成 vendored 内核
tarball」→「安装依赖」三步），README 未同步。本 PR 将其补入中英两版 README，
并顺带修正逐步实跑中暴露的路径与失效引用问题。

## 改动一览

| # | 位置 | 改动 | 理由 |
|---|---|---|---|
| 1 | 两版构建块 | 前置补入 `npm install -g pnpm@11.7.0` 与 `node scripts/fetch-kernel.js` | 对齐 ci.yml 既有步骤；node 直调是因 `npm run fetch-kernel` 的 `npm run build &&` 前缀在无 node_modules 的全新 clone 上因缺 tsc 失败 |
| 2 | README.md 构建块 | `node tauri-shell/…` → `node ../tauri-shell/…`；`cd tauri-shell` → `cd ../tauri-shell` | 工作目录是 dsh-desktop，tauri-shell 是其兄弟目录，原相对路径不存在（逐步实跑暴露） |
| 3 | README.en.md 安装块 | 整体替换 | 原块引用不存在的 `npm run dist` script（package.json 无此 script，Electron 时代遗留） |
| 4 | README.en.md | 移除 ELECTRON_MIRROR 提示 | Electron 壳已退役 |
| 5 | README.md | 移除 DEVELOPMENT.md 死链 | docs/DEVELOPMENT.md 不存在（全仓搜索 + CDN 404 双确认）；是否补写文档另行开 issue |
| 6 | 两版「运行测试」注释 | `test/*.test.mjs` → `test/*.test.ts` | test/ 目录下已无 .mjs 测试 |

## 架构与范围

纯文档改动，仅 README.md 与 README.en.md。不涉及 L1/L2/L3 任何代码、CI
配置、插件或打包逻辑。

## 风险与兼容

- 无运行时行为变化，不影响任何构建产物；
- 改动一览 #4/#5 属内容取舍（移除过时提示与死链），若维护者希望保留或改为
  指向其他文档，review 中指出即可随时调整。

## 验证

- 问题复现（本机，Windows 11 / Node v24.13.0；2026-09-08，当时 main 为
  5dbbba0）：按 README 原步骤执行 `cd dsh-desktop && npm install`，复现
  上述 ENOENT。
- 修复序列按 README 新顺序逐步实跑（独立沙箱，Windows；README 安装块在
  5dbbba0..8c17e99 间无变化，git diff 实证）：`npm install -g pnpm@11.7.0`
  → `node scripts/fetch-kernel.js`（退出码 0，258 个 tarball 落位）→
  `npm install`（退出码 0）→ `npm run fetch-runtime`（退出码 0）→
  `node ../tauri-shell/stage-resources.mjs`（退出码 0）。实跑同时暴露了
  改动一览 #2 的 `cd tauri-shell` 路径错误，本 PR 一并修正。
- 引用核查（grep/ls 实证）：package.json 无 `dist` script；`test/` 目录无
  *.test.mjs 文件；docs/DEVELOPMENT.md 不存在。
- 本 PR 仅含 Markdown 改动，按 ci.yml paths 过滤规则（排除 `**/*.md`）不会
  触发 CI，属预期。

## 配置与迁移

无。

## 回退方式

revert 单一提交即可恢复原文档。

## 未验证项

- README 其余章节未逐句核对（超出本 PR 范围）。

---

**Checklist**

- [x] `git diff --check` 已通过
- [x] 无无关文件、日志、凭据、用户数据或行尾变化（diff 仅 README.md 14 行 [8+/6-] 与 README.en.md 15 行 [9+/6-]，numstat 实证）
- [x] UI 变化：不适用
- [x] 未验证项已在上文明确列出
- [x] Skill 最低验证级别：纯 Markdown 文档改动，无需运行时验证