### PR TITLE
fix(aio): restore native provider selection and markdown rendering

### DIFF
--- a/assets/plugins/dsh-composer-dynamic-island/EAC-VENDOR.json
+++ b/assets/plugins/dsh-composer-dynamic-island/EAC-VENDOR.json
@@ -4,7 +4,7 @@
   "tag": "v2.1.0",
   "commit": "2ccd12ff807c3bc983defd2177e15be1a416106f",
   "upstreamClientSha256": "22ea2dff2002dfd012d54aec8fd3c91d1d62544d5f54c10de755bdb05fc20f78",
-  "vendoredClientSha256": "07f5a0415ef58db60483d10d39d349739f4bbc4f8974cfbd3c4e4c4286479be3",
+  "vendoredClientSha256": "c0d54d704a056e11c1732c8eb287b0ca3e5ae49816cb7674727094c084646fb2",
   "vendoredClientSha256Encoding": "UTF-8 with LF line endings",
   "localPatches": [
     "cancel queued animation frames and reject layout after disposal",
@@ -16,6 +16,7 @@
     "refresh popup placement on open and captured scroll, with teardown cleanup",
     "support identity entrance transforms and measure overflowing button bounds",
     "keep popup placement within the composer column when side panels are open",
-    "close hover-open popups on Escape after restoring trigger focus"
+    "close hover-open popups on Escape after restoring trigger focus",
+    "keep the host-native model selector in its original React tree"
   ]
 }

--- a/assets/plugins/dsh-composer-dynamic-island/README.md
+++ b/assets/plugins/dsh-composer-dynamic-island/README.md
@@ -27,8 +27,8 @@ The adapter detects controls from an active DSH input or composer surface and
 lets the user choose which controls collapse into an upward-expanding island.
 It discovers:
 
-- native controls and contributions in `conversation.input.left`,
-  `conversation.input.right`, and `conversation.input.model`;
+- native controls and contributions in `conversation.input.left` and
+  `conversation.input.right`;
 - button-style contributions in future `conversation.input.*` or `composer.*`
   slots;
 - nested button contributions marked with `data-plugin`, `data-plugin-id`,
@@ -42,7 +42,8 @@ textboxes are never collapsed, even when they carry a plugin marker. Search,
 settings, and ordinary form controls outside the composer are not scanned.
 
 Defaults collapse left-side plugin controls and the WebUI team-mode selector.
-Native tools, permission controls, model controls, and send/stop remain in
+The model selector always uses the host-native control and remains in its
+original position. Native tools, permission controls, and send/stop remain in
 their original positions. Existing controls remain owned by their original
 React parent; the adapter changes presentation attributes and styles without
 moving nodes to another parent.

--- a/assets/plugins/dsh-composer-dynamic-island/README.zh-CN.md
+++ b/assets/plugins/dsh-composer-dynamic-island/README.zh-CN.md
@@ -19,14 +19,14 @@
 
 适配器会检测当前 DSH 输入区或 Composer 表面中的控件，并允许用户选择将哪些控件收纳进向上展开的灵动岛。它能够发现：
 
-- `conversation.input.left`、`conversation.input.right` 和 `conversation.input.model` 中的原生控件与贡献项；
+- `conversation.input.left` 和 `conversation.input.right` 中的原生控件与贡献项；
 - 后续新增的 `conversation.input.*` 或 `composer.*` 槽位中的按钮型贡献；
 - 通过 `data-plugin`、`data-plugin-id`、`data-extension`、`data-extension-id` 或 `data-contribution` 标记的嵌套按钮贡献；
 - 已确认 Composer 工具栏中的无标记按钮，作为可手动选择的集成项。
 
 发现范围始终限制在已确认的输入区或 Composer 表面内。文本/搜索输入框、`textarea`、`contenteditable` 区域和 ARIA 文本框永远不会被收纳，即使它们带有插件标记。Composer 之外的搜索、设置和普通表单控件不会被扫描。
 
-默认收起左侧插件控件和 WebUI 团队模式选择器。原生工具、权限控件、模型控件以及发送/停止按钮保持原位。现有控件仍由原来的 React 父节点管理；适配器只修改展示属性与样式，不会把节点移动到其他父节点。
+默认收起左侧插件控件和 WebUI 团队模式选择器。模型选择器始终使用宿主原生控件并保持原位；原生工具、权限控件以及发送/停止按钮也保持原位。现有控件仍由原来的 React 父节点管理；适配器只修改展示属性与样式，不会把节点移动到其他父节点。
 
 打开 DSH 设置并选择“输入灵动岛”，即可调整检测到的控件。选择会立即生效并保存在浏览器本地存储中。鼠标悬停或键盘聚焦三点按钮时打开灵动岛；在触摸设备上可点击固定；移开后关闭；按 Escape 可关闭并恢复焦点。
 

--- a/assets/plugins/dsh-composer-dynamic-island/lib/client.js
+++ b/assets/plugins/dsh-composer-dynamic-island/lib/client.js
@@ -14,7 +14,6 @@ window.__ModuleLoader__.load({
     const ITEM_ATTR = "data-dsh-island-item";
     const LEFT_SLOT = "conversation.input.left";
     const RIGHT_SLOT = "conversation.input.right";
-    const MODEL_SLOT = "conversation.input.model";
     const STORE_KEY = "dsh-composer-dynamic-island-config-v1";
     const MAX_PANEL_WIDTH = 520;
     const BUTTON_CONTROL_SELECTOR = 'button,[role="button"],input[type="button"],input[type="submit"],input[type="reset"]';
@@ -31,10 +30,9 @@ window.__ModuleLoader__.load({
       team: "团队模式",
       extension: "输入区插件",
       right: "右侧插件",
-      model: "模型控件",
       action: "发送操作",
     };
-    const ZONE_ORDER = ["native", "left", "team", "extension", "right", "model", "action"];
+    const ZONE_ORDER = ["native", "left", "team", "extension", "right", "action"];
 
     const CSS = [
       "[data-dsh-island-row]{position:relative!important;flex-wrap:nowrap!important;gap:8px!important;min-height:36px!important;isolation:isolate}",
@@ -314,7 +312,6 @@ window.__ModuleLoader__.load({
     function inputSlotZone(slotName) {
       if (slotName === LEFT_SLOT) return "left";
       if (slotName === RIGHT_SLOT) return "right";
-      if (slotName === MODEL_SLOT) return "model";
       return "extension";
     }
 
@@ -334,14 +331,13 @@ window.__ModuleLoader__.load({
         .filter((slot) => slot instanceof HTMLElement && INPUT_SLOT_PATTERN.test(slot.getAttribute("data-slot") ?? ""));
       const leftSlot = inputSlots.find((slot) => slot.getAttribute("data-slot") === LEFT_SLOT) ?? null;
       const rightSlot = inputSlots.find((slot) => slot.getAttribute("data-slot") === RIGHT_SLOT) ?? null;
-      const modelSlot = inputSlots.find((slot) => slot.getAttribute("data-slot") === MODEL_SLOT) ?? null;
       const modes = directElementChildren(tools).find((child) => child !== leftSlot
         && child.getAttribute("data-slot") === null
         && !child.matches(PLUGIN_MARKER_SELECTOR)
         && child.querySelector(PLUGIN_MARKER_SELECTOR) === null
         && buttonControlOf(child) === null
         && /(?:^|[-_])(mode|modes)(?:[-_]|$)/i.test(child.className)) ?? null;
-      return { card, row, tools, trailing, modes, leftSlot, rightSlot, modelSlot, inputSlots };
+      return { card, row, tools, trailing, modes, leftSlot, rightSlot, inputSlots };
     }
 
     function fixedPositionIsReliable(node) {
@@ -398,6 +394,9 @@ window.__ModuleLoader__.load({
       // composer.* slots become available without another hard-coded branch.
       for (const slot of parts.inputSlots) {
         const slotName = slot.getAttribute("data-slot") ?? "";
+        // The host's model selector is a native control owned by WebUI. Keep it
+        // in its original React tree instead of collapsing or restyling it.
+        if (slotName === "conversation.input.model") continue;
         const zone = inputSlotZone(slotName);
         for (const child of directElementChildren(slot)) {
           const resolvedZone = child.classList.contains("team-seat") ? "team" : zone;

--- a/scripts/migrate-plugin-interfaces.mjs
+++ b/scripts/migrate-plugin-interfaces.mjs
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto';
 import { migrateProviderSettingsClient } from './lib/migrate-provider-settings.mjs';
 import { migrateWebuiChatRenderers } from './webui-chat-compat.mjs';
 import { migrateWebuiPromptOptimize } from './webui-prompt-optimize-compat.mjs';
+import { migrateWebuiNativeModelSelection } from './webui-native-model-selection-compat.mjs';
 import { migrateWebuiContinue } from './webui-continue-compat.mjs';
 import { migrateWebuiInputChatToolShapes } from './webui-input-chat-tool-compat.mjs';
 import { fileURLToPath } from 'node:url';
@@ -170,6 +171,133 @@ function migrateTypes(text, providers, changes, file) {
     });
 }
 
+// The reviewed WebUI bundle keeps its markdown parser and math nodes, but the
+// public extraction replaces the browser KaTeX module with a throwing stub.
+// KaTeX is still a declared runtime dependency, so restore the same lazy
+// renderer fallback used by the upstream markstream worker path.
+export function migrateWebuiKatexFallback(text) {
+  // The public WebUI bundle has its KaTeX runtime stripped. The staging patch
+  // inlines the audited KaTeX distribution into these two lazy initializers;
+  // keep the renderer independent from native ESM and the host module table.
+  const newLoader = 'return er = await Promise.resolve().then(() => (init_katex_stub(), init__webui_katex_mhchem_stub(), katex_stub_exports)), er;';
+  const previousLoader = 'return er = await import("katex"), await import("katex/contrib/mhchem"), er;';
+  const previousRequireLoader = 'return er = await Promise.resolve().then(() => { const runtime = require("katex"); require("katex/contrib/mhchem"); return runtime?.default ?? runtime; }), er;';
+  if (text.includes(newLoader) && !text.includes('katex disabled in webui')) {
+    return migrateWebuiMathDelimiters(text);
+  }
+  if (text.includes(previousLoader) && !text.includes('katex disabled in webui')) {
+    return migrateWebuiMathDelimiters(text.replace(previousLoader, newLoader));
+  }
+  if (text.includes(previousRequireLoader) && !text.includes('katex disabled in webui')) {
+    return migrateWebuiMathDelimiters(text.replace(previousRequireLoader, newLoader));
+  }
+  const marker = '//#region src/client/markdown/katex-stub.ts';
+  const start = text.indexOf(marker);
+  const end = text.indexOf('//#endregion', start);
+  if (start < 0 || end < start || text.indexOf(marker, start + marker.length) >= 0) {
+    throw new Error('Unknown reviewed WebUI KaTeX stub region');
+  }
+  const regionEnd = end + '//#endregion'.length;
+  const original = text.slice(start, regionEnd);
+  const newline = original.includes('\r\n') ? '\r\n' : '\n';
+  const replacement = [
+    marker,
+    'var katex_stub_exports = /* @__PURE__ */ __exportAll({});',
+    'var init_katex_stub = __esmMin((() => {}));',
+    '//#endregion',
+  ].join('\n');
+  let output = text.slice(0, start) + replacement.replaceAll('\n', newline) + text.slice(regionEnd);
+  const oldLoader = 'return er = await Promise.resolve().then(() => (init_katex_stub(), katex_stub_exports)), await Promise.resolve().then(() => (init__webui_katex_mhchem_stub(), _webui_katex_mhchem_stub_exports)), er;';
+  if (output.split(oldLoader).length !== 2) {
+    throw new Error('Unknown reviewed WebUI KaTeX loader');
+  }
+  output = output.replace(oldLoader, newLoader);
+  return migrateWebuiMathDelimiters(output);
+}
+
+export function migrateWebuiMathDelimiters(text) {
+  const idempotenceMarker = 'const mathFence = (state, startLine, endLine, silent) => {';
+  if (text.includes(idempotenceMarker)) return text;
+  const anchor = 'const explicitMathBlockBeforeSetext = (state, startLine, endLine, silent) => {';
+  const anchorIndex = text.indexOf(anchor);
+  if (anchorIndex < 0 || text.indexOf(anchor, anchorIndex + anchor.length) >= 0) {
+    throw new Error('Unknown reviewed WebUI math block boundary');
+  }
+  const injected = `const mathFence = (state, startLine, endLine, silent) => {
+				const s = state;
+				const startPos = s.bMarks[startLine] + s.tShift[startLine];
+				const lineText = s.src.slice(startPos, s.eMarks[startLine]).trim();
+				const opener = lineText.match(/^(?:\\x60{3,}|~{3,})\\s*(?:math|latex|tex)(?:\\s+.*)?$/i);
+				if (!opener) return false;
+				const marker = opener[1][0];
+				const markerLength = opener[1].length;
+				let nextLine = startLine + 1;
+				let content = '';
+				let found = false;
+				for (; nextLine < endLine; nextLine++) {
+					const lineStart = s.bMarks[nextLine] + s.tShift[nextLine];
+					const current = s.src.slice(lineStart, s.eMarks[nextLine]);
+					if (new RegExp('^\\\\s*' + marker + '{' + markerLength + ',}\\\\s*$').test(current)) {
+						found = true;
+						break;
+					}
+					content += (content ? '\\n' : '') + current;
+				}
+				if (!found) return false;
+				if (silent) return true;
+				const token = s.push('math_block', 'math', 0);
+				token.content = normalizeStandaloneBackslashT(content);
+				token.markup = 'fence';
+				token.raw = s.src.slice(startPos, s.eMarks[nextLine] || s.eMarks[startLine]);
+				token.map = [startLine, nextLine + 1];
+				token.block = true;
+				token.loading = false;
+				s.line = nextLine + 1;
+				return true;
+			};
+			const mathEnvironmentBlock = (state, startLine, endLine, silent) => {
+				const s = state;
+				const startPos = s.bMarks[startLine] + s.tShift[startLine];
+				const firstLine = s.src.slice(startPos, s.eMarks[startLine]);
+				const opener = firstLine.match(/^\\\\begin\\{([^{}\\n]+)\\}/);
+				if (!opener) return false;
+				const environment = opener[1];
+				const closeRe = new RegExp('^\\\\s*\\\\end\\\\{' + environment.replace(/[.*+?^()|[\\]\\\\]/g, '\\\\$&') + '\\\\}\\\\s*$');
+				let nextLine = startLine;
+				let content = '';
+				let found = false;
+				for (; nextLine < endLine; nextLine++) {
+					const lineStart = s.bMarks[nextLine] + s.tShift[nextLine];
+					const current = s.src.slice(lineStart, s.eMarks[nextLine]);
+					if (nextLine > startLine && closeRe.test(current)) {
+						found = true;
+						break;
+					}
+					content += (content ? '\\n' : '') + current;
+				}
+				if (!found) return false;
+				if (silent) return true;
+				const token = s.push('math_block', 'math', 0);
+				token.content = normalizeStandaloneBackslashT(content);
+				token.markup = 'environment';
+				token.raw = s.src.slice(startPos, s.eMarks[nextLine]);
+				token.map = [startLine, nextLine + 1];
+				token.block = true;
+				token.loading = false;
+				s.line = nextLine + 1;
+				return true;
+			};
+			`;
+  const next = text.slice(0, anchorIndex) + injected.replaceAll('\n', text.includes('\r\n') ? '\r\n' : '\n') + text.slice(anchorIndex);
+  const registration = 'md.inline.ruler.before("escape", "math", mathInline);';
+  const registrationIndex = next.indexOf(registration);
+  if (registrationIndex < 0 || next.indexOf(registration, registrationIndex + registration.length) >= 0) {
+    throw new Error('Unknown reviewed WebUI math plugin registration');
+  }
+  return next.replace(registration,
+    `${registration}\n\t\t\tmd.block.ruler.before("fence", "math_fence", mathFence);\n\t\t\tmd.block.ruler.before("paragraph", "math_environment", mathEnvironmentBlock);`);
+}
+
 /**
  * Plan, or apply with { write: true }, interface-only changes to a reviewed
  * extraction. Unknown identities/content throw before writes. Known unresolved
@@ -273,8 +401,10 @@ export function transformPluginInterfaces(packageDirectory, { stage, write = fal
       text = migrateProviderSettingsClient(text);
       text = migrateWebuiChatRenderers(text);
       text = migrateWebuiPromptOptimize(text);
+      text = migrateWebuiNativeModelSelection(text);
       text = migrateWebuiContinue(text);
       text = migrateWebuiInputChatToolShapes(text);
+      text = migrateWebuiKatexFallback(text);
       changes.push({ file, kind: 'slot-props', from: 'session chat/input snapshots',
         to: 'useChat/useInput' });
       changes.push({ file, kind: 'provider-settings-api', from: 'connection.api',

--- a/scripts/patch-status-rotator.mjs
+++ b/scripts/patch-status-rotator.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import { migrateStatusRotator } from './status-rotator-compat.mjs';
+
+const target = process.argv[2];
+if (!target) throw new Error('usage: node patch-status-rotator.mjs <client.js>');
+
+const source = fs.readFileSync(target, 'utf8');
+const patched = migrateStatusRotator(source);
+const changed = patched !== source;
+if (changed) fs.writeFileSync(target, patched);
+
+console.log(JSON.stringify({
+  target,
+  changed,
+  pillDisabled: patched.includes('AIO disables the optional status-rotator Pill.') &&
+    patched.includes('cfg.pill = { ...(cfg.pill || {}), enabled: false };'),
+}));

--- a/scripts/patch-webui-continue.mjs
+++ b/scripts/patch-webui-continue.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import { migrateWebuiContinue } from './webui-continue-compat.mjs';
+
+const target = process.argv[2];
+if (!target) throw new Error('usage: node patch-webui-continue.mjs <client.js>');
+
+const source = fs.readFileSync(target, 'utf8');
+const patched = migrateWebuiContinue(source);
+const changed = patched !== source;
+if (changed) fs.writeFileSync(target, patched);
+
+console.log(JSON.stringify({
+  target,
+  changed,
+  readableStats: patched.includes('const formatStat = (key, values) => {'),
+  rawSpeedRemoved: !patched.includes('stats.tokensPerSecond'),
+}));

--- a/scripts/patch-webui-katex.mjs
+++ b/scripts/patch-webui-katex.mjs
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { migrateWebuiKatexFallback } from './migrate-plugin-interfaces.mjs';
+
+const target = path.resolve(process.argv[2] || '');
+if (!target || !fs.existsSync(target)) throw new Error(`WebUI client not found: ${target}`);
+
+function readFirstExisting(candidates, label) {
+  const file = candidates.find(candidate => fs.existsSync(candidate));
+  if (!file) throw new Error(`WebUI KaTeX ${label} not found; checked: ${candidates.join(', ')}`);
+  return { file, text: fs.readFileSync(file, 'utf8') };
+}
+
+function inlineKaTeXRuntime(text) {
+  const marker = '//#region src/client/markdown/katex-stub.ts';
+  const start = text.indexOf(marker);
+  const end = text.indexOf('//#endregion', start);
+  if (start < 0 || end < start || text.indexOf(marker, start + marker.length) >= 0) {
+    throw new Error('Unknown staged WebUI KaTeX stub region');
+  }
+  const regionEnd = end + '//#endregion'.length;
+  const original = text.slice(start, regionEnd);
+  const newline = original.includes('\r\n') ? '\r\n' : '\n';
+  const packageRoot = path.resolve(path.dirname(target), '..');
+  const katexRoot = path.join(packageRoot, 'node_modules', 'katex');
+  const fallbackRoot = path.resolve(packageRoot, '..', '..', 'katex');
+  const roots = [katexRoot, fallbackRoot];
+  const katex = readFirstExisting(roots.map(root => path.join(root, 'dist', 'katex.min.js')), 'runtime');
+  const mhchem = readFirstExisting(roots.map(root => path.join(root, 'dist', 'contrib', 'mhchem.min.js')), 'mhchem runtime');
+  const css = readFirstExisting(roots.map(root => path.join(root, 'dist', 'katex.min.css')), 'stylesheet');
+
+  const cssText = JSON.stringify(css.text);
+  const replacement = [
+    marker,
+    'var katex_stub_exports = {};',
+    'var init_katex_stub = __esmMin((() => {',
+    '  const localModule = { exports: {} };',
+    '  const localExports = localModule.exports;',
+    '  (function(module, exports, require) {',
+    katex.text,
+    '  })(localModule, localExports, () => { throw new Error("KaTeX has no runtime dependency"); });',
+    '  const runtime = localModule.exports?.default ?? localModule.exports;',
+    '  Object.assign(katex_stub_exports, runtime);',
+    `  if (typeof document !== "undefined" && !document.querySelector("style[data-dsh-aio-katex]")) { const style = document.createElement("style"); style.setAttribute("data-dsh-aio-katex", "true"); style.textContent = ${cssText}; document.head.append(style); }`,
+    '}));',
+    '//#endregion',
+  ].join('\n');
+
+  const mhchemMarker = '//#region \\0webui-katex-mhchem-stub';
+  const mhchemStart = text.indexOf(mhchemMarker);
+  const mhchemEnd = text.indexOf('//#endregion', mhchemStart);
+  if (mhchemStart < 0 || mhchemEnd < mhchemStart || text.indexOf(mhchemMarker, mhchemStart + mhchemMarker.length) >= 0) {
+    throw new Error('Unknown staged WebUI mhchem stub region');
+  }
+  const mhchemRegionEnd = mhchemEnd + '//#endregion'.length;
+  const mhchemReplacement = [
+    mhchemMarker,
+    'var _webui_katex_mhchem_stub_exports = {};',
+    'var init__webui_katex_mhchem_stub = __esmMin((() => {',
+    '  const localModule = { exports: {} };',
+    '  const localExports = localModule.exports;',
+    '  (function(module, exports, require) {',
+    mhchem.text,
+    '  })(localModule, localExports, (specifier) => { if (specifier === "katex") return katex_stub_exports; throw new Error(`Unknown KaTeX dependency: ${specifier}`); });',
+    '  Object.assign(_webui_katex_mhchem_stub_exports, localModule.exports?.default ?? localModule.exports);',
+    '}));',
+    '//#endregion',
+  ].join('\n');
+
+  let output = text.slice(0, start) + replacement.replaceAll('\n', newline) + text.slice(regionEnd);
+  const offset = output.length - text.length;
+  const shiftedMhchemStart = mhchemStart >= regionEnd ? mhchemStart + offset : mhchemStart;
+  const shiftedMhchemEnd = mhchemEnd >= regionEnd ? mhchemEnd + offset : mhchemEnd;
+  const shiftedMhchemRegionEnd = shiftedMhchemEnd + '//#endregion'.length;
+  output = output.slice(0, shiftedMhchemStart) + mhchemReplacement.replaceAll('\n', newline) + output.slice(shiftedMhchemRegionEnd);
+  return output;
+}
+
+const original = fs.readFileSync(target, 'utf8');
+let patched = migrateWebuiKatexFallback(original);
+if (!patched.includes('data-dsh-aio-katex')) patched = inlineKaTeXRuntime(patched);
+if (patched !== original) fs.writeFileSync(target, patched, 'utf8');
+console.log(JSON.stringify({ target, changed: patched !== original, embedded: patched.includes('data-dsh-aio-katex') }));

--- a/scripts/patch-webui-layout.mjs
+++ b/scripts/patch-webui-layout.mjs
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import { migrateWebuiLayout } from './webui-layout-compat.mjs';
+
+const target = process.argv[2];
+if (!target) throw new Error('usage: node patch-webui-layout.mjs <client.js>');
+
+const source = fs.readFileSync(target, 'utf8');
+const patched = migrateWebuiLayout(source);
+const changed = patched !== source;
+if (changed) fs.writeFileSync(target, patched);
+
+console.log(JSON.stringify({
+  target,
+  changed,
+  usageNavigation: patched.includes('children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(UsageWorkbenchEntry, {})'),
+}));

--- a/scripts/patch-webui-native-model-selection.mjs
+++ b/scripts/patch-webui-native-model-selection.mjs
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import { migrateWebuiNativeModelSelection } from './webui-native-model-selection-compat.mjs';
+
+const target = process.argv[2];
+if (!target) throw new Error('usage: node patch-webui-native-model-selection.mjs <client.js>');
+
+const source = fs.readFileSync(target, 'utf8');
+const patched = migrateWebuiNativeModelSelection(source);
+const changed = patched !== source;
+if (changed) fs.writeFileSync(target, patched);
+
+console.log(JSON.stringify({ target, changed, nativeModelSelection: patched.includes('AIO keeps provider/model selection in the host native control.') }));

--- a/scripts/patch-webui-prompt-optimize.mjs
+++ b/scripts/patch-webui-prompt-optimize.mjs
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import { migrateWebuiPromptOptimize } from './webui-prompt-optimize-compat.mjs';
+
+const target = process.argv[2];
+if (!target) throw new Error('usage: node patch-webui-prompt-optimize.mjs <client.js>');
+
+const source = fs.readFileSync(target, 'utf8');
+const patched = migrateWebuiPromptOptimize(source);
+const changed = patched !== source;
+if (changed) fs.writeFileSync(target, patched);
+
+console.log(JSON.stringify({ target, changed, promptOptimize: patched.includes('const mountPromptOptimize = () => {') }));

--- a/scripts/prepare-aio-staged-seed.mjs
+++ b/scripts/prepare-aio-staged-seed.mjs
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { installWebuiUsageHost } from './webui-usage-host-compat.mjs';
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(path.join(repo, 'package.json'));
+const yaml = require('js-yaml');
+
+const profile = path.resolve(process.argv[2] || '');
+if (!profile || !fs.existsSync(path.join(profile, 'package.json'))) {
+  throw new Error('staged web profile is required');
+}
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(profile, 'package.json'), 'utf8'));
+const modules = path.join(profile, 'node_modules');
+const patchFile = path.join(profile, 'cordis.patch.yml');
+const patch = yaml.load(fs.readFileSync(patchFile, 'utf8')) || [];
+const builtinNames = new Set(fs.readdirSync(path.join(repo, 'assets', 'plugins'), { withFileTypes: true })
+  .filter(entry => entry.isDirectory()).map(entry => entry.name));
+const dependencies = new Set(Object.keys(packageJson.dependencies || {}));
+const packageDirectory = name => path.join(modules, ...name.split('/'));
+const hasPackage = name => dependencies.has(name) || fs.existsSync(packageDirectory(name));
+
+let removed = [];
+const filtered = patch.flatMap(entry => {
+  if (!entry || !Array.isArray(entry.insert)) return [entry];
+  const insert = entry.insert.filter(item => {
+    if (!item || typeof item.name !== 'string') return true;
+    const shortName = item.name.startsWith('@') ? item.name.split('/')[1] : item.name;
+    const known = hasPackage(item.name) || builtinNames.has(shortName);
+    if (!known) removed.push(`${item.id || '(anonymous)'}:${item.name}`);
+    return known;
+  });
+  return insert.length ? [{ ...entry, insert }] : [];
+});
+
+if (removed.length) {
+  fs.writeFileSync(patchFile, yaml.dump(filtered, {
+    noRefs: true,
+    lineWidth: -1,
+    noCompatMode: true,
+  }), 'utf8');
+}
+
+const webui = path.join(modules, '@dsh-external', 'dsh-webui');
+const usageHost = await installWebuiUsageHost(webui);
+console.log(JSON.stringify({
+  patchFile,
+  removed,
+  usageHost: usageHost.directory,
+  usageHostChanged: usageHost.changed,
+}));

--- a/scripts/status-rotator-compat.mjs
+++ b/scripts/status-rotator-compat.mjs
@@ -1,0 +1,16 @@
+// AIO intentionally does not show the optional bottom-right live status pill.
+// This must win over old localStorage/config.json overrides in existing profiles.
+const marker = '// AIO disables the optional status-rotator Pill.';
+const old = '\t\t\t\tconfig = cfg;';
+const replacement = `${marker}\n\t\t\t\tcfg.pill = { ...(cfg.pill || {}), enabled: false };\n\t\t\t\tconfig = cfg;`;
+
+export function migrateStatusRotator(source) {
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  let output = source.replace(/\r\n/g, '\n');
+  if (output.includes(marker)) return newline === '\n' ? output : output.replace(/\n/g, newline);
+  if (output.split(old).length !== 2) {
+    throw new Error('Unrecognized status-rotator effective config boundary');
+  }
+  output = output.replace(old, replacement);
+  return newline === '\n' ? output : output.replace(/\n/g, newline);
+}

--- a/scripts/verify-aio-installer.ps1
+++ b/scripts/verify-aio-installer.ps1
@@ -84,6 +84,24 @@ function Get-ListenerPid([int]$Port) {
     return 0
 }
 
+function Mark-CleanExit([string]$StateFile) {
+    if (-not (Test-Path -LiteralPath $StateFile)) { return }
+    try {
+        $state = Get-Content -Raw -LiteralPath $StateFile -Encoding UTF8 | ConvertFrom-Json
+        $state.cleanExit = $true
+        $endedAt = (Get-Date).ToUniversalTime().ToString('o')
+        if ($null -eq $state.PSObject.Properties['endedAt']) {
+            $state | Add-Member -NotePropertyName endedAt -NotePropertyValue $endedAt
+        } else {
+            $state.endedAt = $endedAt
+        }
+        $utf8 = New-Object System.Text.UTF8Encoding($false)
+        [IO.File]::WriteAllText($StateFile, ($state | ConvertTo-Json -Compress), $utf8)
+    } catch {
+        Write-Warning "Unable to mark the test instance for clean shutdown: $($_.Exception.Message)"
+    }
+}
+
 function Test-ProcessInTree([int]$CandidatePid, [int]$RootPid) {
     if ($CandidatePid -le 0 -or $RootPid -le 0) { return $false }
     $seen = @{}
@@ -229,7 +247,6 @@ try {
         $deadline = [DateTime]::UtcNow.AddSeconds($StartupTimeoutSeconds)
         while ([DateTime]::UtcNow -lt $deadline) {
             Start-Sleep -Milliseconds 400
-            if ($appProcess.HasExited) { break }
             if (Test-Path -LiteralPath $settingsJson) {
                 try {
                     $settings = Get-Content -Raw -LiteralPath $settingsJson | ConvertFrom-Json
@@ -264,6 +281,7 @@ try {
                     if (Test-ProcessInTree $listenerPid $appProcess.Id) { break }
                 }
             }
+            if ($appProcess.HasExited) { break }
         }
         $startTimer.Stop()
         if ($appProcess.HasExited) { throw "GUI exited early with code $($appProcess.ExitCode)." }
@@ -315,7 +333,7 @@ try {
         }
         $profilePatchText = Get-Content -Raw -LiteralPath (Join-Path $isolatedHome 'profiles\web-desktop\cordis.patch.yml')
         $islandPatchRows = [regex]::Matches($profilePatchText, '(?m)^\s*- id: composer-dynamic-island\s*$').Count
-        if ($islandPatchRows -ne 1 -or $profilePatchText -notmatch "(?m)^\s*name: 'dsh-composer-dynamic-island'\s*$") {
+        if ($islandPatchRows -ne 1 -or $profilePatchText -notmatch '(?m)^\s*name:\s*[''\"]?dsh-composer-dynamic-island[''\"]?\s*$') {
             throw "Composer Dynamic Island profile patch is missing or duplicated (rows=$islandPatchRows)."
         }
         $builtinMarker = Get-Content -Raw -LiteralPath (Join-Path $isolatedHome 'profiles\web-desktop\.dsh-builtin-plugins.json') | ConvertFrom-Json
@@ -377,8 +395,167 @@ try {
         } else {
             $report.originalLite.status = 'N/A - original Lite was not running'
         }
+
+        # The kernel creates the <home>/profiles/node_modules shared dependency layer
+        # during the first launch, so only a second launch exercises the profile gate
+        # against those kernel-generated links. Without this step an install that
+        # passes first-run acceptance can still be blocked on every later start.
+        $stage = 'restart'
+        Write-Host '[5b/7] Restarting the GUI to verify the profile gate accepts kernel-generated links...'
+        # Capture the baseline before stopping the first process. The watchdog may
+        # append a fresh startup sequence while the process tree is winding down.
+        $restartMarker = ([regex]::Matches(((Get-Content -LiteralPath $desktopLog -Encoding UTF8 -Tail 400 -ErrorAction SilentlyContinue) -join "`n"), 'dsh web:')).Count
+        $restartLogLineCount = @((Get-Content -LiteralPath $desktopLog -Encoding UTF8 -ErrorAction SilentlyContinue)).Count
+        $restartBaselineListenerPid = $listenerPid
+        Mark-CleanExit (Join-Path $isolatedUserData 'run-state.json')
+        & "$env:SystemRoot\System32\taskkill.exe" /PID $appProcess.Id /T /F | Out-Null
+        $appProcess.WaitForExit(15000) | Out-Null
+        Start-Sleep -Seconds 3
+        $appProcess = Start-Process -FilePath $appExe -WorkingDirectory $installRoot -PassThru -WindowStyle Hidden
+        $restartTimer = [Diagnostics.Stopwatch]::StartNew()
+        $restartDeadline = [DateTime]::UtcNow.AddSeconds($StartupTimeoutSeconds)
+        $restartReady = $false
+        $restartTail = ''
+        $restartBootCount = 0
+        $restartReadyCount = 0
+        $restartWebReadyCount = 0
+        $rawBootCount = 0
+        $rawReadyCount = 0
+        $rawWebReadyCount = 0
+        while ([DateTime]::UtcNow -lt $restartDeadline) {
+            Start-Sleep -Milliseconds 500
+            try {
+                $restartLines = @(Get-Content -LiteralPath $desktopLog -Encoding UTF8 -ErrorAction Stop)
+                $restartTail = ($restartLines | Select-Object -Last 400) -join "`n"
+                $restartNewLines = if ($restartLines.Count -gt $restartLogLineCount) {
+                    $restartLines | Select-Object -Skip $restartLogLineCount
+                } else {
+                    @()
+                }
+                $restartNewLog = $restartNewLines -join "`n"
+            } catch {
+                $restartNewLog = ''
+            }
+            if ($restartNewLog -match 'profile 迁移/同步失败') { break }
+            if ($restartNewLog -match 'dsh web:' -and $restartNewLog -match 'http://127\.0\.0\.1:\d+/') {
+                $restartReady = $true
+                break
+            }
+            # Keep the count-based fallback for log rotation or a watchdog that
+            # rewrites the file instead of appending to it.
+            if ($restartNewLog -eq '' -and ([regex]::Matches($restartTail, 'dsh web:')).Count -gt $restartMarker) {
+                $restartReady = $true
+                break
+            }
+            # The running GUI may keep the log handle open while its child web
+            # server is already healthy. Accept a new listener on the same
+            # port after the old listener has gone away; the log checks above
+            # remain the preferred path when the file is readable.
+            if ($webPort -gt 0) {
+                $restartListenerPid = Get-ListenerPid $webPort
+                if ($restartListenerPid -gt 0 -and $restartListenerPid -ne $restartBaselineListenerPid) {
+                    $restartProbe = Test-HttpReady "http://127.0.0.1:$webPort/" 1
+                    if ($restartProbe.ok) {
+                        $restartReady = $true
+                        break
+                    }
+                }
+            }
+            # The watchdog can replace the explicitly launched process after a
+            # clean tree shutdown. Keep waiting for the new boot marker instead
+            # of treating that handoff as a failed restart.
+            if ($appProcess.HasExited) { continue }
+        }
+        $restartTimer.Stop()
+        if (-not $restartReady) {
+            try {
+                # Read the complete log for the final decision. The watchdog can
+                # append a second boot while the tail is being rotated, so a
+                # bounded tail is not a reliable acceptance source here.
+                $restartFullLog = Get-Content -LiteralPath $desktopLog -Encoding UTF8 -Raw -ErrorAction Stop
+                $restartTail = $restartFullLog
+            } catch {}
+            # A clean shutdown can hand control to the watchdog before the
+            # explicitly launched process returns. In that path the log may be
+            # rewritten between reads, so the incremental-line check can miss
+            # the handoff even though a complete second boot is present.
+            $restartBootCount = ([regex]::Matches($restartTail, 'DSHEAC AIO v')).Count
+            $restartReadyCount = ([regex]::Matches($restartTail, 'dsh web:')).Count
+            $restartWebReadyCount = ([regex]::Matches($restartTail, 'http://127\.0\.0\.1:\d+/')).Count
+            if ($restartBootCount -ge 2 -and $restartWebReadyCount -ge 2) {
+                $restartReady = $true
+            }
+            $report.startup.restartDiagnostics = [ordered]@{
+                bootMarkers = $restartBootCount
+                webReadyMarkers = $restartWebReadyCount
+                startupCompleteMarkers = $restartReadyCount
+            }
+        }
+        if (-not $restartReady) {
+            # Last-chance acceptance uses the raw file API so a transient
+            # Get-Content read/rotation issue cannot hide a completed boot.
+            try {
+                $restartRawLog = [System.IO.File]::ReadAllText($desktopLog)
+                $rawBootCount = ([regex]::Matches($restartRawLog, 'DSHEAC AIO v')).Count
+                $rawReadyCount = ([regex]::Matches($restartRawLog, 'dsh web:')).Count
+                $rawWebReadyCount = ([regex]::Matches($restartRawLog, 'http://127\.0\.0\.1:\d+/')).Count
+                $report.startup.restartDiagnostics = [ordered]@{
+                    bootMarkers = $rawBootCount
+                    webReadyMarkers = $rawWebReadyCount
+                    startupCompleteMarkers = $rawReadyCount
+                }
+                if ($rawBootCount -ge 2 -and $rawWebReadyCount -ge 2) {
+                    $restartReady = $true
+                    $restartTail = $restartRawLog
+                }
+            } catch {}
+        }
+        if (-not $restartReady) {
+            # The running shell can hold the desktop log without read sharing.
+            # Stop this already-probed second launch, then perform one final
+            # whole-file check before declaring the restart unhealthy.
+            try {
+                if ($null -ne $appProcess -and -not $appProcess.HasExited) {
+                    Mark-CleanExit (Join-Path $isolatedUserData 'run-state.json')
+                    & "$env:SystemRoot\System32\taskkill.exe" /PID $appProcess.Id /T /F | Out-Null
+                    $appProcess.WaitForExit(15000) | Out-Null
+                    Start-Sleep -Milliseconds 500
+                }
+                $restartRawLog = [System.IO.File]::ReadAllText($desktopLog)
+                $rawBootCount = ([regex]::Matches($restartRawLog, 'DSHEAC AIO v')).Count
+                $rawReadyCount = ([regex]::Matches($restartRawLog, 'dsh web:')).Count
+                $rawWebReadyCount = ([regex]::Matches($restartRawLog, 'http://127\.0\.0\.1:\d+/')).Count
+                $report.startup.restartDiagnostics = [ordered]@{
+                    bootMarkers = $rawBootCount
+                    webReadyMarkers = $rawWebReadyCount
+                    startupCompleteMarkers = $rawReadyCount
+                }
+                if ($rawBootCount -ge 2 -and $rawWebReadyCount -ge 2) {
+                    $restartReady = $true
+                    $restartTail = $restartRawLog
+                }
+            } catch {}
+        }
+        if (-not $restartReady) {
+            if ($restartTail -match 'profile 迁移/同步失败') { throw 'The second launch was blocked by the profile upgrade gate.' }
+            throw "The GUI did not reach a healthy second launch. Diagnostics: boot=$restartBootCount/$rawBootCount web=$restartWebReadyCount/$rawWebReadyCount complete=$restartReadyCount/$rawReadyCount"
+        }
+        $restartReadyMatches = [regex]::Matches($restartTail, 'http://127\.0\.0\.1:(\d+)/')
+        if ($restartReadyMatches.Count -gt 0) {
+            $webPort = [int]$restartReadyMatches[$restartReadyMatches.Count - 1].Groups[1].Value
+            $listenerPid = Get-ListenerPid $webPort
+            $report.startup.webPort = $webPort
+            $report.startup.listenerPid = $listenerPid
+        }
+        $report.startup.restart = [ordered]@{
+            elapsedMs = $restartTimer.ElapsedMilliseconds
+            appPid = $appProcess.Id
+            webPort = $webPort
+            profileGatePassed = $true
+        }
     } finally {
         if ($null -ne $appProcess -and -not $appProcess.HasExited) {
+            Mark-CleanExit (Join-Path $isolatedUserData 'run-state.json')
             & "$env:SystemRoot\System32\taskkill.exe" /PID $appProcess.Id /T /F | Out-Null
             $appProcess.WaitForExit(15000) | Out-Null
         }
@@ -449,6 +626,7 @@ try {
     }
 } finally {
     if ($null -ne $appProcess -and -not $appProcess.HasExited) {
+        Mark-CleanExit (Join-Path $isolatedUserData 'run-state.json')
         try { & "$env:SystemRoot\System32\taskkill.exe" /PID $appProcess.Id /T /F | Out-Null } catch {}
     }
     $report.logs = [ordered]@{

--- a/scripts/webui-continue-compat.mjs
+++ b/scripts/webui-continue-compat.mjs
@@ -13,6 +13,20 @@ const newFace = `const session = props.useSession((snapshot) => snapshot);
 \t\t\tconst faceRef = (0, react.useRef)(face);
 \t\t\tfaceRef.current = face;`;
 
+const statsFallback = `\t\t\tconst formatStat = (key, values) => {
+\t\t\t\tconst translated = t(key, values);
+\t\t\t\tif (typeof translated === "string" && !translated.startsWith("stats.")) return translated;
+\t\t\t\tconst fallback = {
+\t\t\t\t\t"stats.counts": () => \`\${values.turns} 轮 · \${values.steps} 步\`,
+\t\t\t\t\t"stats.llm": () => \`LLM \${values.duration}\`,
+\t\t\t\t\t"stats.toolCall": () => \`工具调用 \${values.duration}\`,
+\t\t\t\t\t"stats.ttftAverage": () => \`首 token 平均 \${values.duration}\`,
+\t\t\t\t\t"stats.cacheHit": () => \`缓存命中 \${values.percent}%\`,
+\t\t\t\t\t"stats.tokens": () => \`输入 \${values.input} tok · 输出 \${values.output} tok\`
+\t\t\t\t}[key];
+\t\t\t\treturn fallback === void 0 ? translated : fallback();
+\t\t\t};`;
+
 function replaceRegion(source, start, replacements) {
   const from = source.indexOf(start);
   const to = source.indexOf('//#endregion', from);
@@ -34,9 +48,21 @@ function replaceRegion(source, start, replacements) {
 
 export function migrateWebuiContinue(source) {
   let output = replaceRegion(source, 'function ComposerContinueEnhancer(props)', [[oldFace, newFace]]);
-  output = replaceRegion(output, 'const StatsLineShadow = ', [
+  const statsReplacements = [
     ['StatsLineShadow({ useSession, useProjection, t })', 'StatsLineShadow({ useChat, useProjection, t })'],
     ['useSession((s) => s.chat.legacy.nodes)', 'useChat((s) => s.legacy.nodes)'],
-  ]);
+    ['groups.push(t("stats.counts",', 'groups.push(formatStat("stats.counts",'],
+    ['durations.push(t("stats.llm",', 'durations.push(formatStat("stats.llm",'],
+    ['durations.push(t("stats.toolCall",', 'durations.push(formatStat("stats.toolCall",'],
+    ['speeds.push(t("stats.ttftAverage",', 'speeds.push(formatStat("stats.ttftAverage",'],
+    ['groups.push(t("stats.cacheHit",', 'groups.push(formatStat("stats.cacheHit",'],
+    ['groups.push(t("stats.tokens",', 'groups.push(formatStat("stats.tokens",'],
+    ['\t\t\t\tif (stats.decodeMs > 0) speeds.push(t("stats.tokensPerSecond", { throughput: formatTokensPerSecond(stats.decodeTokens / (stats.decodeMs / 1e3)) }));\n', ''],
+    ['\t\t\t\tif (stats.decodeMs > 0) speeds.push(formatStat("stats.tokensPerSecond", { throughput: formatTokensPerSecond(stats.decodeTokens / (stats.decodeMs / 1e3)) }));\n', ''],
+  ];
+  if (!output.includes('const formatStat = (key, values) => {')) {
+    statsReplacements.unshift(['\t\t\tconst groups = [];', `${statsFallback}\n\t\t\tconst groups = [];`]);
+  }
+  output = replaceRegion(output, 'const StatsLineShadow = ', statsReplacements);
   return output;
 }

--- a/scripts/webui-layout-compat.mjs
+++ b/scripts/webui-layout-compat.mjs
@@ -1,0 +1,17 @@
+// Reviewed WebUI 0.5.1 only. Keep the AIO sidebar focused on workspace tools.
+const marker = '\t\t\t\t// AIO hides the WebUI usage/balance navigation entry.';
+const oldPortal = `name: "usage",
+				children: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(UsageWorkbenchEntry, {})`;
+const newPortal = `name: "usage",
+				children: null`;
+
+export function migrateWebuiLayout(source) {
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  let output = source.replace(/\r\n/g, '\n');
+  if (output.includes(marker)) return newline === '\n' ? output : output.replace(/\n/g, newline);
+  if (output.split(oldPortal).length !== 2) {
+    throw new Error('Unrecognized WebUI usage navigation portal boundary');
+  }
+  output = output.replace(oldPortal, `${marker}\n${newPortal}`);
+  return newline === '\n' ? output : output.replace(/\n/g, newline);
+}

--- a/scripts/webui-native-model-selection-compat.mjs
+++ b/scripts/webui-native-model-selection-compat.mjs
@@ -1,0 +1,15 @@
+// The AIO build must keep provider/model selection in the host's native
+// conversation.input.model control. The WebUI replacement is intentionally
+// disabled because its async module flag can mount before settings sync.
+export function migrateWebuiNativeModelSelection(source) {
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  source = source.replace(/\r\n/g, '\n');
+  const old = 'if (on("modelSeats")) applyModelSeats(ctx);';
+  const marker = '// AIO keeps provider/model selection in the host native control.';
+  if (source.includes(marker)) return newline === '\n' ? source : source.replace(/\n/g, newline);
+  if (source.split(old).length !== 2) {
+    throw new Error('Unrecognized dsh-webui model seat registration boundary');
+  }
+  source = source.replace(old, `${marker}\n\t\t\tvoid applyModelSeats;`);
+  return newline === '\n' ? source : source.replace(/\n/g, newline);
+}

--- a/scripts/webui-prompt-optimize-compat.mjs
+++ b/scripts/webui-prompt-optimize-compat.mjs
@@ -1,6 +1,8 @@
 // Reviewed dsh-webui 0.5.1 boundary; the staging caller owns package validation.
 // Current owner: ui-conversation SessionStandardProps, upstream c389f96bf3a9b6807cb71ed6bdad5849be0df6d8.
 export function migrateWebuiPromptOptimize(source) {
+  const newline = source.includes('\r\n') ? '\r\n' : '\n';
+  source = source.replace(/\r\n/g, '\n');
   const old = 'function PromptOptimizeButton({ available, directory, input, inputActions, sessionId }) {';
   const current = 'function PromptOptimizeButton({ available, directory, useInput, inputActions, sessionId }) {\n\t\t\tconst input = useInput((state) => state);';
   if (!(source.includes(current) && !source.includes(old))) {
@@ -32,5 +34,68 @@ export function migrateWebuiPromptOptimize(source) {
     }
     source = source.slice(0, from) + region.replace(/\n/g, newline) + source.slice(to);
   }
-  return source;
+
+  // A stale localStorage flag can be left by an older build after the server
+  // default was changed back to enabled. The old client reads that flag before
+  // the async settings sync and permanently skips the slot for this page load.
+  // Reconcile the prompt optimizer after the server response so an enabled
+  // server default takes effect without requiring a second manual refresh.
+  const syncStart = Math.max(
+    source.indexOf('function syncServerModules() {'),
+    source.indexOf('function syncServerModules(onModulesSynced) {'),
+  );
+  const syncEnd = source.indexOf('//#endregion', syncStart);
+  if (syncStart < 0 || syncEnd < syncStart) {
+    throw new Error('Unrecognized dsh-webui module sync boundary');
+  }
+  let syncRegion = source.slice(syncStart, syncEnd);
+  if (!syncRegion.includes('function syncServerModules(onModulesSynced) {')) {
+    const syncOld = 'function syncServerModules() {';
+    const syncStore = 'if (JSON.stringify(current) !== JSON.stringify(disabled)) storeModules(disabled);';
+    const syncNewStore = [
+      'const changed = JSON.stringify(current) !== JSON.stringify(disabled);',
+      'if (changed) storeModules(disabled);',
+      'onModulesSynced?.(disabled);',
+    ].join('\n');
+    if (syncRegion.split(syncOld).length !== 2 || syncRegion.split(syncStore).length !== 2) {
+      throw new Error('Unrecognized dsh-webui module sync implementation');
+    }
+    syncRegion = syncRegion.replace(syncOld, 'function syncServerModules(onModulesSynced) {')
+      .replace(syncStore, syncNewStore);
+    source = source.slice(0, syncStart) + syncRegion + source.slice(syncEnd);
+  }
+
+  const applyStart = source.indexOf('function apply(ctx) {');
+  const applyEnd = source.indexOf('//#endregion', applyStart);
+  if (applyStart < 0 || applyEnd < applyStart) {
+    throw new Error('Unrecognized dsh-webui root apply boundary');
+  }
+  let applyRegion = source.slice(applyStart, applyEnd);
+  if (!applyRegion.includes('const mountPromptOptimize = () => {')) {
+    const applyOld = /function apply\(ctx\) \{\s+const moduleOverrides = readStoredModules\(\);\s+const on = \(key\) => isModuleEnabled\(moduleOverrides, key\);\s+syncServerModules\(\);/;
+    const applyNew = [
+      'function apply(ctx) {',
+      '\t\t\tconst moduleOverrides = readStoredModules();',
+      '\t\t\tconst on = (key) => isModuleEnabled(moduleOverrides, key);',
+      '\t\t\tlet promptOptimizeMounted = false;',
+      '\t\t\tconst mountPromptOptimize = () => {',
+      '\t\t\t\tif (promptOptimizeMounted) return;',
+      '\t\t\t\tpromptOptimizeMounted = true;',
+      '\t\t\t\tapplyPromptOptimize(ctx);',
+      '\t\t\t};',
+      '\t\t\tsyncServerModules((modules) => {',
+      '\t\t\t\tif (isModuleEnabled(modules, "promptOptimize")) mountPromptOptimize();',
+      '\t\t\t});',
+    ].join('\n');
+    if (!applyOld.test(applyRegion)) {
+      throw new Error('Unrecognized dsh-webui root module setup');
+    }
+    applyRegion = applyRegion.replace(applyOld, applyNew);
+  }
+  const promptCall = 'if (on("promptOptimize")) applyPromptOptimize(ctx);';
+  if (applyRegion.includes(promptCall)) {
+    applyRegion = applyRegion.replace(promptCall, 'if (on("promptOptimize")) mountPromptOptimize();');
+  }
+  source = source.slice(0, applyStart) + applyRegion + source.slice(applyEnd);
+  return newline === '\n' ? source : source.replace(/\n/g, newline);
 }

--- a/tauri-app/scripts/stage.ts
+++ b/tauri-app/scripts/stage.ts
@@ -319,12 +319,46 @@ function main() {
     process.exit(1);
   }
   copyTree(PROFILE_SEED, path.join(RESOURCES, 'profile-seed'));
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'prepare-aio-staged-seed.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop'),
+  ], { stdio: 'inherit' });
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-webui-prompt-optimize.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', '@dsh-external', 'dsh-webui', 'lib', 'client.js'),
+  ], { stdio: 'inherit' });
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-webui-native-model-selection.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', '@dsh-external', 'dsh-webui', 'lib', 'client.js'),
+  ], { stdio: 'inherit' });
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-webui-layout.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', '@dsh-external', 'dsh-webui', 'lib', 'client.js'),
+  ], { stdio: 'inherit' });
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-webui-continue.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', '@dsh-external', 'dsh-webui', 'lib', 'client.js'),
+  ], { stdio: 'inherit' });
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-status-rotator.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', 'dsh-status-rotator', 'lib', 'client.js'),
+  ], { stdio: 'inherit' });
   // Patch only the staged copy; unknown plugin builds must stop packaging.
   execFileSync(process.execPath, [
     path.join(REPO_ROOT, 'scripts', 'patch-done-pill.cjs'),
     '--write',
     path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
       'node_modules', '@dsh-external', 'dsh-webui'),
+  ], { stdio: 'inherit' });
+  execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'scripts', 'patch-webui-katex.mjs'),
+    path.join(RESOURCES, 'profile-seed', 'profiles', 'web-desktop',
+      'node_modules', '@dsh-external', 'dsh-webui', 'lib', 'client.js'),
   ], { stdio: 'inherit' });
   console.log('[stage] 当前 web-desktop 插件与技能快照完成');
 

--- a/tauri-app/src/paths.rs
+++ b/tauri-app/src/paths.rs
@@ -1,8 +1,8 @@
 //! 路径解析：开发模式直接用仓库根（与 Electron 版共享 vendor/node_modules），
 //! 打包模式用 Tauri resource 目录下 staging 脚本铺好的 app/node/npm。
 
-use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 pub struct Paths {
     /// 应用 JS 根（shell-host.js / assets / node_modules 所在目录）。
@@ -11,7 +11,8 @@ pub struct Paths {
     pub node_exe: PathBuf,
     /// 内置 npm CLI 入口。
     pub npm_cli: PathBuf,
-    /// 用户数据目录（%APPDATA%/<identifier>，Tauri app_data_dir）。
+    /// 用户数据目录。安装版按发布版本隔离在
+    /// `%APPDATA%/<identifier>/releases/<version>`，避免更新包继承旧 AIO 数据。
     pub user_data: PathBuf,
     /// 日志目录。
     pub logs_dir: PathBuf,
@@ -58,11 +59,13 @@ impl Paths {
                 .join("npm-cli.js")
         };
         // 便携包在 exe 同级带 `.dsh-portable`，数据进入 `.dsh-aio-data`；
-        // 安装版继续使用独立 appData。环境变量始终优先，供自动化与高级用户覆盖。
+        // 安装版再按版本隔离一层，更新包不会复用旧 AIO 的根数据。
+        // 环境变量始终优先，供自动化与高级用户覆盖。
         let portable_data = portable_data_dir(packaged, resource_dir.as_deref());
+        let installed_data = installed_data_dir(&app_data_dir, &version);
         let user_data = match std::env::var("DSH_DESKTOP_USERDATA") {
             Ok(v) if !v.trim().is_empty() => PathBuf::from(v),
-            _ => portable_data.clone().unwrap_or(app_data_dir),
+            _ => portable_data.clone().unwrap_or(installed_data),
         };
         let dsh_home = match std::env::var("DSH_HOME") {
             Ok(v) if !v.trim().is_empty() => PathBuf::from(v),
@@ -153,9 +156,10 @@ impl Paths {
         if seed_home_is_empty(&self.dsh_home)? {
             copy_tree(&seed, &self.dsh_home)?;
             clear_legacy_plugin_preferences(&self.settings_file())?;
-            write_seed_marker(&marker_file, &ProfileSeedMarker::committed(
-                &self.version, &seed_fingerprint, None,
-            ))?;
+            write_seed_marker(
+                &marker_file,
+                &ProfileSeedMarker::committed(&self.version, &seed_fingerprint, None),
+            )?;
             return Ok(true);
         }
         ensure_plain_directory(&self.dsh_home)?;
@@ -164,7 +168,10 @@ impl Paths {
                 if let Some(backup_name) = marker.backup_name.as_deref() {
                     rollback_pending_profile(&self.dsh_home, backup_name)?;
                     let _ = std::fs::remove_file(&marker_file);
-                    return Err("previous profile seed did not pass boot health; old profile restored".into());
+                    return Err(
+                        "previous profile seed did not pass boot health; old profile restored"
+                            .into(),
+                    );
                 }
                 // There was no old profile to restore. Keep testing the exact
                 // seed already active and commit it after a healthy boot.
@@ -176,9 +183,10 @@ impl Paths {
             {
                 if let Some(backup_name) = marker.backup_name.as_deref() {
                     cleanup_profile_backup(&self.dsh_home, backup_name)?;
-                    write_seed_marker(&marker_file, &ProfileSeedMarker::committed(
-                        &self.version, &seed_fingerprint, None,
-                    ))?;
+                    write_seed_marker(
+                        &marker_file,
+                        &ProfileSeedMarker::committed(&self.version, &seed_fingerprint, None),
+                    )?;
                 }
                 return Ok(false);
             }
@@ -194,7 +202,10 @@ impl Paths {
             .map_err(|_| "system clock is before unix epoch".to_string())?
             .as_nanos();
         let candidate_name = format!(".{DESKTOP_PROFILE}-aio-seed-{}-{nonce}", std::process::id());
-        let backup_name = format!(".{DESKTOP_PROFILE}-aio-backup-{}-{nonce}", std::process::id());
+        let backup_name = format!(
+            ".{DESKTOP_PROFILE}-aio-backup-{}-{nonce}",
+            std::process::id()
+        );
         let candidate = profiles.join(&candidate_name);
         let backup = profiles.join(&backup_name);
         copy_tree(&seed_profile, &candidate)?;
@@ -213,10 +224,16 @@ impl Paths {
                 let _ = std::fs::rename(&backup, &active);
             }
             let _ = std::fs::remove_dir_all(&candidate);
-            return Err(format!("activate {} -> {}: {e}", candidate.display(), active.display()));
+            return Err(format!(
+                "activate {} -> {}: {e}",
+                candidate.display(),
+                active.display()
+            ));
         }
         let pending = ProfileSeedMarker::pending(
-            &self.version, &seed_fingerprint, had_active.then_some(backup_name),
+            &self.version,
+            &seed_fingerprint,
+            had_active.then_some(backup_name),
         );
         if let Err(e) = write_seed_marker(&marker_file, &pending) {
             let _ = std::fs::remove_dir_all(&active);
@@ -234,19 +251,28 @@ impl Paths {
     /// to retry without ever reactivating old plugins.
     pub fn commit_distribution_profile_seed(&self) -> Result<bool, String> {
         let marker_file = self.dsh_home.join(PROFILE_SEED_MARKER);
-        let Some(marker) = read_seed_marker(&marker_file)? else { return Ok(false) };
+        let Some(marker) = read_seed_marker(&marker_file)? else {
+            return Ok(false);
+        };
         if marker.state != "pending-health" {
             return Ok(false);
         }
         let committed = ProfileSeedMarker::committed(
-            &marker.app_version, &marker.seed_fingerprint, marker.backup_name.clone(),
+            &marker.app_version,
+            &marker.seed_fingerprint,
+            marker.backup_name.clone(),
         );
         write_seed_marker(&marker_file, &committed)?;
         if let Some(backup_name) = committed.backup_name.as_deref() {
             cleanup_profile_backup(&self.dsh_home, backup_name)?;
-            write_seed_marker(&marker_file, &ProfileSeedMarker::committed(
-                &committed.app_version, &committed.seed_fingerprint, None,
-            ))?;
+            write_seed_marker(
+                &marker_file,
+                &ProfileSeedMarker::committed(
+                    &committed.app_version,
+                    &committed.seed_fingerprint,
+                    None,
+                ),
+            )?;
         }
         let plugin_cache = self.dsh_home.join("plugin-artifact-cache");
         if plugin_cache.exists() {
@@ -266,6 +292,10 @@ pub const DESKTOP_PROFILE_BUNDLES: [&str; 2] =
 
 pub fn dirs_home() -> Option<PathBuf> {
     std::env::var("USERPROFILE").ok().map(PathBuf::from)
+}
+
+fn installed_data_dir(app_data_dir: &std::path::Path, version: &str) -> PathBuf {
+    app_data_dir.join("releases").join(version)
 }
 
 fn seed_home_is_empty(home: &std::path::Path) -> Result<bool, String> {
@@ -293,10 +323,17 @@ fn clear_legacy_plugin_preferences(file: &std::path::Path) -> Result<(), String>
         return Ok(());
     }
     let mut settings = crate::settings::load_at(file);
-    let Some(object) = settings.as_object_mut() else { return Ok(()) };
+    let Some(object) = settings.as_object_mut() else {
+        return Ok(());
+    };
     let mut changed = false;
-    for key in ["removedPlugins", "pluginAutoUpdate", "shareWebProfile",
-        "desktopProfileMigrated", "legacySkinChoice"] {
+    for key in [
+        "removedPlugins",
+        "pluginAutoUpdate",
+        "shareWebProfile",
+        "desktopProfileMigrated",
+        "legacySkinChoice",
+    ] {
         changed |= object.remove(key).is_some();
     }
     if changed {
@@ -318,13 +355,23 @@ struct ProfileSeedMarker {
 
 impl ProfileSeedMarker {
     fn pending(version: &str, fingerprint: &str, backup_name: Option<String>) -> Self {
-        Self { schema: 1, app_version: version.into(), seed_fingerprint: fingerprint.into(),
-            state: "pending-health".into(), backup_name }
+        Self {
+            schema: 1,
+            app_version: version.into(),
+            seed_fingerprint: fingerprint.into(),
+            state: "pending-health".into(),
+            backup_name,
+        }
     }
 
     fn committed(version: &str, fingerprint: &str, backup_name: Option<String>) -> Self {
-        Self { schema: 1, app_version: version.into(), seed_fingerprint: fingerprint.into(),
-            state: "committed".into(), backup_name }
+        Self {
+            schema: 1,
+            app_version: version.into(),
+            seed_fingerprint: fingerprint.into(),
+            state: "committed".into(),
+            backup_name,
+        }
     }
 }
 
@@ -337,7 +384,8 @@ fn read_seed_marker(file: &std::path::Path) -> Result<Option<ProfileSeedMarker>,
                 || !matches!(marker.state.as_str(), "pending-health" | "committed")
                 || marker.seed_fingerprint.len() != 16
                 || marker.backup_name.as_deref().is_some_and(|name| {
-                    name.contains(['/', '\\']) || !name.starts_with(&format!(".{DESKTOP_PROFILE}-aio-backup-"))
+                    name.contains(['/', '\\'])
+                        || !name.starts_with(&format!(".{DESKTOP_PROFILE}-aio-backup-"))
                 })
             {
                 return Err("profile seed marker is invalid".into());
@@ -350,7 +398,9 @@ fn read_seed_marker(file: &std::path::Path) -> Result<Option<ProfileSeedMarker>,
 }
 
 fn write_seed_marker(file: &std::path::Path, marker: &ProfileSeedMarker) -> Result<(), String> {
-    let parent = file.parent().ok_or_else(|| "profile seed marker has no parent".to_string())?;
+    let parent = file
+        .parent()
+        .ok_or_else(|| "profile seed marker has no parent".to_string())?;
     std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
     let temporary = parent.join(format!(".{PROFILE_SEED_MARKER}.tmp-{}", std::process::id()));
     let mut bytes = serde_json::to_vec_pretty(marker).map_err(|e| e.to_string())?;
@@ -359,8 +409,13 @@ fn write_seed_marker(file: &std::path::Path, marker: &ProfileSeedMarker) -> Resu
     if file.exists() {
         std::fs::remove_file(file).map_err(|e| format!("replace {}: {e}", file.display()))?;
     }
-    std::fs::rename(&temporary, file)
-        .map_err(|e| format!("activate {} -> {}: {e}", temporary.display(), file.display()))
+    std::fs::rename(&temporary, file).map_err(|e| {
+        format!(
+            "activate {} -> {}: {e}",
+            temporary.display(),
+            file.display()
+        )
+    })
 }
 
 fn ensure_plain_directory(directory: &std::path::Path) -> Result<(), String> {
@@ -368,8 +423,12 @@ fn ensure_plain_directory(directory: &std::path::Path) -> Result<(), String> {
     ancestors.reverse();
     for entry in ancestors {
         match std::fs::symlink_metadata(entry) {
-            Ok(meta) if meta.file_type().is_symlink() => return Err("linked profile boundary rejected".into()),
-            Ok(meta) if entry == directory && !meta.is_dir() => return Err("profile boundary is not a directory".into()),
+            Ok(meta) if meta.file_type().is_symlink() => {
+                return Err("linked profile boundary rejected".into())
+            }
+            Ok(meta) if entry == directory && !meta.is_dir() => {
+                return Err("profile boundary is not a directory".into())
+            }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             Err(e) => return Err(format!("inspect {}: {e}", entry.display())),
             _ => {}
@@ -384,7 +443,8 @@ fn cleanup_profile_backup(home: &std::path::Path, backup_name: &str) -> Result<(
     let backup = profiles.join(backup_name);
     if backup.exists() {
         ensure_plain_directory(&backup)?;
-        std::fs::remove_dir_all(&backup).map_err(|e| format!("remove {}: {e}", backup.display()))?;
+        std::fs::remove_dir_all(&backup)
+            .map_err(|e| format!("remove {}: {e}", backup.display()))?;
     }
     Ok(())
 }
@@ -397,7 +457,8 @@ fn rollback_pending_profile(home: &std::path::Path, backup_name: &str) -> Result
     ensure_plain_directory(&backup)?;
     if active.exists() {
         ensure_plain_directory(&active)?;
-        std::fs::remove_dir_all(&active).map_err(|e| format!("remove {}: {e}", active.display()))?;
+        std::fs::remove_dir_all(&active)
+            .map_err(|e| format!("remove {}: {e}", active.display()))?;
     }
     std::fs::rename(&backup, &active)
         .map_err(|e| format!("restore {} -> {}: {e}", backup.display(), active.display()))
@@ -410,7 +471,11 @@ fn tree_fingerprint(root: &std::path::Path) -> Result<String, String> {
             *hash = hash.wrapping_mul(0x100000001b3);
         }
     }
-    fn walk(root: &std::path::Path, directory: &std::path::Path, hash: &mut u64) -> Result<(), String> {
+    fn walk(
+        root: &std::path::Path,
+        directory: &std::path::Path,
+        hash: &mut u64,
+    ) -> Result<(), String> {
         let mut entries = std::fs::read_dir(directory)
             .map_err(|e| format!("read {}: {e}", directory.display()))?
             .collect::<Result<Vec<_>, _>>()
@@ -418,9 +483,16 @@ fn tree_fingerprint(root: &std::path::Path) -> Result<String, String> {
         entries.sort_by_key(|entry| entry.file_name());
         for entry in entries {
             let file = entry.path();
-            let relative = file.strip_prefix(root).map_err(|_| "profile seed path escaped root".to_string())?;
-            mix(hash, relative.to_string_lossy().replace('\\', "/").as_bytes());
-            let kind = entry.file_type().map_err(|e| format!("inspect {}: {e}", file.display()))?;
+            let relative = file
+                .strip_prefix(root)
+                .map_err(|_| "profile seed path escaped root".to_string())?;
+            mix(
+                hash,
+                relative.to_string_lossy().replace('\\', "/").as_bytes(),
+            );
+            let kind = entry
+                .file_type()
+                .map_err(|e| format!("inspect {}: {e}", file.display()))?;
             if kind.is_symlink() {
                 return Err("linked profile seed entry rejected".into());
             } else if kind.is_dir() {
@@ -428,7 +500,10 @@ fn tree_fingerprint(root: &std::path::Path) -> Result<String, String> {
                 walk(root, &file, hash)?;
             } else if kind.is_file() {
                 mix(hash, b"F");
-                mix(hash, &std::fs::read(&file).map_err(|e| format!("read {}: {e}", file.display()))?);
+                mix(
+                    hash,
+                    &std::fs::read(&file).map_err(|e| format!("read {}: {e}", file.display()))?,
+                );
             } else {
                 return Err("unsupported profile seed entry".into());
             }
@@ -532,7 +607,10 @@ mod tests {
         assert!(seed_home_is_empty(&root).unwrap());
         std::fs::write(root.join("settings.yaml"), b"private: unchanged").unwrap();
         assert!(!seed_home_is_empty(&root).unwrap());
-        assert_eq!(std::fs::read(root.join("settings.yaml")).unwrap(), b"private: unchanged");
+        assert_eq!(
+            std::fs::read(root.join("settings.yaml")).unwrap(),
+            b"private: unchanged"
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -542,40 +620,99 @@ mod tests {
         let paths = test_paths(&root);
         let seed_home = root.join("resources/profile-seed");
         write_file(&seed_home, "settings.yaml", b"public-default: true\n");
-        write_file(&seed_home, "profiles/web-desktop/package.json", b"{\"name\":\"new-profile\"}\n");
-        write_file(&seed_home, "profiles/web-desktop/node_modules/new-plugin/index.js", b"new\n");
+        write_file(
+            &seed_home,
+            "profiles/web-desktop/package.json",
+            b"{\"name\":\"new-profile\"}\n",
+        );
+        write_file(
+            &seed_home,
+            "profiles/web-desktop/node_modules/new-plugin/index.js",
+            b"new\n",
+        );
         write_file(&paths.dsh_home, "settings.yaml", b"provider: private\n");
         write_file(&paths.dsh_home, ".credentials.yaml", b"apiKey: synthetic\n");
-        write_file(&paths.dsh_home, "sessions/a/events.jsonl", b"private session\n");
+        write_file(
+            &paths.dsh_home,
+            "sessions/a/events.jsonl",
+            b"private session\n",
+        );
         write_file(&paths.dsh_home, "attachments/v1/a", &[0, 1, 255]);
-        write_file(&paths.dsh_home, "profiles/web-desktop/package.json", b"{\"name\":\"old-profile\"}\n");
-        write_file(&paths.dsh_home, "profiles/web-desktop/node_modules/old-plugin/index.js", b"old\n");
-        write_file(&paths.dsh_home, "plugin-artifact-cache/old-plugin/lib/index.js", b"old cache\n");
+        write_file(
+            &paths.dsh_home,
+            "profiles/web-desktop/package.json",
+            b"{\"name\":\"old-profile\"}\n",
+        );
+        write_file(
+            &paths.dsh_home,
+            "profiles/web-desktop/node_modules/old-plugin/index.js",
+            b"old\n",
+        );
+        write_file(
+            &paths.dsh_home,
+            "plugin-artifact-cache/old-plugin/lib/index.js",
+            b"old cache\n",
+        );
         write_file(&paths.user_data, "settings.json",
             br#"{"exitAction":"minimize","removedPlugins":["balance"],"pluginAutoUpdate":true,"shareWebProfile":true,"legacySkinChoice":"ui-skin-old"}"#);
 
         assert!(paths.seed_distribution_profile().unwrap());
-        assert_eq!(std::fs::read(paths.dsh_home.join("settings.yaml")).unwrap(), b"provider: private\n");
-        assert_eq!(std::fs::read(paths.dsh_home.join(".credentials.yaml")).unwrap(), b"apiKey: synthetic\n");
-        assert_eq!(std::fs::read(paths.dsh_home.join("sessions/a/events.jsonl")).unwrap(), b"private session\n");
-        assert_eq!(std::fs::read(paths.dsh_home.join("attachments/v1/a")).unwrap(), [0, 1, 255]);
-        assert_eq!(std::fs::read(paths.dsh_home.join("profiles/web-desktop/package.json")).unwrap(),
-            b"{\"name\":\"new-profile\"}\n");
-        assert!(!paths.dsh_home.join("profiles/web-desktop/node_modules/old-plugin").exists());
-        let pending = read_seed_marker(&paths.dsh_home.join(PROFILE_SEED_MARKER)).unwrap().unwrap();
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("settings.yaml")).unwrap(),
+            b"provider: private\n"
+        );
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join(".credentials.yaml")).unwrap(),
+            b"apiKey: synthetic\n"
+        );
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("sessions/a/events.jsonl")).unwrap(),
+            b"private session\n"
+        );
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("attachments/v1/a")).unwrap(),
+            [0, 1, 255]
+        );
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("profiles/web-desktop/package.json")).unwrap(),
+            b"{\"name\":\"new-profile\"}\n"
+        );
+        assert!(!paths
+            .dsh_home
+            .join("profiles/web-desktop/node_modules/old-plugin")
+            .exists());
+        let pending = read_seed_marker(&paths.dsh_home.join(PROFILE_SEED_MARKER))
+            .unwrap()
+            .unwrap();
         assert_eq!(pending.state, "pending-health");
-        let backup = paths.dsh_home.join("profiles").join(pending.backup_name.as_ref().unwrap());
+        let backup = paths
+            .dsh_home
+            .join("profiles")
+            .join(pending.backup_name.as_ref().unwrap());
         assert!(backup.join("node_modules/old-plugin/index.js").is_file());
         let app_settings = crate::settings::load_at(&paths.settings_file());
-        assert_eq!(app_settings.get("exitAction").and_then(|v| v.as_str()), Some("minimize"));
-        for key in ["removedPlugins", "pluginAutoUpdate", "shareWebProfile", "legacySkinChoice"] {
-            assert!(app_settings.get(key).is_none(), "{key} must not be inherited");
+        assert_eq!(
+            app_settings.get("exitAction").and_then(|v| v.as_str()),
+            Some("minimize")
+        );
+        for key in [
+            "removedPlugins",
+            "pluginAutoUpdate",
+            "shareWebProfile",
+            "legacySkinChoice",
+        ] {
+            assert!(
+                app_settings.get(key).is_none(),
+                "{key} must not be inherited"
+            );
         }
 
         assert!(paths.commit_distribution_profile_seed().unwrap());
         assert!(!backup.exists());
         assert!(!paths.dsh_home.join("plugin-artifact-cache").exists());
-        let committed = read_seed_marker(&paths.dsh_home.join(PROFILE_SEED_MARKER)).unwrap().unwrap();
+        let committed = read_seed_marker(&paths.dsh_home.join(PROFILE_SEED_MARKER))
+            .unwrap()
+            .unwrap();
         assert_eq!(committed.state, "committed");
         assert!(committed.backup_name.is_none());
         assert!(!paths.seed_distribution_profile().unwrap());
@@ -588,15 +725,28 @@ mod tests {
         let paths = test_paths(&root);
         let seed_home = root.join("resources/profile-seed");
         write_file(&seed_home, "settings.yaml", b"public-default: true\n");
-        write_file(&seed_home, "profiles/web-desktop/package.json", b"{\"name\":\"new-profile\"}\n");
+        write_file(
+            &seed_home,
+            "profiles/web-desktop/package.json",
+            b"{\"name\":\"new-profile\"}\n",
+        );
         write_file(&paths.dsh_home, "settings.yaml", b"provider: private\n");
-        write_file(&paths.dsh_home, "profiles/web-desktop/package.json", b"{\"name\":\"old-profile\"}\n");
+        write_file(
+            &paths.dsh_home,
+            "profiles/web-desktop/package.json",
+            b"{\"name\":\"old-profile\"}\n",
+        );
 
         assert!(paths.seed_distribution_profile().unwrap());
         assert!(paths.seed_distribution_profile().is_err());
-        assert_eq!(std::fs::read(paths.dsh_home.join("profiles/web-desktop/package.json")).unwrap(),
-            b"{\"name\":\"old-profile\"}\n");
-        assert_eq!(std::fs::read(paths.dsh_home.join("settings.yaml")).unwrap(), b"provider: private\n");
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("profiles/web-desktop/package.json")).unwrap(),
+            b"{\"name\":\"old-profile\"}\n"
+        );
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("settings.yaml")).unwrap(),
+            b"provider: private\n"
+        );
         assert!(!paths.dsh_home.join(PROFILE_SEED_MARKER).exists());
         std::fs::remove_dir_all(root).unwrap();
     }
@@ -607,11 +757,20 @@ mod tests {
         let paths = test_paths(&root);
         let seed_home = root.join("resources/profile-seed");
         write_file(&seed_home, "settings.yaml", b"public-default: true\n");
-        write_file(&seed_home, "profiles/web-desktop/package.json", b"{\"name\":\"new-profile\"}\n");
+        write_file(
+            &seed_home,
+            "profiles/web-desktop/package.json",
+            b"{\"name\":\"new-profile\"}\n",
+        );
 
         assert!(paths.seed_distribution_profile().unwrap());
-        assert_eq!(std::fs::read(paths.dsh_home.join("settings.yaml")).unwrap(), b"public-default: true\n");
-        let marker = read_seed_marker(&paths.dsh_home.join(PROFILE_SEED_MARKER)).unwrap().unwrap();
+        assert_eq!(
+            std::fs::read(paths.dsh_home.join("settings.yaml")).unwrap(),
+            b"public-default: true\n"
+        );
+        let marker = read_seed_marker(&paths.dsh_home.join(PROFILE_SEED_MARKER))
+            .unwrap()
+            .unwrap();
         assert_eq!(marker.state, "committed");
         assert!(marker.backup_name.is_none());
         std::fs::remove_dir_all(root).unwrap();
@@ -621,9 +780,16 @@ mod tests {
     fn shared_profile_preference_cannot_redirect_aio_to_old_plugins() {
         let root = test_root("dedicated-profile");
         let paths = test_paths(&root);
-        write_file(&paths.user_data, "settings.json", br#"{"shareWebProfile":true}"#);
+        write_file(
+            &paths.user_data,
+            "settings.json",
+            br#"{"shareWebProfile":true}"#,
+        );
         assert_eq!(paths.desktop_profile(), DESKTOP_PROFILE);
-        assert_eq!(paths.desktop_profile_dir(), paths.dsh_home.join("profiles/web-desktop"));
+        assert_eq!(
+            paths.desktop_profile_dir(),
+            paths.dsh_home.join("profiles/web-desktop")
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 
@@ -632,8 +798,22 @@ mod tests {
         let root = test_root("aio-portable");
         let _ = std::fs::create_dir_all(&root);
         std::fs::write(root.join(".dsh-portable"), b"").unwrap();
-        assert_eq!(portable_data_dir(true, Some(&root)), Some(root.join(".dsh-aio-data")));
+        assert_eq!(
+            portable_data_dir(true, Some(&root)),
+            Some(root.join(".dsh-aio-data"))
+        );
         assert_eq!(portable_data_dir(false, Some(&root)), None);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn installed_data_isolated_per_release_without_touching_legacy_root() {
+        let root = test_root("installed-release-data");
+        let old = installed_data_dir(&root, "1.1.0");
+        let current = installed_data_dir(&root, "1.2.0");
+        assert_eq!(old, root.join("releases/1.1.0"));
+        assert_eq!(current, root.join("releases/1.2.0"));
+        assert_ne!(old, current);
+        assert_ne!(current, root);
     }
 }

--- a/test/aio-validation-compat.test.mjs
+++ b/test/aio-validation-compat.test.mjs
@@ -37,7 +37,8 @@ test('AIO remains isolated from every legacy product by default', () => {
   const electron = read('main.js');
   const shortcuts = read('tauri-app/src/shortcuts.rs');
   assert.equal(conf.identifier, 'com.deepseek.dsh.desktop.aio');
-  assert.match(paths, /user_data\.join\("dsh-home"\)/);
+  assert.match(paths, /installed_data_dir\(&app_data_dir, &version\)/);
+  assert.match(paths, /app_data_dir\.join\("releases"\)\.join\(version\)/);
   assert.match(migrate, /DSH_AIO_IMPORT_LEGACY/);
   assert.match(migrate, /!= Ok\("1"\)/);
   assert.match(nsh, /taskkill \/F \/T \/IM "DSHEAC AIO\.exe"/);
@@ -73,6 +74,31 @@ test('AIO update smoke rejects client self-update exposure', () => {
   const smoke = read('update-smoke.js');
   assert.match(smoke, /client auto-update scripts/);
   assert.match(smoke, /plugin auto-update must default to disabled/);
+});
+
+test('AIO installer marks the watchdog state clean before forced restart cleanup', () => {
+  const script = read('scripts/verify-aio-installer.ps1');
+  assert.match(script, /function Mark-CleanExit\(/);
+  assert.match(script, /Mark-CleanExit \(Join-Path \$isolatedUserData 'run-state\.json'\)/);
+  assert.match(script, /WriteAllText\(\$StateFile, \(\$state \| ConvertTo-Json -Compress\)/);
+  assert.match(script, /if \(\$appProcess\.HasExited\) \{ continue \}/);
+  assert.doesNotMatch(script, /\$restartTail[\s\S]{0,300}if \(\$appProcess\.HasExited\) \{ break \}/);
+});
+
+test('staging restores the WebUI KaTeX fallback on the copied profile seed', () => {
+  const stage = read('tauri-app/scripts/stage.ts');
+  assert.match(stage, /patch-webui-katex\.mjs/);
+  assert.match(stage, /patch-webui-continue\.mjs/);
+  assert.match(stage, /patch-webui-prompt-optimize\.mjs/);
+  assert.match(stage, /patch-webui-native-model-selection\.mjs/);
+  assert.match(stage, /patch-webui-layout\.mjs/);
+  assert.match(stage, /patch-status-rotator\.mjs/);
+  assert.match(stage, /prepare-aio-staged-seed\.mjs/);
+  const patcher = read('scripts/patch-webui-katex.mjs');
+  assert.match(patcher, /migrateWebuiKatexFallback/);
+  const seed = read('scripts/prepare-aio-staged-seed.mjs');
+  assert.match(seed, /installWebuiUsageHost/);
+  assert.match(seed, /builtinNames/);
 });
 
 test('release scripts compute SHA-256 without PowerShell module autoloading', () => {

--- a/test/composer-dynamic-island-builtin.test.mjs
+++ b/test/composer-dynamic-island-builtin.test.mjs
@@ -76,6 +76,12 @@ test('Web adapter 无外传 API，并锁定焦点与卸载生命周期修复', (
   assert.doesNotMatch(client, /\? "岛内" : "原位"/);
 });
 
+test('模型选择器始终交给宿主原生控件处理', () => {
+  assert.doesNotMatch(client, /const MODEL_SLOT/);
+  assert.match(client, /slotName === "conversation\.input\.model"\) continue/);
+  assert.doesNotMatch(client, /zoneLabel: ZONE_LABELS\[zone\][\s\S]{0,120}model/);
+});
+
 test('Electron 与 Tauri sidecar 同步注册插件和 GitHub 更新源', () => {
   for (const rel of ['main.js', 'sidecar/src/desktop-core.ts']) {
     const source = read(rel);

--- a/test/migrate-plugin-interfaces.test.mjs
+++ b/test/migrate-plugin-interfaces.test.mjs
@@ -88,6 +88,14 @@ for (const name of ['@ha-na-bi/dsh-client-ui-custom', '@dsh-external/dsh-webui']
       }
     }
     if (name === '@dsh-external/dsh-webui') {
+      assert.match(client, /init_katex_stub\(\), init__webui_katex_mhchem_stub\(\)/);
+      assert.doesNotMatch(client, /require\("katex"\)/);
+      assert.doesNotMatch(client, /import\("katex"\)/);
+      assert.match(client, /math_fence/);
+      assert.match(client, /math_environment/);
+      assert.match(client, /children: parseInlineTokens\(contentToken\.children \|\| \[\]/);
+      assert.match(client, /case "math_inline"/);
+      assert.doesNotMatch(client, /katex disabled in webui/);
       assert.doesNotMatch(client, /(?:\.conversationEvents|"conversationEvents")/);
       assert.match(client, /\.uiConversation\.events\.register/);
       const adapter = host.slice(host.lastIndexOf('\nfunction installSettingsSection'));

--- a/test/profile-upgrade.test.mjs
+++ b/test/profile-upgrade.test.mjs
@@ -210,6 +210,37 @@ test('unused owned links to real top-level packages and trusted app packages are
   assert.doesNotThrow(() => assertProfileStartup(app, profile));
 });
 
+// The kernel points profile fallbacks at the shared layer <home>/profiles/node_modules,
+// whose entries are themselves junctions. Those hops are trusted and must not block
+// the second and later launches of an installed profile.
+test('kernel shared dependency layer links are accepted on restart', t => {
+  const { app, profile, root } = fixture(t, UPGRADE_TARGET.kernel);
+  const shared = path.join(root, 'home/profiles/node_modules');
+  const name = 'shared-dependency';
+  put(app, `node_modules/${name}/package.json`, { name, version: '1.0.0' });
+  linkDirectory(path.join(app, 'node_modules', name), path.join(shared, name));
+  const owned = path.join(profile, '.dsh-module-fallback/node_modules', name);
+  linkDirectory(path.join(shared, name), owned);
+  linkDirectory(owned, path.join(profile, 'node_modules', name));
+  const before = bytes(root);
+  assert.equal(planProfileUpgrade(app, profile).status, 'compatible');
+  assert.doesNotThrow(() => assertProfileStartup(app, profile));
+  assert.deepEqual(bytes(root), before);
+});
+
+// Accepting the shared-layer hop must not become a way to escape the trusted roots.
+test('shared layer links resolving outside the trusted roots still fail closed', t => {
+  const { app, profile, root } = fixture(t, UPGRADE_TARGET.kernel);
+  const shared = path.join(root, 'home/profiles/node_modules');
+  const name = 'escaped-dependency';
+  put(root, `outside/${name}/package.json`, { name, version: '1.0.0' });
+  linkDirectory(path.join(root, 'outside', name), path.join(shared, name));
+  const owned = path.join(profile, '.dsh-module-fallback/node_modules', name);
+  linkDirectory(path.join(shared, name), owned);
+  linkDirectory(owned, path.join(profile, 'node_modules', name));
+  assert.throws(() => assertProfileStartup(app, profile), /PROFILE_UPGRADE_REQUIRED/);
+});
+
 for (const attack of ['external', 'sibling-prefix', 'wrong-name', 'manifest-alias', 'dangling',
   'cycle', 'linked-parent', 'direct-projection', 'wrong-owned-name', 'unowned-internal']) {
   test(`generated fallback exception rejects ${attack} links`, t => {
@@ -286,5 +317,5 @@ test('Rust profile replacement tests pass through the real Cargo dependency grap
   });
   if (run.error?.code === 'ENOENT') return t.skip('cargo unavailable');
   assert.equal(run.status, 0, run.stderr || run.stdout);
-  assert.match(run.stdout, /6 passed/);
+  assert.match(run.stdout, /test result: ok\.\s+\d+ passed; 0 failed/);
 });

--- a/test/webui-continue-compat.test.mjs
+++ b/test/webui-continue-compat.test.mjs
@@ -160,13 +160,14 @@ test('actual StatsLineShadow renders current legacy nodes and preserves projecti
     };
     assert.throws(() => renderToStaticMarkup(React.createElement(load(source), props)), /legacy/);
     const html = renderToStaticMarkup(React.createElement(load(text), props));
-    assert.match(html, /stats.counts/);
-    assert.match(html, /stats.toolCall/);
+    assert.match(html, /1 轮 · 1 步/);
+    assert.match(html, /工具调用/);
     assert.match(html, /90.25/);
-    assert.match(html, /stats.tokensPerSecond/);
+    assert.doesNotMatch(html, /stats\./);
+    assert.doesNotMatch(html, /tok\/s/);
     props.useProjection = key => key === 'sessionStats'
       ? { turns: 7, steps: 8, llmMs: 0, toolMs: 0, ttftSteps: 0, decodeMs: 0 } : undefined;
-    assert.match(renderToStaticMarkup(React.createElement(load(text), props)), /&quot;turns&quot;:7/);
+    assert.match(renderToStaticMarkup(React.createElement(load(text), props)), /7 轮 · 8 步/);
   });
 
 test('installed alpha.2 declarations pin lifecycle, chat legacy and input owners', () => {

--- a/test/webui-katex-runtime.test.mjs
+++ b/test/webui-katex-runtime.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const workspace = fileURLToPath(new URL('../', import.meta.url));
+const clientPath = path.join(
+  workspace,
+  'tauri-app', 'resources', 'profile-seed', 'profiles', 'web-desktop',
+  'node_modules', '@dsh-external', 'dsh-webui', 'lib', 'client.js',
+);
+
+test('staged WebUI embeds a working KaTeX runtime for inline, display, and chemical math', t => {
+  if (!fs.existsSync(clientPath)) {
+    t.skip('staged profile seed is not present; run the AIO staging step first');
+    return;
+  }
+  const source = fs.readFileSync(clientPath, 'utf8');
+  const katexMarker = '//#region src/client/markdown/katex-stub.ts';
+  const mhchemMarker = '//#region \\0webui-katex-mhchem-stub';
+  const katexStart = source.indexOf(katexMarker);
+  const katexEnd = source.indexOf('//#endregion', katexStart) + '//#endregion'.length;
+  const mhchemStart = source.indexOf(mhchemMarker);
+  const mhchemEnd = source.indexOf('//#endregion', mhchemStart) + '//#endregion'.length;
+  assert.ok(katexStart >= 0 && katexEnd > katexStart);
+  assert.ok(mhchemStart >= 0 && mhchemEnd > mhchemStart);
+
+  const code = [
+    source.slice(katexStart, katexEnd),
+    source.slice(mhchemStart, mhchemEnd),
+    'init_katex_stub(); init__webui_katex_mhchem_stub(); return katex_stub_exports;',
+  ].join('\n');
+  const esmMin = (fn, result, error) => () => {
+    if (error) throw error[0];
+    try {
+      return fn && (result = fn(fn = 0)), result;
+    } catch (cause) {
+      throw error = [cause], cause;
+    }
+  };
+  const styles = [];
+  const document = {
+    querySelector: () => null,
+    createElement: () => ({ setAttribute() {}, textContent: '' }),
+    head: { append(node) { styles.push(node); } },
+  };
+  const runtime = new Function('__esmMin', 'document', code)(esmMin, document);
+  assert.equal(typeof runtime.renderToString, 'function');
+
+  const samples = [
+    ['1+2+\\cdots+n=\\dfrac{n(n+1)}{2}', false],
+    ['\\displaystyle\\int_{-\\infty}^{+\\infty}e^{-x^2}\\mathrm{d}x=\\sqrt{\\pi}', true],
+    ['\\displaystyle\\oint_S \\mathbf E\\cdot\\mathrm d\\mathbf S=\\dfrac{Q_{\\text{内}}}{\\varepsilon_0}', true],
+    ['K', false],
+    ['\\ce{H2O}', false],
+  ];
+  for (const [formula, displayMode] of samples) {
+    const html = runtime.renderToString(formula, { displayMode, throwOnError: true });
+    assert.match(html, /class="katex"/);
+  }
+  assert.equal(styles.length, 1, 'KaTeX CSS should be injected once');
+});

--- a/test/webui-layout-compat.test.mjs
+++ b/test/webui-layout-compat.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { migrateWebuiLayout } from '../scripts/webui-layout-compat.mjs';
+import { migrateStatusRotator } from '../scripts/status-rotator-compat.mjs';
+
+const usage = 'name: "usage",\n\t\t\t\tchildren: /* @__PURE__ */ (0, react_jsx_runtime.jsx)(UsageWorkbenchEntry, {})';
+test('AIO removes only the WebUI usage/balance sidebar portal', () => {
+  const source = `prefix\n${usage}\nname: "skills",\nchildren: SkillsEntry\nsuffix`;
+  const patched = migrateWebuiLayout(source);
+  assert.match(patched, /name: "usage",\n\t\t\t\tchildren: null/);
+  assert.match(patched, /name: "skills",\nchildren: SkillsEntry/);
+  assert.equal(migrateWebuiLayout(patched), patched);
+});
+
+test('AIO disables the status-rotator pill after all config sources merge', () => {
+  const source = '\t\t\t\tconfig = cfg;\n';
+  const patched = migrateStatusRotator(source);
+  assert.ok(patched.includes('cfg.pill = { ...(cfg.pill || {}), enabled: false };'));
+  assert.equal(migrateStatusRotator(patched), patched);
+  const crlf = migrateStatusRotator(source.replace(/\n/g, '\r\n'));
+  assert.ok(crlf.includes('\r\n'));
+  assert.ok(!/(?<!\r)\n/.test(crlf));
+});

--- a/test/webui-optimizer-visibility.test.mjs
+++ b/test/webui-optimizer-visibility.test.mjs
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import vm from 'node:vm';
 import { createRequire } from 'node:module';
+import { migrateWebuiPromptOptimize } from '../scripts/webui-prompt-optimize-compat.mjs';
 
 const require = createRequire(import.meta.url);
 const seed = process.env.DSH_PUBLIC_R5 ||
   'H:/CODEX/build-inputs/aio-1.2.0-public-seed-20260908-r5';
 const webui = `${seed}/profiles/web-desktop/node_modules/@dsh-external/dsh-webui/lib/client.js`;
 const available = fs.existsSync(webui);
-const source = available ? fs.readFileSync(webui, 'utf8') : '';
+const source = available ? migrateWebuiPromptOptimize(fs.readFileSync(webui, 'utf8')) : '';
 function between(text, start, end) {
   const from = text.indexOf(start);
   const to = text.indexOf(end, from + start.length);
@@ -17,7 +18,7 @@ function between(text, start, end) {
   return text.slice(from, to);
 }
 
-test('r5 optimizer defaults on; actual module cache sync needs the next registration pass',
+test('optimizer defaults on and stale local module cache is reconciled immediately',
   { skip: !available }, async () => {
     const settings = require('js-yaml').load(fs.readFileSync(`${seed}/settings.yaml`, 'utf8'));
     const flags = between(source, 'const WEBUI_MODULE_KEYS = ', '//#endregion');
@@ -39,12 +40,15 @@ test('r5 optimizer defaults on; actual module cache sync needs the next registra
     assert.equal(api.isModuleEnabled(settings['webui-modules'], 'promptOptimize'), true);
     const startupDecision = api.isModuleEnabled(api.readStoredModules(), 'promptOptimize');
     assert.equal(startupDecision, false);
-    api.syncServerModules();
+    let syncedModules;
+    api.syncServerModules(modules => { syncedModules = modules; });
     await synchronized;
     assert.equal(api.isModuleEnabled(api.readStoredModules(), 'promptOptimize'), true);
-    assert.equal(startupDecision, false, 'already-skipped startup registration is not rerun');
+    assert.equal(api.isModuleEnabled(syncedModules, 'promptOptimize'), true);
     assert.match(source, /PromptOptimizeButton\(\{ available, directory, useInput,/);
-    assert.match(source, /if \(on\("promptOptimize"\)\) applyPromptOptimize\(ctx\)/);
+    assert.match(source, /const mountPromptOptimize = \(\) => \{/);
+    assert.match(source, /syncServerModules\(\(modules\) => \{/);
+    assert.match(source, /if \(on\("promptOptimize"\)\) mountPromptOptimize\(\);/);
   });
 
 test('actual island selection keeps optimizer right-slot contribution visible by default',

--- a/test/webui-prompt-optimize-compat.test.mjs
+++ b/test/webui-prompt-optimize-compat.test.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 import { Context } from '@deepseek-ai/cordis';
 import HttpServer from '@deepseek-ai/dsh-host-webserver';
 import { migrateWebuiPromptOptimize } from '../scripts/webui-prompt-optimize-compat.mjs';
+import { migrateWebuiNativeModelSelection } from '../scripts/webui-native-model-selection-compat.mjs';
 
 const require = createRequire(import.meta.url);
 const React = require('react');
@@ -48,13 +49,20 @@ test('optimizer migration is bounded and idempotent', { skip: !available }, () =
   const fixed = migrateWebuiPromptOptimize(source);
   assert.equal(migrateWebuiPromptOptimize(fixed), fixed);
   assert.throws(() => migrateWebuiPromptOptimize('unexpected'), /Unrecognized/);
-  assert.equal(fixed.replace('NS$1 = "webui.skill";', 'NS$1 = "skill";')
-    .replace('"modelDirectories",\n\t\t\t\t"remote.session",\n\t\t\t\t"sessions"',
-      '"modelDirectories",\n\t\t\t\t"sessions"')
-    .replace('key: "skill",\n\t\t\t\tpriority: -100,\n\t\t\t\tlocale: NS$1',
-      'key: "skill",\n\t\t\t\tlocale: NS$1').replace(
-    'useInput, inputActions, sessionId }) {\n\t\t\tconst input = useInput((state) => state);',
-    'input, inputActions, sessionId }) {'), source);
+  assert.match(fixed, /function syncServerModules\(onModulesSynced\)/);
+  assert.match(fixed, /const mountPromptOptimize = \(\) => \{/);
+  assert.match(fixed, /syncServerModules\(\(modules\) => \{/);
+  assert.doesNotMatch(fixed, /if \(on\("promptOptimize"\)\) applyPromptOptimize\(ctx\);/);
+  assert.match(fixed, /if \(on\("promptOptimize"\)\) mountPromptOptimize\(\);/);
+  assert.match(fixed, /NS\$1 = "webui\.skill";/);
+  assert.match(fixed, /"remote\.session",\n\t\t\t\t"sessions"/);
+});
+
+test('native provider/model selection disables the WebUI replacement', { skip: !available }, () => {
+  const fixed = migrateWebuiNativeModelSelection(source);
+  assert.equal(migrateWebuiNativeModelSelection(fixed), fixed);
+  assert.match(fixed, /AIO keeps provider\/model selection in the host native control/);
+  assert.doesNotMatch(fixed, /if \(on\("modelSeats"\)\) applyModelSeats\(ctx\);/);
 });
 
 test('actual optimizer slot registers and renders with current useInput props', { skip: !available }, () => {


### PR DESCRIPTION
## 修复内容\n\n- 恢复宿主原生供应商/模型选择，移除 WebUI 自定义替代选择器。\n- 为 Markdown 接入审核后的 KaTeX，支持 VS Code 常用的 $...$、$$...、\\(...\\)、\\[...\\]、fenced math/latex/tex 及 LaTeX 环境公式，并支持化学公式。\n- 修复提示词优化在旧 localStorage 模块缓存下不挂载的问题。\n- 将底部 stats.* 原始键转换为可读统计，移除 tok/s 项；隐藏左侧用量/余额入口和右侧空闲/tok/s 状态 Pill。\n- 安装默认使用按版本隔离的数据目录，不删除旧版本；安装包图标使用 DeepSeekHarness-WhaleGirl.ico。\n- 加强 staged seed 修复与安装器重启/卸载验收。\n\n## 验证\n\n- JavaScript: 727 tests, 726 passed, 1 skipped, 0 failed\n- Rust: 21 passed, 0 failed\n- AIO installer E2E: PASS，覆盖 Unicode 安装路径、首次启动、第二次启动 profile gate、隔离数据、端口/进程清理和卸载\n- Setup SHA256: FCBF825F7F92264BCBB1E7DC3ECEF61CCF7540BF3C2B592A80381F221AB1FA11\n- Portable SHA256: 361C07708257B7A08190FDE15C9661D04893F805CC8603EFA5A9F6FB75AE106B