### PR TITLE
fix(picturereader): 适配内核 0.1.3 的 settings 命名空间 API（修复内置插件拖垮插件树）

### DIFF
--- a/dsh-desktop/assets/SOURCES.json
+++ b/dsh-desktop/assets/SOURCES.json
@@ -1193,13 +1193,13 @@
       "name": "picturereader",
       "type": "plugin",
       "origin": "upstream",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "path": "dsh-desktop/assets/plugins/picturereader",
       "registryStatus": "注册表默认启用",
       "audit": {
         "verdict": "catalog-hit",
         "compare": "same-version-modified",
-        "note": "同步 picturereader 3.3.2：补齐文本模型将 image block 预降级为 attachment sha256 提示时的本地附件恢复；仍保留 EAC 内核 settings namespace 适配说明与内嵌运行依赖分类。",
+        "note": "同步 picturereader 3.3.3：适配内核 0.1.3 的 settings 命名空间 API 变更（dsh-settings 移除 settingsNamespace() 导出，改为 sctx.settings.register(NS, ...)，register 内部完成命名空间校验）；此前 3.3.2 补齐文本模型将 image block 预降级为 attachment sha256 提示时的本地附件恢复；仍保留 EAC 内核 settings namespace 适配说明与内嵌运行依赖分类。",
         "basis": "package.repository明确声明",
         "conflict": null
       },

--- a/dsh-desktop/assets/plugins/picturereader/README.md
+++ b/dsh-desktop/assets/plugins/picturereader/README.md
@@ -1,6 +1,6 @@
 # picturereader
 
-> **v3.3.2** — 给纯文本模型（DeepSeek / text-only）的全能「看图 / 读文档 / 修图」能力。
+> **v3.3.3** — 给纯文本模型（DeepSeek / text-only）的全能「看图 / 读文档 / 修图」能力。
 > 融合 **视觉孪生 adapter**（把任意文本模型原位包装成「支持图片」→ DSH 原生缩略图 + 图片块自动分析）、**三模式路由**、**本地像素级工具链**（scan / OCR×4 引擎 / crop / palette / compare / batch）、**文档转图片**（pdf / word / excel / ppt）、**本地修图工具 `image_edit`**（Pillow/OpenCV 纯 CPU：缩放 / 旋转 / 滤镜 / 合成 / 水印 / 去背景 / 超分等）与**可选外部 VLM 桥**。一个插件全包。
 >
 > **v3.3.0 新增**：**macOS 原生 Vision OCR 引擎**（`engine="macos"`，`scripts/setup-macos.mjs` 一键编译，PR #4 合入）；OCR 引擎选项按平台条件显示（macos 仅 macOS、windows 仅 Windows，paddle/rapid 跨平台始终显示）；修复 PaddleOCR 新环境首次调用三个缺陷（stdout 污染 / w/h→width/height / 缓存路径写死，issue #2）；设置卡 UI 重做（settings-panel 设计语言）；调试日志门控（llm/stream 桥不再刷屏）；peerDependencies 兼容 DSH 0.1.1-rc.2（issue #3）。
@@ -21,7 +21,9 @@ picturereader 现在解决三件事：
 2. **通过「视觉孪生 adapter」让纯文本模型在 DSH 里获得原生缩略图体验**：勾选模型即生成「(视觉)」变体，粘贴图片显示原生缩略图、图片块进会话、并被自动分析成文本路径 + 本地证据再交给模型。即使上游先降级为 `attachment sha256` 文本，图片桥也会仅从本机附件对象库恢复经过文件头校验的图片并注入本地工具路径；模型拿到的永远是纯文本，不会触发 `UNSUPPORTED_CONTENT`。
 3. **本地直接修图 / 批量处理图片**：`image_edit` 提供缩放、旋转、滤镜、合成、水印、去背景、拼接、透视校正等纯 CPU 动作，图片不出本机。
 
-> **版本兼容性**：本版本专门兼容 **dsh 0.1.1-rc.2** 及 **dsheac 5.1.0**，已针对这两个版本进行适配测试与优化，确保稳定运行。同时兼容 DeepSeek Harness EAC 4.2.0 与 `@deepseek-ai/dsh-client-ui-workspace` rc.7。`peerDependencies` 采用 `^0.1.0-rc.6 || ^0.1.1-rc.2` 联合区间，覆盖两条 0.1.x 发布线。
+> **版本兼容性**：本版本专门兼容 **dsh 0.1.3-alpha.1 / dsheac 5.4.0**，同时向后兼容 **dsh 0.1.1-rc.2** 与 **dsheac 5.1.0**，以及 DeepSeek Harness EAC 4.2.0 与 `@deepseek-ai/dsh-client-ui-workspace` rc.7。`peerDependencies` 采用 `^0.1.0-rc.6 || ^0.1.1-rc.2 || ^0.1.3-alpha.1` 联合区间，覆盖三条 0.1.x 发布线。
+>
+> ⚠️ **升级到 dsh 0.1.3 必须使用 v3.3.2 之后的版本**：内核 0.1.3 起 `@deepseek-ai/dsh-settings` 不再导出 `settingsNamespace()` 品牌函数（命名空间校验收进 `register()` 内部）。ESM 静态导入不存在的符号会让模块**整体加载失败**，进而拖垮整棵插件树、触发 EAC 的 guard 安全模式（表现为「一对话就报错」+ 插件大范围消失）。v3.3.3 已适配。
 
 > 🚀 **后续将作为 DeepSeek Harness EAC 的内置视觉插件**：本插件计划替换内置的 `dsh-tool-vision`，随 DSH EAC 桌面版直接捆绑发布，开箱即用。作为独立包发布的目的，是让非 EAC / 旧版用户也能通过 `dsh plugin add picturereader` 或 Git/npm 安装获得同等「看图 / 读文档」能力。
 
@@ -407,13 +409,20 @@ await main()
 
 ## 版本更新日志
 
-### v3.3.2（本次）
+### v3.3.3（本次）
+
+- **适配 dsh 0.1.3-alpha.1 / dsheac 5.4.0 的 settings 命名空间 API 变更（关键修复）**：内核 0.1.3 起 `@deepseek-ai/dsh-settings` 只导出 `SettingsConflictError` / `SettingsProvider` / `redactSecrets`，`settingsNamespace()` 品牌函数被移除（命名空间校验收进 `register()` 内部，见内核 `parseSettingsNamespace`）。原先 `import { settingsNamespace } from '@deepseek-ai/dsh-settings'` 在 ESM 静态解析阶段即失败，导致插件模块加载失败、整棵插件树崩溃 —— 在 EAC 上表现为更新后「一对话就报错」并触发 guard 安全模式（插件行被大范围剥离）。现改为把裸 `NS` 直接交给 `sctx.settings.register(NS, Config, { base: config })`，`register()` 自行完成命名空间校验，返回的 scope 仍具备 `get / watch / update / replace`，行为不变。
+- **`peerDependencies` 补上 0.1.3 线**：`^0.1.0-rc.6 || ^0.1.1-rc.2 || ^0.1.3-alpha.1`（`@deepseek-ai/dsh-settings` 与 `@deepseek-ai/dsh-llm`），避免新环境安装时被旧的版本区间误导。
+- 逐项复核其余 `@deepseek-ai/*` 导入：`contentHasImage`（`dsh-llm`）与 `schemastery` 默认导出在 0.1.3 上均仍存在，无需改动。
+- 兼容性保持不变：0.1.1-rc.2 / dsheac 5.1.0 及更早内核下行为与 v3.3.2 一致。
+
+### v3.3.2
 
 - **修复文本模型附件降级链路**：当模型入口将图片改写为 `[image omitted ...; attachment sha256:…]` 时，图片桥会在本地附件对象库中按 SHA 前缀查找唯一对象，验证 PNG/JPEG/GIF/BMP/WebP 文件头后导出并注入 `image_scan` / `image_ocr` 引导；找不到、前缀歧义或非图片对象时保持原文本，不猜测路径。
 - 修复全局 SHA 匹配正则的状态残留，避免同轮多次检测后遗漏附件。
 - 新增 SHA 降级恢复与无效 SHA 保持原文本的回归用例；`npm test` 全量 **148 通过 / 0 失败**。
 
-### v3.3.1（本次）
+### v3.3.1
 
 - 元数据修正：npm `description` 中 OCR 引擎数量更正为 ×4（windows / macos / paddle / rapid）。
 

--- a/dsh-desktop/assets/plugins/picturereader/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/picturereader/dsh-plugin.json
@@ -3,7 +3,7 @@
   "manifestVersion": "0.15",
   "id": "io.github.jing-hy.picturereader",
   "name": "picturereader",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "facets": {
     "host": {
       "entry": "src/index.js",

--- a/dsh-desktop/assets/plugins/picturereader/package.json
+++ b/dsh-desktop/assets/plugins/picturereader/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "picturereader",
-    "version":  "3.3.2",
+    "version":  "3.3.3",
     "repository":  {
                        "type":  "git",
                        "url":  "https://github.com/jing-hy/picturereader.git"
@@ -63,9 +63,9 @@
                            }
             },
     "peerDependencies":  {
-                             "@deepseek-ai/dsh-settings":  "^0.1.0-rc.6 || ^0.1.1-rc.2",
+                             "@deepseek-ai/dsh-settings":  "^0.1.0-rc.6 || ^0.1.1-rc.2 || ^0.1.3-alpha.1",
                              "@deepseek-ai/schemastery":  "^3.18.1",
-                             "@deepseek-ai/dsh-llm":  "^0.1.0-rc.6 || ^0.1.1-rc.2"
+                             "@deepseek-ai/dsh-llm":  "^0.1.0-rc.6 || ^0.1.1-rc.2 || ^0.1.3-alpha.1"
                          },
     "dependencies":  {
                          "jpeg-js":  "^0.4.4",

--- a/dsh-desktop/assets/plugins/picturereader/src/index.js
+++ b/dsh-desktop/assets/plugins/picturereader/src/index.js
@@ -30,7 +30,6 @@ import { createImageBatchTool } from './image-batch.js';
 import { createDocumentToImageTool } from './doc-tools.js';
 import { createImageEditTool } from './image-edit.js';
 import { NS } from './config.js';
-import { settingsNamespace } from '@deepseek-ai/dsh-settings';
 import z from '@deepseek-ai/schemastery';
 import { ensureSettingsNamespaceExposed } from './settings-expose.js';
 import { setRuntimeSource, getRuntimeConfig } from './runtime.js';
@@ -340,8 +339,10 @@ export function apply(ctx, config) {
   // ── 设置命名空间 + 模型扫描 + 视觉孪生路由（需要 settings 和 llm 服务）──
   ctx.inject(['settings', 'llm'], (sctx) => {
     const llm = sctx.llm;
-    const settingsNs = settingsNamespace(NS);
-    const scope = sctx.settings.register(settingsNs, Config, { base: config });
+    // 内核 0.1.3 起 dsh-settings 不再导出 settingsNamespace 品牌函数
+    // （命名空间校验收进 register() 内部，见内核 parseSettingsNamespace）。
+    // 直接把裸 NS 交给 register 即可，返回的 scope 仍具备 get/watch/update/replace。
+    const scope = sctx.settings.register(NS, Config, { base: config });
     sourceGetter = () => scope.get();
     scope.watch(() => { /* 触发热更 */ });
 


### PR DESCRIPTION
## 背景

随包内核升级到 **0.1.3-alpha.1**（5.4.0）后，**内置的** `assets/plugins/picturereader` 会在加载阶段失败，并拖垮整棵插件树：

```
Error: dsh: plugin tree failed to load: failed to import loader entry picturereader (picturereader):
The requested module '@deepseek-ai/dsh-settings' does not provide an export named 'settingsNamespace'
```

根因：内核 0.1.3 把 `@deepseek-ai/dsh-settings` 的导出收敛为 `SettingsConflictError` / `SettingsProvider` / `redactSecrets`，`settingsNamespace()` 品牌函数被移除（命名空间校验收进 `register()` 内部，见内核 `parseSettingsNamespace()`）。插件顶层静态导入不存在的导出 = 模块整体加载失败 → `plugin tree failed to load` → `dsh web` 以 code=1 退出 → guard 进安全模式（本次实测 `removed: 47`，即 `cordis.patch.yml` 的配套插件行被大范围剥离，用户侧表现为「更新后一对话就报错」+ 插件消失、侧栏变样）。

内置副本必须同步修复，否则**全新安装的 5.4.0 用户只要启用 picturereader 就会复现**（本机安装目录 `assets/plugins/picturereader/src/index.js` 与仓库副本同源，仅行尾差异）。

## 改动

`dsh-desktop/assets/plugins/picturereader/`（内置副本，3 处）：

- `src/index.js`
  - 删除 `import { settingsNamespace } from '@deepseek-ai/dsh-settings';`
  - 改为 `sctx.settings.register(NS, Config, { base: config })`，由 `register()` 自行完成命名空间校验；返回 scope 仍具备 `get / watch / update / replace`，行为不变
- `package.json`：`version` 3.3.2 → **3.3.3**；`peerDependencies` 补 `^0.1.3-alpha.1` 线（`dsh-settings` / `dsh-llm`）
- `README.md`：版本标记、兼容性矩阵（兼容 dsh 0.1.3 / dsheac 5.4.0，向后兼容 0.1.1-rc.2 / 5.1.0）、新增 v3.3.3 变更日志与升级警告

上游同步：同源修复已提 `jing-hy/picturereader#8`，两边 `src/` 内容逐文件校验一致（仅行尾差异）。

## 验证

- `node --check src/index.js` 通过
- 插件仓库 `npm test`：**148 通过 / 0 失败**
- 内置副本 `src/` 与插件仓库 `src/` 做**忽略行尾的内容比对：16 个文件全部一致**（证明两边同源，未引入额外分叉）
- 实机（EAC 5.4.0 + 内核 0.1.3-alpha.1，全量插件树 91 插件）：插件加载无报错，picturereader 设置命名空间注册成功

## 影响面

- 仅内置插件副本（`assets/plugins/picturereader/`）与其元数据
- 不涉及 L1 Rust 壳、sidecar、bridge 契约
- 向后兼容：0.1.1-rc.2 / dsheac 5.1.0 内核下行为与 3.3.2 一致

## 备注（后续独立处理，不在本 PR）

本次事故还暴露出两个独立问题，将另开 PR：
1. 启动期**零隔离**：任一插件 import 失败即整树 fail（`client-hmr` 的 `ctx.clientModules.artifactBaseline is not a function` 亦属此类，源于安装目录混入的旧 `dsh-client-modules` 副本）
2. guard 安全模式**只删行不加回**：`companion-sync.js` 在 `safeModeActive()` 时跳过配套行写入，退出后无恢复入口，叠加 10 份快照上限导致更新前的完整插件行不可恢复
