### PR TITLE
feat(builtin): 内置中文思考增强插件（EAC 派生版）并同步插件市场 0.4.0

### DIFF
--- a/.sync/plugins.json
+++ b/.sync/plugins.json
@@ -1729,6 +1729,46 @@
         "reviewOnChange": true
       },
       "owner": "desktop-plugins"
+    },
+    {
+      "id": "think-zh-expand-eac",
+      "kind": "plugin",
+      "path": "dsh-desktop/assets/plugins/dsh-think-zh-expand-eac",
+      "packageName": "dsh-think-zh-expand-eac",
+      "class": "follow-upstream",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+      },
+      "request": {
+        "mode": "latest",
+        "range": "*",
+        "releaseAgeHours": 24
+      },
+      "sync": {
+        "mode": "mirror",
+        "patches": [],
+        "preservePaths": []
+      },
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "github",
+          "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+        }
+      },
+      "validation": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "commands": []
+      },
+      "license": {
+        "expected": "MIT",
+        "reviewOnChange": true
+      },
+      "owner": "desktop-plugins"
     }
   ],
   "skins": [

--- a/.sync/plugins.lock.json
+++ b/.sync/plugins.lock.json
@@ -1,7 +1,7 @@
 {
   "generatedRegistry": "dsh-desktop/lib/desktop/plugin-sync-registry.ts",
   "manifest": ".sync/plugins.json",
-  "manifestRevision": "607f34e28aaeb18f570a62e1c84bab93e0ed3572fd12b53603886ac45789cd67",
+  "manifestRevision": "699f9a9e4e6ae55bf0cefe82e5db0c35576bb91c40bd41f50ba87d15298d1e97",
   "plugins": {
     "agent-teams": {
       "compatibility": {},
@@ -10,12 +10,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 64,
+        "fileCount": 65,
         "license": "MIT",
         "packageName": "@nanmicoder/dsh-agent-teams",
         "packageVersion": "0.1.13-eac.3",
         "path": "dsh-desktop/assets/plugins/dsh-agent-teams",
-        "treeSha256": "008de766b0a63082d856568573a921522a945d751bd23838a775287704f0284f"
+        "treeSha256": "058202948a0bc1fa4b2d9538738ded4ff580a8bf74c03e343008b8f1e7bced6d"
       },
       "manifestEntrySha256": "120ff5689beba794843f70ff0cc9f9acee40d886ab131278a0e13c3978d75fb6",
       "patchFiles": [],
@@ -26,7 +26,7 @@
       "source": {
         "kind": "github",
         "repository": "git+https://github.com/NanmiCoder/dsh-agent-teams.git",
-        "sha256": "008de766b0a63082d856568573a921522a945d751bd23838a775287704f0284f",
+        "sha256": "058202948a0bc1fa4b2d9538738ded4ff580a8bf74c03e343008b8f1e7bced6d",
         "version": "0.1.13-eac.3"
       },
       "sourceCommit": null
@@ -38,12 +38,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-balance",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-balance",
-        "treeSha256": "724979b2283c960637d87c71d20e81bce43a70027c27cff6f55afdee2d2910c1"
+        "treeSha256": "d6fd395d9153b96ad207774919329e934fc442634e673328582933ee2c357bb4"
       },
       "manifestEntrySha256": "1ecb7c22a146fbf7726b952163e567192302879b232cb2fc9dbbed0f413ee8ca",
       "patchFiles": [],
@@ -54,7 +54,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-balance",
-        "sha256": "724979b2283c960637d87c71d20e81bce43a70027c27cff6f55afdee2d2910c1",
+        "sha256": "d6fd395d9153b96ad207774919329e934fc442634e673328582933ee2c357bb4",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -66,12 +66,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 115,
+        "fileCount": 116,
         "license": "MIT",
         "packageName": "dsh-better-sidebar",
         "packageVersion": "0.15.3-eac.2",
         "path": "dsh-desktop/assets/plugins/dsh-better-sidebar",
-        "treeSha256": "75492306c5db2e79775fccf7268e3f6741857f9aca8392205f57113e6cf838c7"
+        "treeSha256": "797a9aa65e744cf8eab12ab2e902182346252e1cce243eb29891a5f85a465b44"
       },
       "manifestEntrySha256": "aa31f11c164097334b61ce1b19a7324668e8d680a244a8ae57b3ba77b52f35e3",
       "patchFiles": [],
@@ -83,7 +83,7 @@
         "kind": "npm",
         "name": "dsh-better-sidebar",
         "repository": "https://github.com/omdsh-dev/DSH-better-sidebar",
-        "sha256": "75492306c5db2e79775fccf7268e3f6741857f9aca8392205f57113e6cf838c7",
+        "sha256": "797a9aa65e744cf8eab12ab2e902182346252e1cce243eb29891a5f85a465b44",
         "version": "0.15.3-eac.2"
       },
       "sourceCommit": null
@@ -95,12 +95,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-change-review",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-change-review",
-        "treeSha256": "5f0fd1cc43871a5e3a12e0ae4f7e2c89768e3156ede7cbc33d4ab4dbd68e24b0"
+        "treeSha256": "3a94180a86a9f6aaa19a0d175bd32e76b4944c39640eedc65083c95bb0d6401f"
       },
       "manifestEntrySha256": "f63d8a7351724d644eb89f4707a019d4f14ad6c582f5a7c1caa587cce6746961",
       "patchFiles": [],
@@ -110,7 +110,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "5f0fd1cc43871a5e3a12e0ae4f7e2c89768e3156ede7cbc33d4ab4dbd68e24b0",
+        "sha256": "3a94180a86a9f6aaa19a0d175bd32e76b4944c39640eedc65083c95bb0d6401f",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -122,12 +122,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-client-file-changes",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-client-file-changes",
-        "treeSha256": "6de3a924956a7a0b324a82109e79ecf2d14a78d9c27efd6a70b371e082740a10"
+        "treeSha256": "3a36aace2409a17bbb0721b4d2fab38dc25f52b04c332f0ba43f7fec2feed66d"
       },
       "manifestEntrySha256": "29784a5442ed92ceaa93721d3e7364ee1ce61ae66a8bacf0d6b4b0779213d234",
       "patchFiles": [],
@@ -138,7 +138,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-client-file-changes",
-        "sha256": "6de3a924956a7a0b324a82109e79ecf2d14a78d9c27efd6a70b371e082740a10",
+        "sha256": "3a36aace2409a17bbb0721b4d2fab38dc25f52b04c332f0ba43f7fec2feed66d",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -150,12 +150,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 9,
+        "fileCount": 10,
         "license": "MIT",
         "packageName": "dsh-compact",
         "packageVersion": "1.0.0",
         "path": "dsh-desktop/assets/plugins/dsh-compact",
-        "treeSha256": "319befbb1f5312e9f573f6daf5fa52806d1f96f4e0c78e80ac98af72c82ecb51"
+        "treeSha256": "190eb4915553fc1a60da53851d284e8d15987957a7cc8a6391cb9047b4dff725"
       },
       "manifestEntrySha256": "2cf65bbbf0a3240bd02fc40d42dc564446219a88f6d972da681a64370bd666c5",
       "patchFiles": [],
@@ -165,7 +165,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "319befbb1f5312e9f573f6daf5fa52806d1f96f4e0c78e80ac98af72c82ecb51",
+        "sha256": "190eb4915553fc1a60da53851d284e8d15987957a7cc8a6391cb9047b4dff725",
         "version": "1.0.0"
       },
       "sourceCommit": null
@@ -182,7 +182,7 @@
         "packageName": "dsh-composer-dynamic-island",
         "packageVersion": "2.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-composer-dynamic-island",
-        "treeSha256": "c12a2654229976a425c341413da2494119e4c909318c711c378b389ab67d474e"
+        "treeSha256": "c2cbb1c34aa9c049ae816889a61e8ced4c40505e2be5bba4a03ed220125d15f5"
       },
       "manifestEntrySha256": "c3201847d612da00fa8eabff0b509d69a1214dbe98975199deeda5a44f444741",
       "patchFiles": [],
@@ -193,7 +193,7 @@
       "source": {
         "kind": "github",
         "repository": "git+https://github.com/says693/dsh-composer-dynamic-island.git",
-        "sha256": "c12a2654229976a425c341413da2494119e4c909318c711c378b389ab67d474e",
+        "sha256": "c2cbb1c34aa9c049ae816889a61e8ced4c40505e2be5bba4a03ed220125d15f5",
         "version": "2.1.0"
       },
       "sourceCommit": null
@@ -205,12 +205,12 @@
           "src/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 24,
+        "fileCount": 25,
         "license": "MIT",
         "packageName": "computer-user",
         "packageVersion": "0.3.6",
         "path": "dsh-desktop/assets/plugins/computer-user",
-        "treeSha256": "b3d159d6bf39718d6aca90e8614d2a0fa114b0174c26b6b03e6c20b758fda552"
+        "treeSha256": "8ec2f3dfc45096cbdf1dd9a781f02621d51c3b9c3d0354c5c07245bc1ff9029e"
       },
       "manifestEntrySha256": "1fe24465c04f34c3b32d85da98af5254e7550be0d621b76570c889c21d8483ac",
       "patchFiles": [],
@@ -222,7 +222,7 @@
         "kind": "npm",
         "name": "computer-user",
         "repository": "git+https://github.com/jing-hy/computer-user.git",
-        "sha256": "b3d159d6bf39718d6aca90e8614d2a0fa114b0174c26b6b03e6c20b758fda552",
+        "sha256": "8ec2f3dfc45096cbdf1dd9a781f02621d51c3b9c3d0354c5c07245bc1ff9029e",
         "version": "0.3.6"
       },
       "sourceCommit": null
@@ -234,12 +234,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 4,
+        "fileCount": 5,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-conversation-tweaks",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-conversation-tweaks",
-        "treeSha256": "33922e597a36ac154daf073592e6463a60b771e80bdc58d513612d9855974537"
+        "treeSha256": "88d6ef3c067e0caa2e655bb2e6380133f189d115ad986d8178865bbf9f5e4057"
       },
       "manifestEntrySha256": "981db0608e6d011c717137a18497655f1f5d7312b0edbe4495ddcc3689a209a3",
       "patchFiles": [],
@@ -250,7 +250,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-conversation-tweaks",
-        "sha256": "33922e597a36ac154daf073592e6463a60b771e80bdc58d513612d9855974537",
+        "sha256": "88d6ef3c067e0caa2e655bb2e6380133f189d115ad986d8178865bbf9f5e4057",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -262,12 +262,12 @@
           "lib/host.js"
         ],
         "excludedPaths": [],
-        "fileCount": 6,
+        "fileCount": 7,
         "license": "MIT",
         "packageName": "dsh-dock-settings",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-dock-settings",
-        "treeSha256": "bc683696a055008206b63b12b2300f31e6e4da1ac8551bf095f96d5e7a947bf7"
+        "treeSha256": "72d369ac4ad0da55a765daf45545eacfbff631dd70250844c4e7e18c6bea6e3e"
       },
       "manifestEntrySha256": "a30fb9b9d132ca6f5c7402ff0ac605bc4c18a4b6df0197aa1035df0827c30d67",
       "patchFiles": [],
@@ -277,7 +277,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "bc683696a055008206b63b12b2300f31e6e4da1ac8551bf095f96d5e7a947bf7",
+        "sha256": "72d369ac4ad0da55a765daf45545eacfbff631dd70250844c4e7e18c6bea6e3e",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -289,12 +289,12 @@
           "src/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 71,
+        "fileCount": 72,
         "license": "SEE LICENSE IN ASSET_LICENSE.md",
         "packageName": "dsh-dafeiyu",
         "packageVersion": "0.1.0-alpha.6",
         "path": "dsh-desktop/assets/plugins/dsh-dafeiyu",
-        "treeSha256": "7d291df3f269aed3ddc6f8874469a858a19531611c497db90171c795e0216ed4"
+        "treeSha256": "ced8c98459dab8261dcde2fbb426f668506a6cbde94e843977f7cb52a6ed6784"
       },
       "manifestEntrySha256": "964210a5fe5501a6a43204e9e93f7ad1e58f9a765d2419505d19a05c1eac764a",
       "patchFiles": [],
@@ -305,7 +305,7 @@
       "source": {
         "kind": "github",
         "repository": "git+https://github.com/QCYTSN/dsh-dafeiyu.git",
-        "sha256": "7d291df3f269aed3ddc6f8874469a858a19531611c497db90171c795e0216ed4",
+        "sha256": "ced8c98459dab8261dcde2fbb426f668506a6cbde94e843977f7cb52a6ed6784",
         "version": "0.1.0-alpha.6"
       },
       "sourceCommit": null
@@ -317,12 +317,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-feature-toggles",
         "packageVersion": "0.1.1",
         "path": "dsh-desktop/assets/plugins/dsh-feature-toggles",
-        "treeSha256": "4f433b46e8f8cf9580147a53d3439e80d2e62fd2364ac3560c39887333396687"
+        "treeSha256": "2da3162441c422484d530824b05f76864b4a2d0dc845fd83d2a371a199c88a4c"
       },
       "manifestEntrySha256": "6e313940c15585dd1f72d45cd3da36d69e68724144128daf38e4f02c8595cd8e",
       "patchFiles": [],
@@ -332,7 +332,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "4f433b46e8f8cf9580147a53d3439e80d2e62fd2364ac3560c39887333396687",
+        "sha256": "2da3162441c422484d530824b05f76864b4a2d0dc845fd83d2a371a199c88a4c",
         "version": "0.1.1"
       },
       "sourceCommit": null
@@ -344,12 +344,12 @@
           "lib/index.mjs"
         ],
         "excludedPaths": [],
-        "fileCount": 6,
+        "fileCount": 7,
         "license": "MIT",
         "packageName": "@vlln/dsh-navbar",
         "packageVersion": "0.3.0",
         "path": "dsh-desktop/assets/plugins/dsh-navbar",
-        "treeSha256": "4e78d9d45a87fc9053d8bdb87b3ddc6a7a689e736440f7c44708b4d8a5db4905"
+        "treeSha256": "616be114c0cc98b84747e74d6c1f44c57245a348421f99a83204b944977c34b9"
       },
       "manifestEntrySha256": "6583905ad3fc8d712ebbc92b7e9ba747a2a578dd4d5eef0e2fa4dca8965ba343",
       "patchFiles": [],
@@ -360,7 +360,7 @@
       "source": {
         "kind": "npm",
         "name": "@vlln/dsh-navbar",
-        "sha256": "4e78d9d45a87fc9053d8bdb87b3ddc6a7a689e736440f7c44708b4d8a5db4905",
+        "sha256": "616be114c0cc98b84747e74d6c1f44c57245a348421f99a83204b944977c34b9",
         "version": "0.3.0"
       },
       "sourceCommit": null
@@ -372,12 +372,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 37,
+        "fileCount": 38,
         "license": "MIT",
         "packageName": "dsh-pet",
         "packageVersion": "0.1.3",
         "path": "dsh-desktop/assets/plugins/dsh-pet",
-        "treeSha256": "bb924c4efb4a1b83ed4fa86164c4165b9247faa06c78af17f6bd50f29aa3a8e8"
+        "treeSha256": "b190e8e87deb710a2b5e516fd78797d6d16107a1745f3ba39017c3b03ed2cf48"
       },
       "manifestEntrySha256": "f923bfc1a15b06fcfad8e4505f34954dc0b031bdaad670f6abbc8c8e34e6046e",
       "patchFiles": [],
@@ -389,7 +389,7 @@
         "kind": "npm",
         "name": "dsh-pet",
         "repository": "git+https://github.com/PC2005-cloud/dsh-pet.git",
-        "sha256": "bb924c4efb4a1b83ed4fa86164c4165b9247faa06c78af17f6bd50f29aa3a8e8",
+        "sha256": "b190e8e87deb710a2b5e516fd78797d6d16107a1745f3ba39017c3b03ed2cf48",
         "version": "0.1.3"
       },
       "sourceCommit": null
@@ -401,12 +401,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-pet-settings",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-pet-settings",
-        "treeSha256": "f45bbb9e2c827104b1a59cbd1622bbbb945b13c11a2ca4ba4366d856fccb9272"
+        "treeSha256": "8e16ecd0b62d7a8c81cad8eafe57e550d11dad5c75b3c09126f541b74abbd90c"
       },
       "manifestEntrySha256": "651355060428101a7df530cfc5b929dd4ce4d0eb515e1cf92cc6df5a788d568b",
       "patchFiles": [],
@@ -416,7 +416,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "f45bbb9e2c827104b1a59cbd1622bbbb945b13c11a2ca4ba4366d856fccb9272",
+        "sha256": "8e16ecd0b62d7a8c81cad8eafe57e550d11dad5c75b3c09126f541b74abbd90c",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -428,12 +428,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 5,
+        "fileCount": 6,
         "license": "MIT",
         "packageName": "dsh-phone",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-phone",
-        "treeSha256": "5c823dfbbcc53b115263e2cfbf3277e9e813a677dad56df8fe4565e42d21b003"
+        "treeSha256": "2253ef1d54aa49e764adbffff3d034bb2c8412953e68aafe1d7a177c88a128fa"
       },
       "manifestEntrySha256": "ebea0b3ed84ab4c80368ada3accaa7d89f35d0fc4af2606027e31aaa911f2399",
       "patchFiles": [],
@@ -444,7 +444,7 @@
       "source": {
         "kind": "internal",
         "name": "dsh-phone",
-        "sha256": "5c823dfbbcc53b115263e2cfbf3277e9e813a677dad56df8fe4565e42d21b003",
+        "sha256": "2253ef1d54aa49e764adbffff3d034bb2c8412953e68aafe1d7a177c88a128fa",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -455,13 +455,15 @@
         "entrypoints": [
           "lib/index.js"
         ],
-        "excludedPaths": [],
-        "fileCount": 54,
+        "excludedPaths": [
+          "assets/vendor"
+        ],
+        "fileCount": 55,
         "license": "MIT",
         "packageName": "dsh-raw-html",
         "packageVersion": "0.6.2",
         "path": "dsh-desktop/assets/plugins/dsh-raw-html",
-        "treeSha256": "a6581295c14ac1d451d5e39dcf81fe6de7d903b504e1880f8332f5227eeecbff"
+        "treeSha256": "57ebbc9a88d85722b9db488bad11987bd3e423041a039b72e3c9e77fd6f4e517"
       },
       "manifestEntrySha256": "b7268aafc7cbc1bd891886fb67258f44dbfa069de5d30461db70fb83f99aa489",
       "patchFiles": [],
@@ -472,7 +474,7 @@
       "source": {
         "kind": "internal",
         "name": "dsh-raw-html",
-        "sha256": "a6581295c14ac1d451d5e39dcf81fe6de7d903b504e1880f8332f5227eeecbff",
+        "sha256": "57ebbc9a88d85722b9db488bad11987bd3e423041a039b72e3c9e77fd6f4e517",
         "version": "0.6.2"
       },
       "sourceCommit": null
@@ -484,12 +486,12 @@
           "lib/index.mjs"
         ],
         "excludedPaths": [],
-        "fileCount": 6,
+        "fileCount": 7,
         "license": "MIT",
         "packageName": "dsh-session-manager",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-session-manager",
-        "treeSha256": "54a22859692224148e038500004bc12657902a17d34fbd692029680dcd3c375a"
+        "treeSha256": "e070a87d4be32169bef38d056a2b0be3bcff6d74212226f9402e111769c5abf8"
       },
       "manifestEntrySha256": "159f7030608135c99cc557b8702fa1acfc7cc0efbdc338cac29c8c08c512028a",
       "patchFiles": [],
@@ -500,7 +502,7 @@
       "source": {
         "kind": "npm",
         "name": "dsh-session-manager",
-        "sha256": "54a22859692224148e038500004bc12657902a17d34fbd692029680dcd3c375a",
+        "sha256": "e070a87d4be32169bef38d056a2b0be3bcff6d74212226f9402e111769c5abf8",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -512,12 +514,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 5,
+        "fileCount": 6,
         "license": "MIT",
         "packageName": "dsh-undo-savepoint",
         "packageVersion": "0.3.4",
         "path": "dsh-desktop/assets/plugins/dsh-undo-savepoint",
-        "treeSha256": "8b233d6cfb0c9c4ab65260ca172f8ccb3081cf42aaf6103f00cb027ea8f4f5c6"
+        "treeSha256": "6c191fb2bde9f5328f971c01b78936ae7a6bf29198de8c9c624e3171f40b77b4"
       },
       "manifestEntrySha256": "fb27830ee4d0a5a85bc3aca64601ce5cc4a99ea2bd3cf26b5b2b1fd3c2f18bb0",
       "patchFiles": [],
@@ -528,7 +530,7 @@
       "source": {
         "kind": "github",
         "repository": "https://github.com/lire1131/dsh-undo-savepoint",
-        "sha256": "8b233d6cfb0c9c4ab65260ca172f8ccb3081cf42aaf6103f00cb027ea8f4f5c6",
+        "sha256": "6c191fb2bde9f5328f971c01b78936ae7a6bf29198de8c9c624e3171f40b77b4",
         "version": "0.3.4"
       },
       "sourceCommit": null
@@ -540,12 +542,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 9,
+        "fileCount": 10,
         "license": "BSD-3-Clause",
         "packageName": "dsh-webui-prompt-optimizer",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-webui-prompt-optimizer",
-        "treeSha256": "a58b8279ff6ff7b32ad2d89729d4084de8c909dcb6f690377407f79fd41ff6af"
+        "treeSha256": "cf12e3071d3bbb0242992ab3eebe11561737399f268859d190ea20691f872ba7"
       },
       "manifestEntrySha256": "1af877483b9750a6c24e69c3030548384d1de1fda8bcc40d594aab3e3adda5cd",
       "patchFiles": [],
@@ -555,7 +557,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "a58b8279ff6ff7b32ad2d89729d4084de8c909dcb6f690377407f79fd41ff6af",
+        "sha256": "cf12e3071d3bbb0242992ab3eebe11561737399f268859d190ea20691f872ba7",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -567,12 +569,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 13,
+        "fileCount": 14,
         "license": "MIT",
         "packageName": "dsh-whale-widget",
         "packageVersion": "0.2.10",
         "path": "dsh-desktop/assets/plugins/dsh-whale-widget",
-        "treeSha256": "e69c25e1fef9d02cf6d1f8f544443e0ceda419c16eb7f5b51e820097a939da3d"
+        "treeSha256": "b73fec3fafbb677533ff5fe16b21184d7cd0cc182ce573a6a6c3f9ee4b36256b"
       },
       "manifestEntrySha256": "451468aeb99443ea5b5c0d3a301c414b78187cdb59ec6eef52f17f5aec4dfa9b",
       "patchFiles": [],
@@ -583,7 +585,7 @@
       "source": {
         "kind": "github",
         "repository": "git+https://github.com/MeteorNOX/DeepSeek-Balance-Whale-Widget.git",
-        "sha256": "e69c25e1fef9d02cf6d1f8f544443e0ceda419c16eb7f5b51e820097a939da3d",
+        "sha256": "b73fec3fafbb677533ff5fe16b21184d7cd0cc182ce573a6a6c3f9ee4b36256b",
         "version": "0.2.10"
       },
       "sourceCommit": null
@@ -595,12 +597,12 @@
           "index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 2,
+        "fileCount": 3,
         "license": "MIT",
         "packageName": "dsh-eac-core-bridge",
         "packageVersion": "1.0.0",
         "path": "dsh-desktop/assets/plugins/dsh-eac-core-bridge",
-        "treeSha256": "ca7b989cdd66f762b341faae9ebffe8dd742bb29463cb23b70495d14b1f3c145"
+        "treeSha256": "27e9bddb89c004157da64db9e7e3eeba72347d208984b7890da717c834af0184"
       },
       "manifestEntrySha256": "a452230bc4b70284d1a20cc9068c30ef7de2e73338e2eb36327d9fc3fd4e2ec0",
       "patchFiles": [],
@@ -610,7 +612,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "ca7b989cdd66f762b341faae9ebffe8dd742bb29463cb23b70495d14b1f3c145",
+        "sha256": "27e9bddb89c004157da64db9e7e3eeba72347d208984b7890da717c834af0184",
         "version": "1.0.0"
       },
       "sourceCommit": null
@@ -622,12 +624,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-eac-locale-compat",
         "packageVersion": "1.0.0",
         "path": "dsh-desktop/assets/plugins/dsh-eac-locale-compat",
-        "treeSha256": "09d14a469de595afdd31636acade7bea4b8b4e93368b9d35e6ed00ea2dee27b8"
+        "treeSha256": "03d62843a0f36c5c496ff93f9511ae200b67bb08e7f9432f21513cfb2bef9f20"
       },
       "manifestEntrySha256": "fa77e5647c14df2d6739113c05cc0f74f0df223ebd6b0f1803a4e0a42677f600",
       "patchFiles": [],
@@ -637,7 +639,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "09d14a469de595afdd31636acade7bea4b8b4e93368b9d35e6ed00ea2dee27b8",
+        "sha256": "03d62843a0f36c5c496ff93f9511ae200b67bb08e7f9432f21513cfb2bef9f20",
         "version": "1.0.0"
       },
       "sourceCommit": null
@@ -649,12 +651,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 4,
+        "fileCount": 5,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-easy-setup",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-easy-setup",
-        "treeSha256": "459d8a980525a074738859f0d5fedffc89e285ff704bda752017ad212a67b41d"
+        "treeSha256": "9608b6214c31b748ecbda92016ca86f04eb58dcf6fd1b15153170016c3ad128f"
       },
       "manifestEntrySha256": "aef538c02636206d5325e02e48e0f1946aad38ac29a6246fea181a54a25a2614",
       "patchFiles": [],
@@ -665,7 +667,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-easy-setup",
-        "sha256": "459d8a980525a074738859f0d5fedffc89e285ff704bda752017ad212a67b41d",
+        "sha256": "9608b6214c31b748ecbda92016ca86f04eb58dcf6fd1b15153170016c3ad128f",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -677,12 +679,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 2,
+        "fileCount": 3,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-file-changes",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-file-changes",
-        "treeSha256": "f4eeb8cd0260a32383ddb1f0f3a2234117cd15108dee3e247cf684c82b4bd907"
+        "treeSha256": "9a6ba31c271aa4f316a55155e245b6adf23730f11254094f983128d9938e079e"
       },
       "manifestEntrySha256": "44ac80cfe38428ccfd15ef965a1e9732d132f373f8afa472e0c932fe82da7007",
       "patchFiles": [],
@@ -693,7 +695,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-file-changes",
-        "sha256": "f4eeb8cd0260a32383ddb1f0f3a2234117cd15108dee3e247cf684c82b4bd907",
+        "sha256": "9a6ba31c271aa4f316a55155e245b6adf23730f11254094f983128d9938e079e",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -705,12 +707,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 5,
+        "fileCount": 6,
         "license": "MIT",
         "packageName": "dsh-file-drop-eac",
         "packageVersion": "0.1.2",
         "path": "dsh-desktop/assets/plugins/dsh-file-drop-eac",
-        "treeSha256": "b91ab4607aefc3a82360d8253a48da0d33ffc52d598211c937a9e479e574cacb"
+        "treeSha256": "571bbc2477f686c42412c59bbe542923d4e8134e8a99009061ecb9643994daa9"
       },
       "manifestEntrySha256": "01e903ea850238a86e666391d59cacd6d1e5b9c7c89e373383b3b3401dc60623",
       "patchFiles": [],
@@ -721,7 +723,7 @@
       "source": {
         "kind": "internal",
         "name": "dsh-file-drop-eac",
-        "sha256": "b91ab4607aefc3a82360d8253a48da0d33ffc52d598211c937a9e479e574cacb",
+        "sha256": "571bbc2477f686c42412c59bbe542923d4e8134e8a99009061ecb9643994daa9",
         "version": "0.1.2"
       },
       "sourceCommit": null
@@ -733,12 +735,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-float-window",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-float-window",
-        "treeSha256": "1809d62da2357333e19d3f2cbb6680e4800a6364c68d4307b07bdc4b5a7a0ec4"
+        "treeSha256": "d77b57891044c417c05ce03dda7d7f9404e214b209458a5af569befb83c4a265"
       },
       "manifestEntrySha256": "fb408988af2b6955b37c306c6a661347dc274f0853730637d2dd23e510912cd4",
       "patchFiles": [],
@@ -749,7 +751,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-float-window",
-        "sha256": "1809d62da2357333e19d3f2cbb6680e4800a6364c68d4307b07bdc4b5a7a0ec4",
+        "sha256": "d77b57891044c417c05ce03dda7d7f9404e214b209458a5af569befb83c4a265",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -761,12 +763,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-font-custom",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-font-custom",
-        "treeSha256": "012d73a83d8c8161e9d150a043af2a19847a7b3bb4b9e7bc051c8897d76ee203"
+        "treeSha256": "de5856e29f298796a88ffbaca1c4cdb24f2ccb1c5b4055ec10453f606145c218"
       },
       "manifestEntrySha256": "19ab9bdc0a920c7756ebe4776ea824f6d160f88eaea4a94ccadf37bc951ef406",
       "patchFiles": [],
@@ -776,7 +778,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "012d73a83d8c8161e9d150a043af2a19847a7b3bb4b9e7bc051c8897d76ee203",
+        "sha256": "de5856e29f298796a88ffbaca1c4cdb24f2ccb1c5b4055ec10453f606145c218",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -788,12 +790,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 4,
+        "fileCount": 5,
         "license": "MIT",
         "packageName": "dsh-image-paste",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-image-paste",
-        "treeSha256": "81866f676b95edafa6c21a040218488e7140d5977b57c37b89a37598fe0e20d2"
+        "treeSha256": "bc2eb982dc44f63e388ca2fc1d23719e75a59750eb7fcf8da3405afd129bbdbf"
       },
       "manifestEntrySha256": "9595a976228b7adc199b86872be31db559960b5ecec535c7ca8f057bdc28c132",
       "patchFiles": [],
@@ -803,7 +805,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "81866f676b95edafa6c21a040218488e7140d5977b57c37b89a37598fe0e20d2",
+        "sha256": "bc2eb982dc44f63e388ca2fc1d23719e75a59750eb7fcf8da3405afd129bbdbf",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -815,12 +817,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 11,
+        "fileCount": 12,
         "license": "MIT",
         "packageName": "meow-smooth",
         "packageVersion": "0.5.0",
         "path": "dsh-desktop/assets/plugins/dsh-meow-smooth",
-        "treeSha256": "e92b3142749f078ae5f576609dba511f5d9120482db2066cb56c3792fa8d5448"
+        "treeSha256": "ed46ac697dda9029943ca5c899e294c780f276520faa7063fe95e966e51595e1"
       },
       "manifestEntrySha256": "ace12c07d39f5a07a4ac68873c75ab4b815a20ffa6c451cb3dc93e864c4f5cad",
       "patchFiles": [],
@@ -831,7 +833,7 @@
       "source": {
         "kind": "github",
         "repository": "git+https://github.com/Phant0Meow/dsh-meow-smooth.git",
-        "sha256": "e92b3142749f078ae5f576609dba511f5d9120482db2066cb56c3792fa8d5448",
+        "sha256": "ed46ac697dda9029943ca5c899e294c780f276520faa7063fe95e966e51595e1",
         "version": "0.5.0"
       },
       "sourceCommit": null
@@ -843,12 +845,12 @@
           "lib/host.js"
         ],
         "excludedPaths": [],
-        "fileCount": 6,
+        "fileCount": 7,
         "license": "MIT",
         "packageName": "dsh-message-rewind",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-message-rewind",
-        "treeSha256": "d80b8559180830d83010b5bf25fe043eb44449cde7e2244b84a0d91a727f2006"
+        "treeSha256": "0c4b6e7a482fdbae91dea3d3e4e1d9855a2937aec03d60a3b406b995d98860a7"
       },
       "manifestEntrySha256": "2936e79880dbcfc3d6a6a5702ef39aed870f6c1a054fa5991134782ccd2c0415",
       "patchFiles": [],
@@ -858,7 +860,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "d80b8559180830d83010b5bf25fe043eb44449cde7e2244b84a0d91a727f2006",
+        "sha256": "0c4b6e7a482fdbae91dea3d3e4e1d9855a2937aec03d60a3b406b995d98860a7",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -870,12 +872,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 7,
+        "fileCount": 8,
         "license": "MIT",
         "packageName": "dsh-web-mobile-fix",
         "packageVersion": "1.0.1",
         "path": "dsh-desktop/assets/plugins/dsh-web-mobile-fix",
-        "treeSha256": "32340c069ac863f0e59d3e789fac2b4e0f4812498080ce24d251f6e6f94645ee"
+        "treeSha256": "6779f258493c562c8fcb244eb618b176aa045001c0fc895a0acf2e107acfc550"
       },
       "manifestEntrySha256": "38d8f2e7daad4f811bade02c37a6e833e6d6e6562c0c730b3df49edbe3edff44",
       "patchFiles": [],
@@ -887,7 +889,7 @@
         "kind": "npm",
         "name": "dsh-web-mobile-fix",
         "repository": "git+https://github.com/AcidGr/dsh-web-mobile-fix.git",
-        "sha256": "32340c069ac863f0e59d3e789fac2b4e0f4812498080ce24d251f6e6f94645ee",
+        "sha256": "6779f258493c562c8fcb244eb618b176aa045001c0fc895a0acf2e107acfc550",
         "version": "1.0.1"
       },
       "sourceCommit": null
@@ -899,12 +901,12 @@
           "src/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 7,
+        "fileCount": 8,
         "license": "MIT",
         "packageName": "dsh-offpeak",
         "packageVersion": "9.9.9",
         "path": "dsh-desktop/assets/plugins/dsh-offpeak",
-        "treeSha256": "f32383017d77af3af033a2330c6801c2e6634d36d2d3f72136cba4ee77aa9401"
+        "treeSha256": "85f37acc541f277cce337f70fab7255f4f76f44b47ff3c5eb86c34b34863e672"
       },
       "manifestEntrySha256": "5a9b031066eeb3e0e9920a1dda973abd42e7d3e99d9ed2884e5be2af594510c0",
       "patchFiles": [],
@@ -916,7 +918,7 @@
         "kind": "npm",
         "name": "dsh-offpeak",
         "repository": "git+https://github.com/christophersmith2737-commits/OffPeak.git",
-        "sha256": "f32383017d77af3af033a2330c6801c2e6634d36d2d3f72136cba4ee77aa9401",
+        "sha256": "85f37acc541f277cce337f70fab7255f4f76f44b47ff3c5eb86c34b34863e672",
         "version": "9.9.9"
       },
       "sourceCommit": null
@@ -928,12 +930,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 8,
+        "fileCount": 9,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-openclaw-bridge",
         "packageVersion": "0.7.0",
         "path": "dsh-desktop/assets/plugins/dsh-openclaw-bridge",
-        "treeSha256": "1f20d90e1151db7f4e6516d199a480698476115387af7e017f13ae8a8c961764"
+        "treeSha256": "4df6e96039960845ccb017cd89faeda73c9c49d29ab2c669b864ca4c33e9b724"
       },
       "manifestEntrySha256": "c235ac0dcc3f48854b818b37ec928f26acaf7d13ba8c08f8f092a6910e69071e",
       "patchFiles": [],
@@ -944,7 +946,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-openclaw-bridge",
-        "sha256": "1f20d90e1151db7f4e6516d199a480698476115387af7e017f13ae8a8c961764",
+        "sha256": "4df6e96039960845ccb017cd89faeda73c9c49d29ab2c669b864ca4c33e9b724",
         "version": "0.7.0"
       },
       "sourceCommit": null
@@ -961,9 +963,9 @@
         "fileCount": 36,
         "license": "MIT",
         "packageName": "picturereader",
-        "packageVersion": "3.3.1",
+        "packageVersion": "3.3.3",
         "path": "dsh-desktop/assets/plugins/picturereader",
-        "treeSha256": "feb54fc85893eca24aa53da7e100896ce857995c8e7d446f9e663591892a01af"
+        "treeSha256": "9341a945a64312ffa339345f7ad7249c2fae2ee688baa709957578a46c3cec9d"
       },
       "manifestEntrySha256": "d3c2dccb3b4758e064fc95e76e59b3697463d0d47c83216f35aa22e4c67e253a",
       "patchFiles": [],
@@ -975,8 +977,8 @@
         "kind": "npm",
         "name": "picturereader",
         "repository": "https://github.com/jing-hy/picturereader.git",
-        "sha256": "feb54fc85893eca24aa53da7e100896ce857995c8e7d446f9e663591892a01af",
-        "version": "3.3.1"
+        "sha256": "9341a945a64312ffa339345f7ad7249c2fae2ee688baa709957578a46c3cec9d",
+        "version": "3.3.3"
       },
       "sourceCommit": null
     },
@@ -987,12 +989,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-plugin-manager",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-plugin-manager",
-        "treeSha256": "50186f22dd48fe88fa045827cfac5f61848519c20813253c8bfe135a23caea4d"
+        "treeSha256": "cc1e2be2eac7635d42c2933217e43846cdb70e470fc492e9fcb470e5aa6615df"
       },
       "manifestEntrySha256": "b23a25f33cbc1ef7c02589e9762f3406ce2db92f1318eb8d182df252ed35ace0",
       "patchFiles": [],
@@ -1003,7 +1005,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-plugin-manager",
-        "sha256": "50186f22dd48fe88fa045827cfac5f61848519c20813253c8bfe135a23caea4d",
+        "sha256": "cc1e2be2eac7635d42c2933217e43846cdb70e470fc492e9fcb470e5aa6615df",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -1015,12 +1017,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-plugin-shield",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-plugin-shield",
-        "treeSha256": "b8c84ec007e9c8117edb4a08f19c497130c89fd1bc3efbdf0469a566ecaf5b78"
+        "treeSha256": "13350e65a59104170663e721542aa01521de5aaa339921e2caba64f5246becda"
       },
       "manifestEntrySha256": "8392421dbfdf36b55f3dfcda336bb4e1cf77bff4afbc39941f7276712e5c5f49",
       "patchFiles": [],
@@ -1030,7 +1032,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "b8c84ec007e9c8117edb4a08f19c497130c89fd1bc3efbdf0469a566ecaf5b78",
+        "sha256": "13350e65a59104170663e721542aa01521de5aaa339921e2caba64f5246becda",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -1042,12 +1044,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-plugin-wizard",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-plugin-wizard",
-        "treeSha256": "097b75e8749c4b77f9466938286248ef6d0b2dc16815622458040180fb86f6c6"
+        "treeSha256": "5b1e5ea52a6d9ea116be768662260341f8b255246bd80176c7573db47faec7b6"
       },
       "manifestEntrySha256": "dee87795f561f230c6cc713ccfd28c8e3f71dc2431e41b8af53e190647d52200",
       "patchFiles": [],
@@ -1057,7 +1059,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "097b75e8749c4b77f9466938286248ef6d0b2dc16815622458040180fb86f6c6",
+        "sha256": "5b1e5ea52a6d9ea116be768662260341f8b255246bd80176c7573db47faec7b6",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -1069,12 +1071,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 4,
+        "fileCount": 5,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-prompt-custom",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-prompt-custom",
-        "treeSha256": "dd42ea016480f84bc6a06c0a58ca1b76533143485af9045cc4faa2d9d593420c"
+        "treeSha256": "8b47630fb42c3bce9d8d444a37004e1fdb5259ddf2bc96618540a944203aaddd"
       },
       "manifestEntrySha256": "80e9eb22c4fb2bc70bb11ad8c37b058d1d3ed5782c737c557f4fa16b0d8163a3",
       "patchFiles": [],
@@ -1085,7 +1087,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-prompt-custom",
-        "sha256": "dd42ea016480f84bc6a06c0a58ca1b76533143485af9045cc4faa2d9d593420c",
+        "sha256": "8b47630fb42c3bce9d8d444a37004e1fdb5259ddf2bc96618540a944203aaddd",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -1125,12 +1127,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 4,
+        "fileCount": 5,
         "license": "MIT",
         "packageName": "dsh-settings-groups",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-settings-groups",
-        "treeSha256": "99206f9d476698e778da985c698a120ca18fba2f99d82b5ed25d58de10a825b3"
+        "treeSha256": "606544070d3843a6edb3656b77250dd405eeffcf3074ce4c16cef347f1d47f7d"
       },
       "manifestEntrySha256": "a2255801c11e5180489d8950ac373d1878d8bcca3bc66326e6d1e3183c0a85f2",
       "patchFiles": [],
@@ -1140,7 +1142,7 @@
       "runtimeUpdate": "disabled",
       "source": {
         "kind": "unknown",
-        "sha256": "99206f9d476698e778da985c698a120ca18fba2f99d82b5ed25d58de10a825b3",
+        "sha256": "606544070d3843a6edb3656b77250dd405eeffcf3074ce4c16cef347f1d47f7d",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -1152,12 +1154,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 11,
+        "fileCount": 12,
         "license": "MIT",
         "packageName": "dsh-settings-scroll-fix",
         "packageVersion": "2.0.2",
         "path": "dsh-desktop/assets/plugins/dsh-settings-scroll-fix",
-        "treeSha256": "9c84ba35d6102bb45bd240092ba21373de87b85015a94775b21447a98518004a"
+        "treeSha256": "02425ba0e9bb6b425e466f3fb6ca4fd98160544ce731da49ae13710730f0db23"
       },
       "manifestEntrySha256": "9c94c889b1dad6c6bbd91c0b85bd35dc45aa27cf83431672df1ef7c0fd733607",
       "patchFiles": [],
@@ -1168,7 +1170,7 @@
       "source": {
         "kind": "internal",
         "name": "dsh-settings-scroll-fix",
-        "sha256": "9c84ba35d6102bb45bd240092ba21373de87b85015a94775b21447a98518004a",
+        "sha256": "02425ba0e9bb6b425e466f3fb6ca4fd98160544ce731da49ae13710730f0db23",
         "version": "2.0.2"
       },
       "sourceCommit": null
@@ -1180,12 +1182,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 7,
+        "fileCount": 8,
         "license": "MIT",
         "packageName": "@dsh-external/dsh-side-session",
         "packageVersion": "0.2.8",
         "path": "dsh-desktop/assets/plugins/dsh-side-session",
-        "treeSha256": "52a5d60b9ca1517d89a68e60f7bc7c9b4b1fb024987b2d9849403e3a9e4eea83"
+        "treeSha256": "381e63c9f59756c79d4f8a3704ebf84ae19c7ea8f338893219c421e2f4c1edd4"
       },
       "manifestEntrySha256": "4c42d0b56fa7c10112725b7ce2376da2c00d72de9c6c99f2cb39b08b496c0db9",
       "patchFiles": [],
@@ -1196,7 +1198,7 @@
       "source": {
         "kind": "internal",
         "name": "@dsh-external/dsh-side-session",
-        "sha256": "52a5d60b9ca1517d89a68e60f7bc7c9b4b1fb024987b2d9849403e3a9e4eea83",
+        "sha256": "381e63c9f59756c79d4f8a3704ebf84ae19c7ea8f338893219c421e2f4c1edd4",
         "version": "0.2.8"
       },
       "sourceCommit": null
@@ -1208,12 +1210,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-skin-switch",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-skin-switch",
-        "treeSha256": "b7aee7de42eec10a2e51922dc39ba56b72f3fca89f13eb5cf65a5a596e980e39"
+        "treeSha256": "8faab15f0fd40ad2c6a29c6db9f81e4f165217405c64216387e28214e0bd528b"
       },
       "manifestEntrySha256": "df6252df12ba08e3a9d164d2d030dfb156525887f5971f265607783632806b0f",
       "patchFiles": [],
@@ -1224,7 +1226,7 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-skin-switch",
-        "sha256": "b7aee7de42eec10a2e51922dc39ba56b72f3fca89f13eb5cf65a5a596e980e39",
+        "sha256": "8faab15f0fd40ad2c6a29c6db9f81e4f165217405c64216387e28214e0bd528b",
         "version": "0.1.0"
       },
       "sourceCommit": null
@@ -1238,12 +1240,12 @@
         "excludedPaths": [
           "vendor"
         ],
-        "fileCount": 7,
+        "fileCount": 8,
         "license": "MIT",
         "packageName": "dsh-soul-md",
         "packageVersion": "0.2.8",
         "path": "dsh-desktop/assets/plugins/dsh-soul-md",
-        "treeSha256": "8ab2960dba0e888a5c94fb1f199c2b48d83ae377c17ffc267b5e13db00363bd2"
+        "treeSha256": "5174a5f66561753d39ce019cad69b91fe5bd50c53072c2a8be1499108c82980d"
       },
       "manifestEntrySha256": "133ef3c451783868b012902692842c6d02cde9193cae9a60d235de9622220898",
       "patchFiles": [],
@@ -1255,7 +1257,7 @@
         "kind": "npm",
         "name": "dsh-soul-md",
         "repository": "git+https://github.com/Scorp1o117/dsh-soul-md.git",
-        "sha256": "8ab2960dba0e888a5c94fb1f199c2b48d83ae377c17ffc267b5e13db00363bd2",
+        "sha256": "5174a5f66561753d39ce019cad69b91fe5bd50c53072c2a8be1499108c82980d",
         "version": "0.2.8"
       },
       "sourceCommit": null
@@ -1267,12 +1269,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "@deepseek-ai/dsh-terminal",
         "packageVersion": "0.1.0",
         "path": "dsh-desktop/assets/plugins/dsh-terminal",
-        "treeSha256": "e745a2c6ad212c9df86a2b3cb740a076c0cb720c1a8b21dc8dbedc46ccf07ca7"
+        "treeSha256": "84b51d39909bd219d165d98544d2a2418eb1a038f6aa3d05a148bbfb4789d5f4"
       },
       "manifestEntrySha256": "661493f26c5309ee758ef59106da3feb77ff053313b7a6b2d21d7cd65fc8424c",
       "patchFiles": [],
@@ -1283,8 +1285,36 @@
       "source": {
         "kind": "internal",
         "name": "@deepseek-ai/dsh-terminal",
-        "sha256": "e745a2c6ad212c9df86a2b3cb740a076c0cb720c1a8b21dc8dbedc46ccf07ca7",
+        "sha256": "84b51d39909bd219d165d98544d2a2418eb1a038f6aa3d05a148bbfb4789d5f4",
         "version": "0.1.0"
+      },
+      "sourceCommit": null
+    },
+    "think-zh-expand-eac": {
+      "compatibility": {},
+      "local": {
+        "entrypoints": [
+          "lib/index.js"
+        ],
+        "excludedPaths": [],
+        "fileCount": 17,
+        "license": "MIT",
+        "packageName": "dsh-think-zh-expand-eac",
+        "packageVersion": "1.0.0",
+        "path": "dsh-desktop/assets/plugins/dsh-think-zh-expand-eac",
+        "treeSha256": "79dc07645864e3e444fe14e00dbae58d3b54ab0b14e8606d0c866fbe64801acc"
+      },
+      "manifestEntrySha256": "9f764900e15db9a0d92654317a8318c5424fd845fe9816ca51391fefc7d141d4",
+      "patchFiles": [],
+      "patchSet": "none",
+      "patchSetSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "requested": "latest",
+      "runtimeUpdate": "enabled",
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac",
+        "sha256": "79dc07645864e3e444fe14e00dbae58d3b54ab0b14e8606d0c866fbe64801acc",
+        "version": "1.0.0"
       },
       "sourceCommit": null
     },
@@ -1300,7 +1330,7 @@
         "packageName": "@linxin666/dsh-client-ui-skin-blue-fantasy",
         "packageVersion": "0.1.11",
         "path": "dsh-desktop/assets/skins/blue-fantasy",
-        "treeSha256": "d7d9bcddb38a8643bed41f4ba529ec9dc1be2152a5a3b6686589fa1012de2b74"
+        "treeSha256": "869daf4db300e569b273000d5361eb37aca20a0c15cc241bc63decc0f1a32ae1"
       },
       "manifestEntrySha256": "f2e4722c5317b64eebe87de54829536658203f8354f048c375bcb2da4d85caff",
       "patchFiles": [],
@@ -1311,7 +1341,7 @@
       "source": {
         "kind": "github",
         "repository": "https://github.com/zhu1090093659/dsh-web-ui.git",
-        "sha256": "d7d9bcddb38a8643bed41f4ba529ec9dc1be2152a5a3b6686589fa1012de2b74",
+        "sha256": "869daf4db300e569b273000d5361eb37aca20a0c15cc241bc63decc0f1a32ae1",
         "version": "0.1.11"
       },
       "sourceCommit": null
@@ -1356,7 +1386,7 @@
         "packageName": "@dsh-external/dsh-client-ui-skin-maid-atelier",
         "packageVersion": "0.0.1",
         "path": "dsh-desktop/assets/skins/maid-atelier",
-        "treeSha256": "fc47009a4a974ad249538d951d8d154927d21099c7742106dfb5dbac9ce34ef9"
+        "treeSha256": "a14a49023c91f1948ef085972bccd0218fcf7ab2490eda8517422cf8d4d65a04"
       },
       "manifestEntrySha256": "0927121550e1bcc168e95f6505cae767bf23d043ecc6b12fb6eab03d5a2b6ae2",
       "patchFiles": [],
@@ -1367,7 +1397,7 @@
       "source": {
         "kind": "internal",
         "name": "@dsh-external/dsh-client-ui-skin-maid-atelier",
-        "sha256": "fc47009a4a974ad249538d951d8d154927d21099c7742106dfb5dbac9ce34ef9",
+        "sha256": "a14a49023c91f1948ef085972bccd0218fcf7ab2490eda8517422cf8d4d65a04",
         "version": "0.0.1"
       },
       "sourceCommit": null
@@ -1575,12 +1605,12 @@
           "lib/host.js"
         ],
         "excludedPaths": [],
-        "fileCount": 14,
+        "fileCount": 16,
         "license": "MIT",
         "packageName": "dsh-unified-market",
-        "packageVersion": "0.3.1",
+        "packageVersion": "0.4.0",
         "path": "dsh-desktop/assets/plugins/dsh-unified-market",
-        "treeSha256": "142de9bdf4837c899efd6d7244ab870311fc090b303f21f996a8d8cebe2518c0"
+        "treeSha256": "198d97d493dce5c4e21c3adf332eced5c2cdc89e5273f71c7154e87a1cd00c7d"
       },
       "manifestEntrySha256": "ae25457e39ddf76a4eb2c86feaaf021915433a007fa0ca034347d735f611c04d",
       "patchFiles": [],
@@ -1592,8 +1622,8 @@
         "kind": "npm",
         "name": "dsh-unified-market",
         "repository": "git+https://github.com/jing-hy/dsh-unified-market.git",
-        "sha256": "142de9bdf4837c899efd6d7244ab870311fc090b303f21f996a8d8cebe2518c0",
-        "version": "0.3.1"
+        "sha256": "198d97d493dce5c4e21c3adf332eced5c2cdc89e5273f71c7154e87a1cd00c7d",
+        "version": "0.4.0"
       },
       "sourceCommit": null
     },
@@ -1604,12 +1634,12 @@
           "lib/index.js"
         ],
         "excludedPaths": [],
-        "fileCount": 3,
+        "fileCount": 4,
         "license": "MIT",
         "packageName": "dsh-viewport-lock",
         "packageVersion": "1.0.1",
         "path": "dsh-desktop/assets/plugins/dsh-viewport-lock",
-        "treeSha256": "3a89a466215c9b0b7725a22f9903b84808a7a36ee9a3eb3717bdae65a18e510c"
+        "treeSha256": "8a3941542aa9d4eb95a5c9630096289e80baa655b78d09902efb353eb4b5e703"
       },
       "manifestEntrySha256": "e6e96d7072aceedcdaada60aa3a8fad6b33513f18bf36131e16956070e7ccb8b",
       "patchFiles": [],
@@ -1620,7 +1650,7 @@
       "source": {
         "kind": "internal",
         "name": "dsh-viewport-lock",
-        "sha256": "3a89a466215c9b0b7725a22f9903b84808a7a36ee9a3eb3717bdae65a18e510c",
+        "sha256": "8a3941542aa9d4eb95a5c9630096289e80baa655b78d09902efb353eb4b5e703",
         "version": "1.0.1"
       },
       "sourceCommit": null

--- a/.sync/policies.json
+++ b/.sync/policies.json
@@ -53,7 +53,7 @@
   "runtimeUpdates": {
     "defaultAllowed": false,
     "requiresExplicitSource": true,
-    "legacySourceCount": 11,
+    "legacySourceCount": 12,
     "sourceMapMustBeOneToOne": true
   },
   "forbiddenTrackedNames": [

--- a/dsh-desktop/assets/SOURCES.json
+++ b/dsh-desktop/assets/SOURCES.json
@@ -1069,13 +1069,13 @@
       "name": "dsh-unified-market",
       "type": "plugin",
       "origin": "upstream",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "path": "dsh-desktop/assets/plugins/dsh-unified-market",
       "registryStatus": "注册表默认启用",
       "audit": {
         "verdict": "catalog-hit",
         "compare": "same-version-modified",
-        "note": "增加EAC推荐标记及对应客户端样式、文案和宿主目录数据处理。具体变更见lib/client.js和lib/host.js行段。",
+        "note": "v0.4.0：profile 配置写入改为双边同步（每次重读磁盘 / 以 id 并集合并 / CAS + 原子写 + 写前校验 + 写后复核回滚 / 双文件快照与还原），新增 profile.state|toggle|snapshots|restore 四个 host 方法，CLI 操作后新增增量同步；保留 EAC 定制（本地推荐清单 data/eac-recommended.json 合并与 EAC 推荐徽章）。",
         "basis": "package.repository明确声明",
         "conflict": null
       },
@@ -2989,6 +2989,28 @@
         "changedFiles": "0",
         "mainOnly": "0",
         "aioOnly": "0"
+      }
+    },
+    {
+      "id": "C114",
+      "line": "main",
+      "name": "dsh-think-zh-expand-eac",
+      "type": "plugin",
+      "origin": "upstream",
+      "version": "1.0.0",
+      "path": "dsh-desktop/assets/plugins/dsh-think-zh-expand-eac",
+      "registryStatus": "注册表默认启用",
+      "audit": {
+        "verdict": "catalog-miss",
+        "compare": "fork-of-upstream",
+        "note": "jing-hy/dsh-think-zh-expand-eac：上游 baosfeng/dsh-think-zh-expand@0.4.8 的 EAC 派生版。移除全部接管对话渲染器的显示功能（assistant-step 渲染器抢占、ThinkBlock 默认展开、自绘图标/样式表），保留强制中文思考与界面中文化；system-prompt section 名改为 dsh-think-zh-eac 以避免与上游同层同名注册抛错。",
+        "basis": "package.repository 明确声明",
+        "conflict": null
+      },
+      "upstream": {
+        "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac",
+        "refType": "version",
+        "provenance": "Fork of https://github.com/baosfeng/my-dsh-plugins (plugins/dsh-think-zh-expand, MIT, 原作者 @baosfeng)"
       }
     }
   ]

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/.gitignore
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+lib/.client-build/
+*.log
+.DS_Store
+Thumbs.db

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/CHANGELOG.md
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+本文件记录 **dsh-think-zh-expand-eac** 的版本变更。格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
+
+> **上游来源**：本仓库派生自 [baosfeng/my-dsh-plugins](https://github.com/baosfeng/my-dsh-plugins) 的
+> `plugins/dsh-think-zh-expand`（派生基线：`v0.4.8`）。原作者 [@baosfeng](https://github.com/baosfeng)，MIT 许可。
+> 上游版本历史请见上游仓库。
+
+## [1.0.0] - 2026-09-11
+
+首个 EAC 定制版本。基于上游 `dsh-think-zh-expand@0.4.8` 裁剪。
+
+### 变更动机
+
+上游以 `priority: -1` 接手 `conversation.chat.node` 的 `assistant-step` 渲染器并自绘思考块
+（默认展开、流式强制展开），与折叠类插件产生结构性冲突：
+
+- `dsh-turn-fold` 同样以 `priority: -1` 抢占同一座位 —— 两者只能有一个生效；
+- `dsh-auto-collapse` 依赖 DOM 锚点 `data-chat-flow-key` / `data-turn-process` 定位折叠目标，
+  而上游自绘的思考块不产生这些锚点 —— 其折叠逻辑对该段静默失明。
+
+表现为「装了折叠插件但思考收不起来」，且不报错，排查困难。
+
+### 移除（BREAKING）
+
+以下显示层功能全部删除，不再接管任何对话渲染器：
+
+- **移除** `conversation.chat.node` 的 `assistant-step` 渲染器注册（原 `priority: -1` 抢位）
+- **移除** `ThinkBlock`（默认展开、流式强制展开的思考块）
+- **移除** `AssistantStepView`、`renderBlocks`、`renderBlock`、`imageGroupEnd`（自绘 assistant 节点与图片分组）
+- **移除** `stripControlTags`（仅供自绘渲染器的控制标签剥离）
+- **移除** 官方 SVG 图标内联（`chevronDownIcon`、`thinkIcon`）
+- **移除** `.dsh-think-zh-expand-*` 样式表及其注入逻辑
+- **移除** 对 `dsh-md-render` 的跨插件依赖（`dsh.client.external` 与 `peerDependencies`）
+- **移除** `react` 依赖（client 端不再创建任何元素）
+
+### 保留
+
+- **保留** 思考与回复强制中文（server 端 `systemPrompt.section` 注入，`order: -90`）
+- **保留** 界面标签中文化（DOM 精准文本替换 + `MutationObserver`，不改动 DOM 结构）
+- **保留** 工具名 / 工具描述 / 工具目录 / 卡片标题摘要的中文化词表
+
+### 变更
+
+- **变更** system-prompt section 名：`dsh-think-zh` → **`dsh-think-zh-eac`**。
+  理由：DSH 对同一层重复 name 的 section 注册会抛错；改名后本版可与上游版共存，
+  但两者注入同一段指令，功能重复，仍建议只启用其一。
+- **变更** 包名：`dsh-think-zh-expand` → **`dsh-think-zh-expand-eac`**
+- **变更** client bundle 的 `__ModuleLoader__.load()` id → `dsh-think-zh-expand-eac`
+- **变更** 构建流程：不再从 `dsh-shared` 注入共享图标；`scripts/build.mjs` 在
+  模板残留 `/*__PART_ICONS__*/` 占位符时**直接报错**，避免静默产出坏包
+- **变更** `tsconfig.client.json`：`lib` 增加 `dom.iterable`（中文化代码迭代 `NodeList`）
+- **变更** 测试：改用 Node 内置 test runner（`node --test test/`），移除对 vitest 的依赖；
+  删除仅适用于上游自绘渲染器的 `test/client-render.mjs` 与 cucumber 特性测试
+
+### 移除的文件
+
+- `vitest.config.mjs`、`stryker.config.mjs`（上游 monorepo 工具链配置）
+- `test/client-render.mjs`、`test/features/`（针对已删除渲染器的测试）
+- `assets/`（思考块截图，已无对应功能）
+
+### 兼容性
+
+- DSH kernel：`0.1.3-alpha.1`（实测）
+- 与 `dsh-auto-collapse`、`dsh-turn-fold` 等折叠类插件**无冲突**（本版不触碰渲染器与 DOM 结构）
+
+### 体积变化
+
+- `lib/client.js`：43.7 KB（上游）→ **18.6 KB**（本版）
+- `src/client/index.ts`：32.8 KB（上游）→ **18.2 KB**（本版）

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/LICENSE
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bsfeng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/README.md
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/README.md
@@ -1,0 +1,177 @@
+# dsh-think-zh-expand-eac
+
+[![topic: dsh](https://img.shields.io/badge/插件生态-topic%20dsh-4d6bfe)](https://github.com/topics/dsh)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+**DSH 思考增强插件（EAC 定制版）**：让 agent 的思考（reasoning）与回复强制使用中文，并把界面残留的硬编码英文（Thinking / Tool Call 等）中文化。
+
+> **本仓库是派生版本（fork），已移除全部会接管对话渲染器的显示功能。**
+
+## 引用与来源声明
+
+本仓库派生自 **[baosfeng/my-dsh-plugins](https://github.com/baosfeng/my-dsh-plugins)** 中的
+[`plugins/dsh-think-zh-expand`](https://github.com/baosfeng/my-dsh-plugins/tree/main/plugins/dsh-think-zh-expand)，
+原作者：**[@baosfeng](https://github.com/baosfeng)**，许可证 MIT。
+
+- **上游版本**：`dsh-think-zh-expand@0.4.8`
+- **本派生版本**：`dsh-think-zh-expand-eac@1.0.0`
+- **上游许可证**：[MIT](./LICENSE)（原样保留，版权归原作者）
+
+本版仅按需裁剪上游的显示层功能，**未修改**上游的强制中文提示词与中文化词表逻辑。
+若你需要上游的完整功能（思考块默认展开、自绘渲染器），请直接使用
+[上游插件](https://github.com/baosfeng/my-dsh-plugins)。
+
+## 为什么会有这个 EAC 版
+
+上游 `dsh-think-zh-expand` 会用 `priority: -1` **接手** `conversation.chat.node` 的
+`assistant-step` 渲染器，自行绘制思考块（默认展开、流式强制展开）。
+
+这会与**任何折叠类插件**发生结构性冲突：
+
+| 折叠插件 | 冲突原因 |
+|---|---|
+| `dsh-turn-fold` | 同样以 `priority: -1` 抢占 `assistant-step` 座位，两者只能有一个生效 |
+| `dsh-auto-collapse` | 依赖 DOM 锚点 `data-chat-flow-key` / `data-turn-process` 定位折叠目标，而上游自绘的思考块**不产生这些锚点**，导致其折叠逻辑对该段失明 |
+
+结果是：装了折叠插件却「思考收不起来」或折叠栏失效，且不报错——属于静默失效，很难排查。
+
+**本版的做法**：把渲染器**完全交还宿主**，只保留不碰 DOM 结构的功能。思考块的折叠表现
+由宿主与折叠插件决定，本版不再干预。
+
+## 功能
+
+### 1. 思考强制中文（Server 端）✅ 保留
+
+通过 `systemPrompt.section` 注入一条固定系统提示（`order: -90`，persona 之前最先读到），
+内容为**结构化语言规则**（最高优先级，不可被上下文覆盖）：
+
+> 强制要求：思考过程（reasoning）必须用简体中文书写；最终回复默认简体中文（跟随用户语言）。
+> 关键场景：英文错误消息/日志/堆栈不改变语言；大量英文上下文不"带偏"输出。
+> 代码与术语：代码、命令、文件路径、标识符与技术术语保持原文，不翻译。
+
+无论用户用什么语言提问，模型的思考过程与回答都使用中文。
+
+### 2. 界面标签中文化（Client 端）✅ 保留
+
+官方 UI 的 zh 字典本身未翻译完（如 `toolbar.duration: "Duration"`），且存在硬编码英文
+（`Thinking`、`Tool Call`、`ASSISTANT` 等）；`locale.register` 对已注册的同名 ns+locale
+字典重复注册会抛错，无法经 locale 服务补译。
+
+因此本插件在 **DOM 层做精准文本替换**：只匹配「完全等于」词表的叶子文本节点
+（排除 `pre`/`code`/输入区，避免误伤代码块与消息正文），`MutationObserver` 跟随 React
+重渲染持续生效。同时覆盖工具名、工具描述、工具目录与卡片标题/摘要的中文化。
+
+> 该功能**不改变 DOM 结构**，只改写文本节点内容，因此不与折叠插件冲突。
+
+## 与上游的差异（已移除的功能）
+
+以下功能**全部移除**，因为它们要么直接抢位、要么产出折叠插件无法识别的 DOM：
+
+| 已移除 | 说明 |
+|---|---|
+| `assistant-step` 渲染器注册 | 上游以 `priority: -1` 抢占 `conversation.chat.node` 座位 |
+| `ThinkBlock` | 上游自绘思考块（默认展开、流式强制展开） |
+| `AssistantStepView` / `renderBlocks` / `imageGroupEnd` | 上游自绘的 assistant 节点与图片分组渲染 |
+| `stripControlTags` | 仅供上述渲染器使用的控制标签剥离 |
+| 官方 SVG 图标内联（`chevronDownIcon` / `thinkIcon`） | 仅供上述思考块使用 |
+| `.dsh-think-zh-expand-*` 样式表 | 仅供上述思考块使用 |
+| `dsh-md-render` 跨插件依赖 | 上游经 `dsh.client.external` require 其 `MarkdownView` |
+
+### 行为差异
+
+| 场景 | 上游 | 本版 |
+|---|---|---|
+| 思考块默认状态 | 展开 | **交还宿主**（通常为收起单行摘要） |
+| 流式中思考块 | 强制展开 | 交还宿主 |
+| 思考内容 Markdown 渲染 | 由本插件经 MarkdownView 渲染 | 由宿主内置渲染 |
+| 工具调用行 | 上游自绘 | 交还宿主（丢失上游的部分自绘样式） |
+| 与折叠插件共存 | ❌ 冲突 | ✅ 无冲突 |
+
+### 兼用性说明（section 名已改名）
+
+上游注册的 system-prompt section 名为 `dsh-think-zh`，本版改为 **`dsh-think-zh-eac`**。
+
+原因：DSH 对**同一层重复 name 的 section 注册会抛错**。改名后，上游版与本版即使同时启用
+也不会导致启动失败。但两者注入的是同一段中文指令，**功能完全重复，仍建议只启用其一**。
+
+## 安装
+
+### DSH Desktop (EAC)
+
+在 DSH Terminal 中针对当前 profile 安装：
+
+```powershell
+dsh plugin --profile web-desktop add github:jing-hy/dsh-think-zh-expand-eac
+dsh --profile web-desktop --dump-config
+pnpm list dsh-think-zh-expand-eac --depth 0
+```
+
+配置输出应包含 `id: think-zh-expand-eac` 与 `name: dsh-think-zh-expand-eac`。
+验证后重启 DSH Desktop。
+
+### 普通 DSH CLI / Web
+
+```sh
+dsh plugin --profile web add github:jing-hy/dsh-think-zh-expand-eac
+dsh --profile web --dump-config
+```
+
+### 从源码安装
+
+```powershell
+git clone https://github.com/jing-hy/dsh-think-zh-expand-eac.git
+dsh plugin --profile web-desktop add link:<仓库路径>
+```
+
+## 与折叠插件一起使用
+
+本版设计目标就是**与折叠插件共存**。推荐组合：
+
+```powershell
+dsh plugin --profile web-desktop add dsh-auto-collapse   # 或 dsh-turn-fold
+dsh plugin --profile web-desktop add github:jing-hy/dsh-think-zh-expand-eac
+```
+
+**不要同时启用** `dsh-auto-collapse` 与 `dsh-turn-fold`——它们都通过 DOM/渲染器操作对话区，
+机制互相致盲。二选一。
+
+## 开发
+
+```powershell
+npm run typecheck   # tsc 类型检查（server + client 两份配置）
+npm run build       # 重新生成 lib/index.js 与 lib/client.js
+npm test            # host 端冒烟测试（Node 内置 test runner）
+```
+
+> `lib/client.js` 是构建产物，**必须提交**——DSH 直接提供该文件，不在安装时构建。
+> 修改 `src/client/index.ts` 后务必重新构建并提交产物。
+
+### 构建流程
+
+1. `tsc -p tsconfig.json` → `lib/index.js`（server 端）
+2. `tsc -p tsconfig.client.json` → `lib/.client-build/index.js`（client 端 CommonJS 单文件）
+3. `node scripts/build.mjs` 把 client 编译产物注入 `lib/client.src.js` 模板的
+   `/*__CLIENT_BUNDLE__*/` 占位符 → `lib/client.js`
+
+> 上游构建还需从 `dsh-shared` 注入共享图标（`/*__PART_ICONS__*/`）。
+> **本版已移除该步骤**，`scripts/build.mjs` 会在此占位符残留时直接报错，避免静默产出坏包。
+
+## 目录结构
+
+| 路径 | 职责 |
+|---|---|
+| `src/index.ts` | server 端：system-prompt section 注册 |
+| `src/types.d.ts` | DSH 运行时类型最小契约 |
+| `src/client/index.ts` | client 端：界面中文化（词表 + DOM 精准替换） |
+| `lib/index.js` | server 端构建产物（提交） |
+| `lib/client.js` | client 端构建产物（提交，DSH 实际提供） |
+| `lib/client.src.js` | client bundle 模板（含 `__CLIENT_BUNDLE__` 占位符） |
+| `scripts/build.mjs` | 构建脚本：编译 + 注入模板 |
+| `cordis.patch.yml` | bundle patch：把插件行挂载进 profile |
+| `test/host-smoke.mjs` | host 端冒烟测试 |
+
+## 许可证
+
+MIT。本仓库保留上游 [MIT 许可证](./LICENSE) 与版权声明。
+
+上游项目：[baosfeng/my-dsh-plugins](https://github.com/baosfeng/my-dsh-plugins) · 原作者 [@baosfeng](https://github.com/baosfeng)

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/cordis.patch.yml
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/cordis.patch.yml
@@ -1,0 +1,16 @@
+# dsh-think-zh-expand-eac bundle patch: inserts the plugin row into the profile
+# roster.
+#
+# 挂载内容（EAC 定制版）：
+#   - host 半：注册 system-prompt section，强制 agent 用中文思考与回复
+#   - client 半：界面标签中文化（DOM 精准文本替换）
+#
+# 与上游 dsh-think-zh-expand 的区别：本版**不注册任何渲染器**，因此不再
+# 抢占 conversation.chat.node 的 assistant-step 座位，可与 dsh-auto-collapse
+# / dsh-turn-fold 等折叠类插件共存。
+#
+# 安装：
+#   dsh plugin --profile web-desktop add github:jing-hy/dsh-think-zh-expand-eac
+- insert:
+    - id: think-zh-expand-eac
+      name: 'dsh-think-zh-expand-eac'

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/dsh-plugin.json
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/dsh-plugin.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/Yan-Zero/dsh-std/614dfa1ac168db79fcf4577cf0ebb34e2e3b944b/packages/manifest/schema/dsh-plugin-0.15.schema.json",
   "manifestVersion": "0.15",
-  "id": "io.github.jing-hy.dsh-unified-market",
-  "name": "dsh-unified-market",
-  "version": "0.4.0",
+  "id": "io.github.jing-hy.dsh-think-zh-expand-eac",
+  "name": "dsh-think-zh-expand-eac",
+  "version": "1.0.0",
   "facets": {
     "host": {
-      "entry": "lib/host.js",
+      "entry": "lib/index.js",
       "apiVersion": "v1alpha1"
     }
   },
@@ -20,14 +20,14 @@
   "subscriptions": [],
   "license": "MIT",
   "source": {
-    "repository": "https://github.com/jing-hy/dsh-unified-market"
+    "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
   },
   "overrides": [],
   "x-eac": {
     "role": "identity-metadata",
     "note": "EAC 经 companion-sync 注册表加载（非 std adapter）；facets 留空 = 尚未参与 std 协商",
-    "ledger": "assets/SOURCES.json#C042",
+    "ledger": "assets/SOURCES.json#C114",
     "patched": true,
-    "patchNote": "same-version-modified"
+    "patchNote": "fork-of-upstream"
   }
 }

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/lib/client.js
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/lib/client.js
@@ -1,0 +1,433 @@
+/**
+ * dsh-think-zh-expand-eac — client half (browser).
+ *
+ * 功能 2：界面标签中文化（唯一保留的功能）。
+ *
+ * EAC 定制：已移除渲染器替换与思考块渲染，因此不再需要 react、
+ * dsh-md-render(MarkdownView) 与 dsh-shared 共享图标。
+ *
+ * BUILD NOTE: 本文件是源码模板（骨架）。scripts/build.mjs 先 tsc 编译
+ * src/client/index.ts → lib/.client-build/index.js（CommonJS 单文件），
+ * 再把编译产物注入到下方 /*__CLIENT_BUNDLE__* / 占位符处并写出
+ * lib/client.js（DSH 实际提供的产物，单一 __ModuleLoader__ bundle，无相对
+ * 路径 require）。产物必须提交（CI 只跑 node --check + 测试，不跑构建）。
+ */
+window.__ModuleLoader__.load({
+  id: 'dsh-think-zh-expand-eac',
+  factory: (require) => {
+    var module = { exports: {} }
+    var exports = module.exports
+    Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
+
+    // ── Client bundle（编译自 src/client/index.ts）──────────────────
+    "use strict";
+/**
+ * dsh-think-zh-expand-eac — client 端入口（EAC 定制版）。
+ *
+ * 本文件由 baosfeng/my-dsh-plugins 的 dsh-think-zh-expand 派生，
+ * 已**移除全部会与宿主对话折叠机制冲突的显示功能**。
+ *
+ * 保留：
+ *   功能 2：界面标签中文化（DOM 精准文本替换，MutationObserver 跟随重渲染）。
+ *
+ * 已移除（与 dsh-auto-collapse / dsh-turn-fold 等折叠插件冲突）：
+ *   - `conversation.chat.node` 的 `assistant-step` 渲染器注册（priority:-1 抢位）
+ *   - ThinkBlock（默认展开、流式强制展开）
+ *   - AssistantStepView 及 imageBlock / renderBlocks 等自绘渲染逻辑
+ *   - 官方 SVG 图标内联与 `.dsh-think-zh-expand-*` 样式表
+ *   - 对 `dsh-md-render` 的跨插件 MarkdownView 依赖
+ *
+ * 结果：不再接管任何渲染器、不产生任何对话区 DOM 结构，因此可与任何
+ * 折叠类插件共存；思考段的折叠表现完全交还给宿主与折叠插件。
+ *
+ * 构建流程：`tsc -p tsconfig.client.json` 编译为 CommonJS 单文件
+ * （lib/.client-build/index.js），scripts/build.mjs 再注入
+ * lib/client.src.js 模板的 __CLIENT_BUNDLE__ 占位符，写出 lib/client.js。
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.zhToolName = zhToolName;
+exports.zhToolDesc = zhToolDesc;
+exports.zhCardTitle = zhCardTitle;
+exports.zhCardSummary = zhCardSummary;
+// ── 界面中文化词表 ─────────────────────────────────────────────────
+const ZH_TABLE = {
+    Thinking: '思考',
+    'Tool Call': '工具调用',
+    'Tool calls': '工具调用',
+    'Tool call': '工具调用',
+    'Tool call only': '仅工具调用',
+    Tools: '工具',
+    'No content': '无内容',
+    'Tools Updated': '工具已更新',
+    Duration: '用时',
+    'Use actual duration': '使用实际耗时',
+    'Use equal-width operations': '使用等宽操作',
+    Turns: '轮次',
+    'Expand turns': '展开轮次',
+    'Collapse turns': '收起轮次',
+    Calls: '调用',
+    'Expand calls': '展开调用',
+    'Collapse calls': '收起调用',
+    'Load earlier history': '加载更早历史',
+    'Loading earlier history…': '正在加载更早历史…',
+    'Loading earlier history': '正在加载更早历史',
+    ASSISTANT: '助手',
+    TOOL: '工具',
+    USER: '用户',
+    'Session log': '会话日志',
+    'Cordis Plugin': 'Cordis 插件',
+    'System prompt': '系统提示',
+    Messages: '消息',
+    Files: '文件',
+    'Full access': '完全访问',
+    'Enable Full access': '启用完全访问',
+    Cancel: '取消',
+};
+const ZH_PATTERNS = [
+    [/^Turn (\d+)$/, '第 $1 轮'],
+    [/^Tool call (.+)$/, '工具调用 $1'],
+    [/^Input ([\d.]+) tok · Output ([\d.]+) tok$/, '输入 $1 tok · 输出 $2 tok'],
+    [/^LLM (.+)$/, '模型调用 $1'],
+];
+const ZH_SKIP_TAGS = new Set(['PRE', 'CODE', 'SCRIPT', 'STYLE', 'TEXTAREA', 'INPUT', 'SELECT', 'OPTION', 'KBD', 'SAMP']);
+const CARD_TITLE_ZH = {
+    Search: '搜索',
+    Read: '读取',
+    Bash: '命令行',
+    Write: '写入',
+    Edit: '编辑',
+    Code: '代码',
+    Inspect: '检查',
+    'Run Cordis Plugin': '运行 Cordis 插件',
+    'Stop Cordis Plugin': '停止 Cordis 插件',
+    'Remove Cordis Plugin': '移除 Cordis 插件',
+};
+const TOOL_NAME_ZH = {
+    web_search: '网络搜索',
+    bash: '命令行',
+    read: '读取文件',
+    write: '写入文件',
+    edit: '编辑文件',
+    glob: '搜索文件',
+    grep: '搜索内容',
+    read_image: '读取图片',
+    skill: '技能',
+    workflow: '工作流',
+    subagent: '子代理',
+    subagent_fork: '子代理（继承）',
+    todo_write: '任务清单',
+    ask_user_question: '询问用户',
+    exit_plan_mode: '退出计划模式',
+    create_goal: '创建目标',
+    get_goal: '查看目标',
+    update_goal: '更新目标',
+    job_list: '任务列表',
+    job_output: '任务输出',
+    job_kill: '终止任务',
+    list_agents: '代理列表',
+    send_message: '发送消息',
+    interrupt_agent: '中断代理',
+    cordis_define: '定义插件',
+    cordis_run: '运行插件',
+    cordis_stop: '停止插件',
+    cordis_undefine: '删除插件',
+    cordis_inspect_list: '查看提供者',
+    cordis_inspect_query: '查询提供者',
+    cordis_inspect_self: '查看自身',
+    'mcp__codebase-memory__check_index_coverage': '检查索引覆盖',
+    'mcp__codebase-memory__delete_project': '删除项目',
+    'mcp__codebase-memory__detect_changes': '变更影响分析',
+    'mcp__codebase-memory__get_architecture': '架构总览',
+    'mcp__codebase-memory__get_code_snippet': '代码片段',
+    'mcp__codebase-memory__get_graph_schema': '图结构',
+    'mcp__codebase-memory__index_repository': '索引仓库',
+    'mcp__codebase-memory__index_status': '索引状态',
+    'mcp__codebase-memory__ingest_traces': '导入运行时轨迹',
+    'mcp__codebase-memory__list_projects': '项目列表',
+    'mcp__codebase-memory__manage_adr': '架构决策记录',
+    'mcp__codebase-memory__query_graph': '图查询',
+    'mcp__codebase-memory__search_code': '代码搜索',
+    'mcp__codebase-memory__search_graph': '图搜索',
+    'mcp__codebase-memory__trace_path': '调用路径追踪',
+    agent_teams_add_member: '添加成员',
+    agent_teams_claim_task: '认领任务',
+    agent_teams_create: '创建团队',
+    agent_teams_create_task: '创建任务',
+    agent_teams_delete: '删除团队',
+    agent_teams_reassign_task: '重新指派任务',
+    agent_teams_remove_member: '移除成员',
+    agent_teams_send_message: '团队消息',
+    agent_teams_status: '团队状态',
+    agent_teams_update_task: '更新任务',
+    vision_toolkit_activate: '激活视觉工具',
+};
+const TOOL_DESC_ZH = {
+    web_search: '搜索网络获取最新信息。',
+    bash: '执行命令并返回输出（可设置工作目录、超时）。',
+    read: '读取 UTF-8 文本文件并返回带行号的内容。',
+    write: '创建或完整替换一个 UTF-8 文本文件。',
+    edit: '对现有文本文件做精确的局部替换修改。',
+    glob: '按路径模式查找文件，包含隐藏与忽略文件。',
+    grep: '用正则搜索文件内容并返回匹配行。',
+    read_image: '读取图片文件并返回图片本身。',
+    skill: '加载指定技能（skill）的完整指令。',
+    workflow: '编写脚本编排多个子代理，并行扇出执行。',
+    subagent: '把独立任务委托给后台子代理。',
+    subagent_fork: '把任务委托给继承当前对话上下文的子代理。',
+    todo_write: '记录并更新当前工作的结构化任务清单。',
+    ask_user_question: '需要确认、选择或补充信息时向用户提问。',
+    exit_plan_mode: '呈现完整计划并退出计划模式。',
+    create_goal: '创建持久化的同会话完成目标。',
+    get_goal: '读取当前目标的准确 id 与状态。',
+    update_goal: '更新目标的执行状态、暂停或恢复。',
+    job_list: '列出当前启动的后台任务。',
+    job_output: '读取后台任务的输出。',
+    job_kill: '请求终止运行中的后台任务。',
+    list_agents: '按持久 id 列出可续接的后台子代理。',
+    send_message: '向后台子代理发送消息，继续其同一对话。',
+    interrupt_agent: '请求中断后台代理的当前轮次。',
+    cordis_define: '定义新的不可变 Cordis 插件包（不运行）。',
+    cordis_run: '启动或更新 Cordis 插件包。',
+    cordis_stop: '停止当前 Cordis 插件并保留定义。',
+    cordis_undefine: '永久删除 Cordis 插件及其所有包。',
+    cordis_inspect_list: '列出当前已知的检查提供者。',
+    cordis_inspect_query: '执行检查提供者的只读查询。',
+    cordis_inspect_self: '查看当前会话的插件、包与诊断。',
+    'mcp__codebase-memory__check_index_coverage': '检查文件的索引覆盖情况。',
+    'mcp__codebase-memory__delete_project': '把项目从索引中删除。',
+    'mcp__codebase-memory__detect_changes': '把 git 变更映射为影响半径。',
+    'mcp__codebase-memory__get_architecture': '获取项目高层架构总览。',
+    'mcp__codebase-memory__get_code_snippet': '读取函数或类的源码。',
+    'mcp__codebase-memory__get_graph_schema': '获取知识图谱的节点与边类型。',
+    'mcp__codebase-memory__index_repository': '把仓库索引进知识图谱。',
+    'mcp__codebase-memory__index_status': '查看项目索引状态与覆盖报告。',
+    'mcp__codebase-memory__ingest_traces': '导入运行时调用轨迹。',
+    'mcp__codebase-memory__list_projects': '列出已索引的项目。',
+    'mcp__codebase-memory__manage_adr': '创建或更新架构决策记录。',
+    'mcp__codebase-memory__query_graph': '执行 Cypher 图查询。',
+    'mcp__codebase-memory__search_code': '图增强的代码搜索。',
+    'mcp__codebase-memory__search_graph': '按关键词、正则或语义搜索代码图谱。',
+    'mcp__codebase-memory__trace_path': '追踪调用链、数据流与跨服务路径。',
+    agent_teams_add_member: '向团队添加可续命的成员。',
+    agent_teams_claim_task: '为团队成员认领一个就绪任务。',
+    agent_teams_create: '创建多代理团队，你成为队长。',
+    agent_teams_create_task: '在团队创建任务并关联依赖。',
+    agent_teams_delete: '删除团队：中断成员并移除状态。',
+    agent_teams_reassign_task: '重试、重新指派任务或由队长接管。',
+    agent_teams_remove_member: '安全移除成员并回收任务。',
+    agent_teams_send_message: '给队长或团队成员发送消息。',
+    agent_teams_status: '查看团队快照：成员与任务状态。',
+    agent_teams_update_task: '更新任务状态或产出摘要。',
+    vision_toolkit_activate: '激活视觉工具集。',
+};
+// ── 界面中文化 DOM 精准替换逻辑 ────────────────────────────────────
+function inSkipped(element) {
+    let node = element;
+    while (node && node.nodeType === 1) {
+        if (ZH_SKIP_TAGS.has(node.nodeName))
+            return true;
+        node = node.parentElement;
+    }
+    return false;
+}
+function inToolCallRow(element) {
+    let node = element;
+    while (node && node.nodeType === 1) {
+        if (node.hasAttribute && node.hasAttribute('data-chat-call-id'))
+            return true;
+        node = node.parentElement;
+    }
+    return false;
+}
+function inToolCatalog(element) {
+    let node = element;
+    while (node && node.nodeType === 1) {
+        const cls = node.className;
+        if (typeof cls === 'string' && cls.indexOf('toolCatalog') !== -1)
+            return true;
+        node = node.parentElement;
+    }
+    return false;
+}
+function catalogItemOf(element) {
+    let node = element;
+    while (node && node.nodeType === 1) {
+        const cls = node.className;
+        if (typeof cls === 'string' && cls.indexOf('toolCatalogItem') !== -1)
+            return node;
+        node = node.parentElement;
+    }
+    return null;
+}
+function localizeCatalogDesc(item, zhDesc) {
+    const descEls = item.querySelectorAll('[class*="toolCatalogDescription"], [class*="toolCatalogFullDescription"]');
+    for (const el of descEls) {
+        if (el.firstChild && el.firstChild.nodeType === 3) {
+            ;
+            el.firstChild.nodeValue = zhDesc;
+        }
+    }
+}
+function localizeParamsJsonLabel(item) {
+    const walker = document.createTreeWalker(item, NodeFilter.SHOW_TEXT);
+    let t;
+    while ((t = walker.nextNode()) !== null) {
+        const v = String(t.nodeValue);
+        if (v.indexOf(' parameters JSON') !== -1) {
+            t.nodeValue = v.replace(' parameters JSON', ' 参数 JSON');
+        }
+    }
+}
+function localizeCatalogItem(item, localizedItems) {
+    if (localizedItems.has(item))
+        return;
+    localizedItems.add(item);
+    const nameEl = item.querySelector('[class*="toolCatalogName"]');
+    if (!nameEl || !nameEl.firstChild || nameEl.firstChild.nodeType !== 3)
+        return;
+    const nameNode = nameEl.firstChild;
+    const en = String(nameNode.nodeValue).trim();
+    const zhName = TOOL_NAME_ZH[en];
+    if (zhName === undefined)
+        return;
+    nameNode.nodeValue = String(nameNode.nodeValue).replace(en, zhName);
+    const zhDesc = TOOL_DESC_ZH[en];
+    if (zhDesc !== undefined)
+        localizeCatalogDesc(item, zhDesc);
+    localizeParamsJsonLabel(item);
+}
+function tryCardTitle(textNode, trimmed) {
+    const cardTitle = CARD_TITLE_ZH[trimmed];
+    if (cardTitle === undefined)
+        return false;
+    const nv = textNode.nodeValue;
+    if (nv !== null)
+        textNode.nodeValue = nv.replace(trimmed, cardTitle);
+    return true;
+}
+function trySummaryPrefix(textNode, trimmed) {
+    const m = trimmed.match(/^([a-zA-Z][a-zA-Z0-9_]*) · /);
+    if (!m || TOOL_NAME_ZH[m[1]] === undefined)
+        return false;
+    const nv = textNode.nodeValue;
+    if (nv !== null)
+        textNode.nodeValue = nv.replace(m[1], TOOL_NAME_ZH[m[1]]);
+    return true;
+}
+function tryExactText(textNode, trimmed) {
+    const exact = ZH_TABLE[trimmed];
+    if (exact === undefined)
+        return false;
+    const nv = textNode.nodeValue;
+    if (nv !== null)
+        textNode.nodeValue = nv.replace(trimmed, exact);
+    return true;
+}
+function tryPatternText(textNode, trimmed) {
+    for (const [pattern, replacement] of ZH_PATTERNS) {
+        if (pattern.test(trimmed)) {
+            const nv = textNode.nodeValue;
+            if (nv !== null)
+                textNode.nodeValue = nv.replace(pattern, replacement);
+            return true;
+        }
+    }
+    return false;
+}
+function translateToolCallText(textNode, trimmed) {
+    if (tryCardTitle(textNode, trimmed))
+        return true;
+    return trySummaryPrefix(textNode, trimmed);
+}
+function translateTextNode(textNode, localizedItems) {
+    const raw = textNode.nodeValue;
+    if (typeof raw !== 'string' || raw === '')
+        return;
+    const trimmed = raw.trim();
+    if (trimmed === '')
+        return;
+    const parent = textNode.parentElement;
+    if (!parent || inSkipped(parent))
+        return;
+    if (inToolCallRow(parent)) {
+        translateToolCallText(textNode, trimmed);
+        return;
+    }
+    if (inToolCatalog(parent)) {
+        const item = catalogItemOf(parent);
+        if (item) {
+            localizeCatalogItem(item, localizedItems);
+            return;
+        }
+    }
+    if (tryExactText(textNode, trimmed))
+        return;
+    tryPatternText(textNode, trimmed);
+}
+function installUiLocalize() {
+    if (typeof document === 'undefined' || document === null || typeof MutationObserver === 'undefined')
+        return () => { };
+    const localizedItems = new WeakSet();
+    const scan = (root) => {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const hits = [];
+        let node;
+        while ((node = walker.nextNode()) !== null)
+            hits.push(node);
+        for (const hit of hits)
+            translateTextNode(hit, localizedItems);
+    };
+    scan(document.body);
+    const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+            if (mutation.type === 'characterData' && mutation.target.nodeType === 3) {
+                translateTextNode(mutation.target, localizedItems);
+            }
+            else if (mutation.type === 'childList') {
+                for (const added of mutation.addedNodes) {
+                    if (added.nodeType === 1)
+                        scan(added);
+                    else if (added.nodeType === 3)
+                        translateTextNode(added, localizedItems);
+                }
+            }
+        }
+    });
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    return () => observer.disconnect();
+}
+// ── 纯函数导出（供纯 Node 测试断言映射，不依赖 DOM）─────────────────
+/** 工具名中文化映射。 */
+function zhToolName(name) {
+    return TOOL_NAME_ZH[name] ?? null;
+}
+/** 工具描述中文化映射。 */
+function zhToolDesc(name) {
+    return TOOL_DESC_ZH[name] ?? null;
+}
+/** 卡片标题中文化映射。 */
+function zhCardTitle(title) {
+    return CARD_TITLE_ZH[title] ?? null;
+}
+/** others 卡片摘要 `工具名 · …` 的工具名前缀替换。 */
+function zhCardSummary(text) {
+    const m = String(text).match(/^([a-zA-Z][a-zA-Z0-9_]*) · /);
+    if (m && TOOL_NAME_ZH[m[1]] !== undefined)
+        return String(text).replace(m[1], TOOL_NAME_ZH[m[1]]);
+    return null;
+}
+// ── 插件入口 ───────────────────────────────────────────────────────
+// 注：编译产物内联进 factory 作用域后，module.exports 已在模板中声明。
+// 此处直接使用 module.exports（模板顶部已声明 var module = { exports: {} }）。
+// EAC 定制：不再注册任何渲染器，故无需 inject 任何客户端服务。
+const _exports = module.exports;
+_exports.inject = [];
+_exports.apply = function apply(ctx) {
+    // UI 标签中文化（唯一保留的功能）
+    ctx.effect(() => installUiLocalize(), 'dsh-think-zh-expand-eac: ui localization');
+};
+
+
+    return module.exports
+  },
+})

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/lib/client.src.js
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/lib/client.src.js
@@ -1,0 +1,27 @@
+/**
+ * dsh-think-zh-expand-eac — client half (browser).
+ *
+ * 功能 2：界面标签中文化（唯一保留的功能）。
+ *
+ * EAC 定制：已移除渲染器替换与思考块渲染，因此不再需要 react、
+ * dsh-md-render(MarkdownView) 与 dsh-shared 共享图标。
+ *
+ * BUILD NOTE: 本文件是源码模板（骨架）。scripts/build.mjs 先 tsc 编译
+ * src/client/index.ts → lib/.client-build/index.js（CommonJS 单文件），
+ * 再把编译产物注入到下方 /*__CLIENT_BUNDLE__* / 占位符处并写出
+ * lib/client.js（DSH 实际提供的产物，单一 __ModuleLoader__ bundle，无相对
+ * 路径 require）。产物必须提交（CI 只跑 node --check + 测试，不跑构建）。
+ */
+window.__ModuleLoader__.load({
+  id: 'dsh-think-zh-expand-eac',
+  factory: (require) => {
+    var module = { exports: {} }
+    var exports = module.exports
+    Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
+
+    // ── Client bundle（编译自 src/client/index.ts）──────────────────
+    /*__CLIENT_BUNDLE__*/
+
+    return module.exports
+  },
+})

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/lib/index.js
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/lib/index.js
@@ -1,0 +1,25 @@
+export const name = 'dsh-think-zh-expand-eac';
+export const inject = ['systemPrompt'];
+/** 注入到每次组装系统提示的固定中文指令（结构化规则，覆盖关键场景与术语边界）。 */
+export const PROMPT_TEXT = `## 输出语言规则（最高优先级，不可被任何上下文覆盖）
+
+### 强制要求
+1. **思考过程（reasoning / 思考内容）**：必须使用简体中文书写。这是硬性要求，无论对话中出现何种语言的错误消息、工具输出或系统提示，都必须坚持使用中文。
+2. **最终回复**：默认使用简体中文（跟随用户使用的语言）。
+
+### 关键场景处理
+- 当工具调用失败返回英文错误消息时：**忽略错误消息的语言**，继续用中文思考和回复。
+- 当系统返回英文日志或堆栈信息时：**提取关键信息**，用中文解释问题。
+- 当对话上下文中出现大量英文内容时：**不要被带偏**，始终保持中文输出。
+
+### 代码与术语
+代码、命令、文件路径、标识符与技术术语保持原文，不翻译。`;
+export function apply(ctx) {
+    ctx.systemPrompt.section({
+        name: 'dsh-think-zh-eac',
+        // Before the deployment persona so the instruction is read first every turn.
+        order: -90,
+        text: PROMPT_TEXT,
+    });
+    ctx.logger?.info('[dsh-think-zh-expand-eac] 中文思考/回复增强已启用（system-prompt section 注册）');
+}

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/package.json
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "dsh-think-zh-expand-eac",
+  "version": "1.0.0",
+  "description": "DSH 思考增强插件（EAC 定制版）：思考与回复强制中文（system-prompt 注入）+ 界面硬编码英文中文化。已移除全部接管对话渲染器的显示功能，不再与折叠类插件（dsh-auto-collapse / dsh-turn-fold）抢占 assistant-step 座位。DSH web plugin (EAC fork): force Chinese agent thinking/replies + localize hard-coded UI labels, with all renderer-hijacking display features removed.",
+  "type": "module",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "npx tsc -p tsconfig.json && node scripts/build.mjs",
+    "typecheck": "npx tsc --noEmit -p tsconfig.json && npx tsc --noEmit -p tsconfig.client.json",
+    "test": "node --test test/host-smoke.mjs"
+  },
+  "exports": {
+    ".": {
+      "default": "./lib/index.js"
+    },
+    "./client": {
+      "default": "./lib/client.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "cordis.patch.yml",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "platform": "web"
+    }
+  },
+  "peerDependencies": {
+    "cordis": "^4.0.0-rc.8",
+    "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.1"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-system-prompt": {
+      "optional": true
+    },
+    "cordis": {
+      "optional": true
+    }
+  },
+  "license": "MIT"
+}

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/scripts/build.mjs
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/scripts/build.mjs
@@ -1,0 +1,59 @@
+/**
+ * Build: compile the client TypeScript source (src/client/index.ts) to a
+ * CommonJS bundle with tsc, then splice it into the lib/client.src.js template
+ * (at the /*__CLIENT_BUNDLE__* / placeholder) and write lib/client.js — the
+ * file DSH actually serves at /plugins/dsh-think-zh-expand/client.js.
+ *
+ * Also splice shared icons from dsh-shared (icons.part.js) into the template.
+ *
+ *   node scripts/build.mjs
+ *
+ * lib/client.js is the build artifact and MUST be committed (CI runs
+ * node --check + tests against it; it does not run this build).
+ *
+ * NOTE: replaceAll uses a FUNCTION replacer — a string replacer would
+ * interpret $& / $1 special patterns inside the bundle source.
+ */
+import { execSync } from 'node:child_process'
+import { readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const BUILD_DIR = join(root, 'lib/.client-build')
+const PLACEHOLDER = '/*__CLIENT_BUNDLE__*/'
+
+// 1. tsc 编译 client TS → lib/.client-build/index.js（CommonJS 单文件）
+execSync('npx tsc -p tsconfig.client.json', { cwd: root, stdio: 'inherit' })
+
+// 2. 读取编译产物
+const bundle = readFileSync(join(BUILD_DIR, 'index.js'), 'utf8')
+
+// 3. 注入模板
+let out = readFileSync(join(root, 'lib/client.src.js'), 'utf8')
+
+// 注入 client bundle
+if (!out.includes(PLACEHOLDER)) {
+  throw new Error(`client.src.js is missing the ${PLACEHOLDER} placeholder`)
+}
+out = out.replaceAll(PLACEHOLDER, () => bundle)
+if (out.includes(PLACEHOLDER)) {
+  throw new Error('client.src.js has unresolved placeholders')
+}
+
+// EAC 定制：不再注入 dsh-shared 共享图标（渲染器已移除，无图标消费者）。
+// 若模板残留 __PART_ICONS__ 占位符，说明模板未同步，直接报错而非静默产出坏包。
+if (out.includes('/*__PART_ICONS__*/')) {
+  throw new Error('client.src.js still contains /*__PART_ICONS__*/ — EAC build does not inject shared icons')
+}
+
+// 剔除仅供 src 模板静态 lint 使用的注释
+out = out.replaceAll('/* global AssistantStepView, installUiLocalize */\n', '')
+out = out.replaceAll('/* global installUiLocalize */\n', '')
+out = out.replaceAll('    // eslint-disable-next-line no-unused-vars\n', '')
+
+writeFileSync(join(root, 'lib/client.js'), out)
+
+// 4. 清理临时编译目录
+rmSync(BUILD_DIR, { recursive: true, force: true })
+console.log(`built lib/client.js (${out.length} bytes, ${out.split('\n').length} lines)`)

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/src/client/index.ts
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/src/client/index.ts
@@ -1,0 +1,418 @@
+/**
+ * dsh-think-zh-expand-eac — client 端入口（EAC 定制版）。
+ *
+ * 本文件由 baosfeng/my-dsh-plugins 的 dsh-think-zh-expand 派生，
+ * 已**移除全部会与宿主对话折叠机制冲突的显示功能**。
+ *
+ * 保留：
+ *   功能 2：界面标签中文化（DOM 精准文本替换，MutationObserver 跟随重渲染）。
+ *
+ * 已移除（与 dsh-auto-collapse / dsh-turn-fold 等折叠插件冲突）：
+ *   - `conversation.chat.node` 的 `assistant-step` 渲染器注册（priority:-1 抢位）
+ *   - ThinkBlock（默认展开、流式强制展开）
+ *   - AssistantStepView 及 imageBlock / renderBlocks 等自绘渲染逻辑
+ *   - 官方 SVG 图标内联与 `.dsh-think-zh-expand-*` 样式表
+ *   - 对 `dsh-md-render` 的跨插件 MarkdownView 依赖
+ *
+ * 结果：不再接管任何渲染器、不产生任何对话区 DOM 结构，因此可与任何
+ * 折叠类插件共存；思考段的折叠表现完全交还给宿主与折叠插件。
+ *
+ * 构建流程：`tsc -p tsconfig.client.json` 编译为 CommonJS 单文件
+ * （lib/.client-build/index.js），scripts/build.mjs 再注入
+ * lib/client.src.js 模板的 __CLIENT_BUNDLE__ 占位符，写出 lib/client.js。
+ */
+
+// ── DSH 运行时最小契约（仅中文化所需）──────────────────────────────
+
+/** client 端 Context（cordis Context 最小契约）。 */
+interface ClientContext {
+  effect(callback: () => void | (() => void), label?: string): void
+}
+// ── 界面中文化词表 ─────────────────────────────────────────────────
+
+const ZH_TABLE: Record<string, string> = {
+  Thinking: '思考',
+  'Tool Call': '工具调用',
+  'Tool calls': '工具调用',
+  'Tool call': '工具调用',
+  'Tool call only': '仅工具调用',
+  Tools: '工具',
+  'No content': '无内容',
+  'Tools Updated': '工具已更新',
+  Duration: '用时',
+  'Use actual duration': '使用实际耗时',
+  'Use equal-width operations': '使用等宽操作',
+  Turns: '轮次',
+  'Expand turns': '展开轮次',
+  'Collapse turns': '收起轮次',
+  Calls: '调用',
+  'Expand calls': '展开调用',
+  'Collapse calls': '收起调用',
+  'Load earlier history': '加载更早历史',
+  'Loading earlier history…': '正在加载更早历史…',
+  'Loading earlier history': '正在加载更早历史',
+  ASSISTANT: '助手',
+  TOOL: '工具',
+  USER: '用户',
+  'Session log': '会话日志',
+  'Cordis Plugin': 'Cordis 插件',
+  'System prompt': '系统提示',
+  Messages: '消息',
+  Files: '文件',
+  'Full access': '完全访问',
+  'Enable Full access': '启用完全访问',
+  Cancel: '取消',
+}
+
+const ZH_PATTERNS: Array<[RegExp, string]> = [
+  [/^Turn (\d+)$/, '第 $1 轮'],
+  [/^Tool call (.+)$/, '工具调用 $1'],
+  [/^Input ([\d.]+) tok · Output ([\d.]+) tok$/, '输入 $1 tok · 输出 $2 tok'],
+  [/^LLM (.+)$/, '模型调用 $1'],
+]
+
+const ZH_SKIP_TAGS = new Set(['PRE', 'CODE', 'SCRIPT', 'STYLE', 'TEXTAREA', 'INPUT', 'SELECT', 'OPTION', 'KBD', 'SAMP'])
+
+const CARD_TITLE_ZH: Record<string, string> = {
+  Search: '搜索',
+  Read: '读取',
+  Bash: '命令行',
+  Write: '写入',
+  Edit: '编辑',
+  Code: '代码',
+  Inspect: '检查',
+  'Run Cordis Plugin': '运行 Cordis 插件',
+  'Stop Cordis Plugin': '停止 Cordis 插件',
+  'Remove Cordis Plugin': '移除 Cordis 插件',
+}
+
+const TOOL_NAME_ZH: Record<string, string> = {
+  web_search: '网络搜索',
+  bash: '命令行',
+  read: '读取文件',
+  write: '写入文件',
+  edit: '编辑文件',
+  glob: '搜索文件',
+  grep: '搜索内容',
+  read_image: '读取图片',
+  skill: '技能',
+  workflow: '工作流',
+  subagent: '子代理',
+  subagent_fork: '子代理（继承）',
+  todo_write: '任务清单',
+  ask_user_question: '询问用户',
+  exit_plan_mode: '退出计划模式',
+  create_goal: '创建目标',
+  get_goal: '查看目标',
+  update_goal: '更新目标',
+  job_list: '任务列表',
+  job_output: '任务输出',
+  job_kill: '终止任务',
+  list_agents: '代理列表',
+  send_message: '发送消息',
+  interrupt_agent: '中断代理',
+  cordis_define: '定义插件',
+  cordis_run: '运行插件',
+  cordis_stop: '停止插件',
+  cordis_undefine: '删除插件',
+  cordis_inspect_list: '查看提供者',
+  cordis_inspect_query: '查询提供者',
+  cordis_inspect_self: '查看自身',
+  'mcp__codebase-memory__check_index_coverage': '检查索引覆盖',
+  'mcp__codebase-memory__delete_project': '删除项目',
+  'mcp__codebase-memory__detect_changes': '变更影响分析',
+  'mcp__codebase-memory__get_architecture': '架构总览',
+  'mcp__codebase-memory__get_code_snippet': '代码片段',
+  'mcp__codebase-memory__get_graph_schema': '图结构',
+  'mcp__codebase-memory__index_repository': '索引仓库',
+  'mcp__codebase-memory__index_status': '索引状态',
+  'mcp__codebase-memory__ingest_traces': '导入运行时轨迹',
+  'mcp__codebase-memory__list_projects': '项目列表',
+  'mcp__codebase-memory__manage_adr': '架构决策记录',
+  'mcp__codebase-memory__query_graph': '图查询',
+  'mcp__codebase-memory__search_code': '代码搜索',
+  'mcp__codebase-memory__search_graph': '图搜索',
+  'mcp__codebase-memory__trace_path': '调用路径追踪',
+  agent_teams_add_member: '添加成员',
+  agent_teams_claim_task: '认领任务',
+  agent_teams_create: '创建团队',
+  agent_teams_create_task: '创建任务',
+  agent_teams_delete: '删除团队',
+  agent_teams_reassign_task: '重新指派任务',
+  agent_teams_remove_member: '移除成员',
+  agent_teams_send_message: '团队消息',
+  agent_teams_status: '团队状态',
+  agent_teams_update_task: '更新任务',
+  vision_toolkit_activate: '激活视觉工具',
+}
+
+const TOOL_DESC_ZH: Record<string, string> = {
+  web_search: '搜索网络获取最新信息。',
+  bash: '执行命令并返回输出（可设置工作目录、超时）。',
+  read: '读取 UTF-8 文本文件并返回带行号的内容。',
+  write: '创建或完整替换一个 UTF-8 文本文件。',
+  edit: '对现有文本文件做精确的局部替换修改。',
+  glob: '按路径模式查找文件，包含隐藏与忽略文件。',
+  grep: '用正则搜索文件内容并返回匹配行。',
+  read_image: '读取图片文件并返回图片本身。',
+  skill: '加载指定技能（skill）的完整指令。',
+  workflow: '编写脚本编排多个子代理，并行扇出执行。',
+  subagent: '把独立任务委托给后台子代理。',
+  subagent_fork: '把任务委托给继承当前对话上下文的子代理。',
+  todo_write: '记录并更新当前工作的结构化任务清单。',
+  ask_user_question: '需要确认、选择或补充信息时向用户提问。',
+  exit_plan_mode: '呈现完整计划并退出计划模式。',
+  create_goal: '创建持久化的同会话完成目标。',
+  get_goal: '读取当前目标的准确 id 与状态。',
+  update_goal: '更新目标的执行状态、暂停或恢复。',
+  job_list: '列出当前启动的后台任务。',
+  job_output: '读取后台任务的输出。',
+  job_kill: '请求终止运行中的后台任务。',
+  list_agents: '按持久 id 列出可续接的后台子代理。',
+  send_message: '向后台子代理发送消息，继续其同一对话。',
+  interrupt_agent: '请求中断后台代理的当前轮次。',
+  cordis_define: '定义新的不可变 Cordis 插件包（不运行）。',
+  cordis_run: '启动或更新 Cordis 插件包。',
+  cordis_stop: '停止当前 Cordis 插件并保留定义。',
+  cordis_undefine: '永久删除 Cordis 插件及其所有包。',
+  cordis_inspect_list: '列出当前已知的检查提供者。',
+  cordis_inspect_query: '执行检查提供者的只读查询。',
+  cordis_inspect_self: '查看当前会话的插件、包与诊断。',
+  'mcp__codebase-memory__check_index_coverage': '检查文件的索引覆盖情况。',
+  'mcp__codebase-memory__delete_project': '把项目从索引中删除。',
+  'mcp__codebase-memory__detect_changes': '把 git 变更映射为影响半径。',
+  'mcp__codebase-memory__get_architecture': '获取项目高层架构总览。',
+  'mcp__codebase-memory__get_code_snippet': '读取函数或类的源码。',
+  'mcp__codebase-memory__get_graph_schema': '获取知识图谱的节点与边类型。',
+  'mcp__codebase-memory__index_repository': '把仓库索引进知识图谱。',
+  'mcp__codebase-memory__index_status': '查看项目索引状态与覆盖报告。',
+  'mcp__codebase-memory__ingest_traces': '导入运行时调用轨迹。',
+  'mcp__codebase-memory__list_projects': '列出已索引的项目。',
+  'mcp__codebase-memory__manage_adr': '创建或更新架构决策记录。',
+  'mcp__codebase-memory__query_graph': '执行 Cypher 图查询。',
+  'mcp__codebase-memory__search_code': '图增强的代码搜索。',
+  'mcp__codebase-memory__search_graph': '按关键词、正则或语义搜索代码图谱。',
+  'mcp__codebase-memory__trace_path': '追踪调用链、数据流与跨服务路径。',
+  agent_teams_add_member: '向团队添加可续命的成员。',
+  agent_teams_claim_task: '为团队成员认领一个就绪任务。',
+  agent_teams_create: '创建多代理团队，你成为队长。',
+  agent_teams_create_task: '在团队创建任务并关联依赖。',
+  agent_teams_delete: '删除团队：中断成员并移除状态。',
+  agent_teams_reassign_task: '重试、重新指派任务或由队长接管。',
+  agent_teams_remove_member: '安全移除成员并回收任务。',
+  agent_teams_send_message: '给队长或团队成员发送消息。',
+  agent_teams_status: '查看团队快照：成员与任务状态。',
+  agent_teams_update_task: '更新任务状态或产出摘要。',
+  vision_toolkit_activate: '激活视觉工具集。',
+}
+
+// ── 界面中文化 DOM 精准替换逻辑 ────────────────────────────────────
+
+function inSkipped(element: Element): boolean {
+  let node: Element | null = element
+  while (node && node.nodeType === 1) {
+    if (ZH_SKIP_TAGS.has(node.nodeName)) return true
+    node = node.parentElement
+  }
+  return false
+}
+
+function inToolCallRow(element: Element): boolean {
+  let node: Element | null = element
+  while (node && node.nodeType === 1) {
+    if (node.hasAttribute && node.hasAttribute('data-chat-call-id')) return true
+    node = node.parentElement
+  }
+  return false
+}
+
+function inToolCatalog(element: Element): boolean {
+  let node: Element | null = element
+  while (node && node.nodeType === 1) {
+    const cls = (node as HTMLElement).className
+    if (typeof cls === 'string' && cls.indexOf('toolCatalog') !== -1) return true
+    node = node.parentElement
+  }
+  return false
+}
+
+function catalogItemOf(element: Element): Element | null {
+  let node: Element | null = element
+  while (node && node.nodeType === 1) {
+    const cls = (node as HTMLElement).className
+    if (typeof cls === 'string' && cls.indexOf('toolCatalogItem') !== -1) return node
+    node = node.parentElement
+  }
+  return null
+}
+
+function localizeCatalogDesc(item: Element, zhDesc: string): void {
+  const descEls = item.querySelectorAll('[class*="toolCatalogDescription"], [class*="toolCatalogFullDescription"]')
+  for (const el of descEls) {
+    if (el.firstChild && el.firstChild.nodeType === 3) {
+      ;(el.firstChild as Text).nodeValue = zhDesc
+    }
+  }
+}
+
+function localizeParamsJsonLabel(item: Element): void {
+  const walker = document.createTreeWalker(item, NodeFilter.SHOW_TEXT)
+  let t: Text | null
+  while ((t = walker.nextNode() as Text | null) !== null) {
+    const v = String(t.nodeValue)
+    if (v.indexOf(' parameters JSON') !== -1) {
+      t.nodeValue = v.replace(' parameters JSON', ' 参数 JSON')
+    }
+  }
+}
+
+function localizeCatalogItem(item: Element, localizedItems: WeakSet<Element>): void {
+  if (localizedItems.has(item)) return
+  localizedItems.add(item)
+  const nameEl = item.querySelector('[class*="toolCatalogName"]')
+  if (!nameEl || !nameEl.firstChild || nameEl.firstChild.nodeType !== 3) return
+  const nameNode = nameEl.firstChild as Text
+  const en = String(nameNode.nodeValue).trim()
+  const zhName = TOOL_NAME_ZH[en]
+  if (zhName === undefined) return
+  nameNode.nodeValue = String(nameNode.nodeValue).replace(en, zhName)
+  const zhDesc = TOOL_DESC_ZH[en]
+  if (zhDesc !== undefined) localizeCatalogDesc(item, zhDesc)
+  localizeParamsJsonLabel(item)
+}
+
+function tryCardTitle(textNode: Text, trimmed: string): boolean {
+  const cardTitle = CARD_TITLE_ZH[trimmed]
+  if (cardTitle === undefined) return false
+  const nv = textNode.nodeValue
+  if (nv !== null) textNode.nodeValue = nv.replace(trimmed, cardTitle)
+  return true
+}
+
+function trySummaryPrefix(textNode: Text, trimmed: string): boolean {
+  const m = trimmed.match(/^([a-zA-Z][a-zA-Z0-9_]*) · /)
+  if (!m || TOOL_NAME_ZH[m[1]] === undefined) return false
+  const nv = textNode.nodeValue
+  if (nv !== null) textNode.nodeValue = nv.replace(m[1], TOOL_NAME_ZH[m[1]])
+  return true
+}
+
+function tryExactText(textNode: Text, trimmed: string): boolean {
+  const exact = ZH_TABLE[trimmed]
+  if (exact === undefined) return false
+  const nv = textNode.nodeValue
+  if (nv !== null) textNode.nodeValue = nv.replace(trimmed, exact)
+  return true
+}
+
+function tryPatternText(textNode: Text, trimmed: string): boolean {
+  for (const [pattern, replacement] of ZH_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      const nv = textNode.nodeValue
+      if (nv !== null) textNode.nodeValue = nv.replace(pattern, replacement)
+      return true
+    }
+  }
+  return false
+}
+
+function translateToolCallText(textNode: Text, trimmed: string): boolean {
+  if (tryCardTitle(textNode, trimmed)) return true
+  return trySummaryPrefix(textNode, trimmed)
+}
+
+function translateTextNode(textNode: Text, localizedItems: WeakSet<Element>): void {
+  const raw = textNode.nodeValue
+  if (typeof raw !== 'string' || raw === '') return
+  const trimmed = raw.trim()
+  if (trimmed === '') return
+  const parent = textNode.parentElement
+  if (!parent || inSkipped(parent)) return
+  if (inToolCallRow(parent)) {
+    translateToolCallText(textNode, trimmed)
+    return
+  }
+  if (inToolCatalog(parent)) {
+    const item = catalogItemOf(parent)
+    if (item) {
+      localizeCatalogItem(item, localizedItems)
+      return
+    }
+  }
+  if (tryExactText(textNode, trimmed)) return
+  tryPatternText(textNode, trimmed)
+}
+
+function installUiLocalize(): () => void {
+  if (typeof document === 'undefined' || document === null || typeof MutationObserver === 'undefined') return () => {}
+
+  const localizedItems = new WeakSet<Element>()
+
+  const scan = (root: Element | Document) => {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    const hits: Text[] = []
+    let node: Text | null
+    while ((node = walker.nextNode() as Text | null) !== null) hits.push(node)
+    for (const hit of hits) translateTextNode(hit, localizedItems)
+  }
+
+  scan(document.body)
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'characterData' && mutation.target.nodeType === 3) {
+        translateTextNode(mutation.target as Text, localizedItems)
+      } else if (mutation.type === 'childList') {
+        for (const added of mutation.addedNodes) {
+          if (added.nodeType === 1) scan(added as Element)
+          else if (added.nodeType === 3) translateTextNode(added as Text, localizedItems)
+        }
+      }
+    }
+  })
+  observer.observe(document.body, { childList: true, subtree: true, characterData: true })
+  return () => observer.disconnect()
+}
+
+// ── 纯函数导出（供纯 Node 测试断言映射，不依赖 DOM）─────────────────
+
+/** 工具名中文化映射。 */
+export function zhToolName(name: string): string | null {
+  return TOOL_NAME_ZH[name] ?? null
+}
+
+/** 工具描述中文化映射。 */
+export function zhToolDesc(name: string): string | null {
+  return TOOL_DESC_ZH[name] ?? null
+}
+
+/** 卡片标题中文化映射。 */
+export function zhCardTitle(title: string): string | null {
+  return CARD_TITLE_ZH[title] ?? null
+}
+
+/** others 卡片摘要 `工具名 · …` 的工具名前缀替换。 */
+export function zhCardSummary(text: string): string | null {
+  const m = String(text).match(/^([a-zA-Z][a-zA-Z0-9_]*) · /)
+  if (m && TOOL_NAME_ZH[m[1]] !== undefined) return String(text).replace(m[1], TOOL_NAME_ZH[m[1]])
+  return null
+}
+
+// ── Factory 作用域变量声明 ─────────────────────────────────────────
+// client 端编译产物将内联进 __ModuleLoader__ factory 作用域，该作用域
+// 由模板（lib/client.src.js）声明了 var module / var exports / require。
+// 此处声明同名变量让 tsc 不报错。
+declare const module: { exports: Record<string, unknown> }
+
+// ── 插件入口 ───────────────────────────────────────────────────────
+
+// 注：编译产物内联进 factory 作用域后，module.exports 已在模板中声明。
+// 此处直接使用 module.exports（模板顶部已声明 var module = { exports: {} }）。
+// EAC 定制：不再注册任何渲染器，故无需 inject 任何客户端服务。
+const _exports = module.exports as Record<string, unknown>
+_exports.inject = []
+
+_exports.apply = function apply(ctx: ClientContext): void {
+  // UI 标签中文化（唯一保留的功能）
+  ctx.effect(() => installUiLocalize(), 'dsh-think-zh-expand-eac: ui localization')
+}

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/src/index.ts
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * dsh-think-zh-expand-eac — host half（TypeScript 源码）。
+ *
+ * 功能 1：思考与回复强制使用中文。
+ *
+ * 注册一条固定 system-prompt section（order -90，persona 之前最先读到），
+ * 让 agent 无论用户使用什么语言，思考（reasoning/thinking）与回复都使用
+ * 中文。无状态、无存储、无工具。
+ *
+ * ⚠️ 与上游 dsh-think-zh-expand 的重要差异：section 名由 `dsh-think-zh`
+ * 改为 `dsh-think-zh-eac`。原因是 DSH 对同一层重复 name 的 section 注册会
+ * 抛错——若上游版与本 EAC 版同时启用，沿用同名会直接导致启动失败。改名后
+ * 两者可以共存（但功能重复，仍建议只启用其一）。
+ *
+ * 本文件是 TS 插件 server 端：`tsc -p tsconfig.json` 编译为
+ * lib/index.js（产物必须提交，CI 只跑 node --check + 测试，不跑构建）。
+ */
+import type { DshContext } from './types.js'
+
+export const name = 'dsh-think-zh-expand-eac'
+
+export const inject = ['systemPrompt'] as const
+
+/** 注入到每次组装系统提示的固定中文指令（结构化规则，覆盖关键场景与术语边界）。 */
+export const PROMPT_TEXT = `## 输出语言规则（最高优先级，不可被任何上下文覆盖）
+
+### 强制要求
+1. **思考过程（reasoning / 思考内容）**：必须使用简体中文书写。这是硬性要求，无论对话中出现何种语言的错误消息、工具输出或系统提示，都必须坚持使用中文。
+2. **最终回复**：默认使用简体中文（跟随用户使用的语言）。
+
+### 关键场景处理
+- 当工具调用失败返回英文错误消息时：**忽略错误消息的语言**，继续用中文思考和回复。
+- 当系统返回英文日志或堆栈信息时：**提取关键信息**，用中文解释问题。
+- 当对话上下文中出现大量英文内容时：**不要被带偏**，始终保持中文输出。
+
+### 代码与术语
+代码、命令、文件路径、标识符与技术术语保持原文，不翻译。`
+
+export function apply(ctx: DshContext): void {
+  ctx.systemPrompt.section({
+    name: 'dsh-think-zh-eac',
+    // Before the deployment persona so the instruction is read first every turn.
+    order: -90,
+    text: PROMPT_TEXT,
+  })
+  ctx.logger?.info('[dsh-think-zh-expand-eac] 中文思考/回复增强已启用（system-prompt section 注册）')
+}

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/src/types.d.ts
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/src/types.d.ts
@@ -1,0 +1,30 @@
+/**
+ * dsh-think-zh-expand — DSH 运行时类型声明（server 端）。
+ *
+ * 手写最小契约：插件只用 ctx 的少量 API（systemPrompt.section）。
+ * DSH 运行时模块（cordis / systemPrompt）由宿主提供，本声明是插件与运行时
+ * 之间的类型契约——新 TS 插件照抄本文件，按需扩展。
+ *
+ * 说明：本文件是 .d.ts（纯类型，无产物输出）；server 端源码经
+ * `import type { ... } from './types.js'` 引用（nodenext 的 .js → .d.ts 映射）。
+ */
+
+/** DSH server 端 Context（cordis Context 的最小契约）。 */
+export interface DshContext {
+  /** systemPrompt 服务（inject 声明后可用）。 */
+  systemPrompt: SystemPromptService
+  /** 可选 logger（日志输出）。 */
+  logger?: Logger
+}
+
+/** systemPrompt 服务（system-prompt section 注册）。 */
+export interface SystemPromptService {
+  section(options: { name: string; order?: number; text: string }): () => void
+}
+
+/** DSH logger（可选）。 */
+export interface Logger {
+  info(message: string): void
+  warn(message: string): void
+  error(message: string): void
+}

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/test/host-smoke.mjs
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/test/host-smoke.mjs
@@ -1,0 +1,82 @@
+/**
+ * dsh-think-zh-expand-eac — host 半冒烟测试。
+ *
+ * 用 mock context 挂载插件，断言 system-prompt section 注册正确。
+ * client 半是浏览器专用；其语法由 `node --check lib/client.js` 校验。
+ *
+ * 使用 Node 内置 test runner（无需额外依赖）：
+ *   node --test test/
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { apply, PROMPT_TEXT, inject, name } from '../lib/index.js'
+
+/** 构造 mock context 并运行 apply，返回注册的 section 与日志。 */
+function boot() {
+  const sections = []
+  const logs = []
+  const ctx = {
+    systemPrompt: {
+      section(section) {
+        sections.push(section)
+        return () => {}
+      },
+    },
+    logger: {
+      info: (message) => logs.push(message),
+      warn: (message) => logs.push(message),
+      error: (message) => logs.push(message),
+    },
+  }
+  apply(ctx)
+  return { sections, logs }
+}
+
+test('插件名与上游区分（独立包名）', () => {
+  assert.equal(name, 'dsh-think-zh-expand-eac', '导出 name 为 EAC 版包名')
+})
+
+test('注册且仅注册一条 system-prompt section', () => {
+  const { sections } = boot()
+  assert.equal(sections.length, 1, '恰好注册一条 section')
+})
+
+test('section 使用 EAC 专名，避免与上游同名冲突', () => {
+  const { sections } = boot()
+  const section = sections[0]
+  assert.equal(section.name, 'dsh-think-zh-eac', 'section 名为 dsh-think-zh-eac（上游为 dsh-think-zh）')
+  assert.equal(section.order, -90, 'order 为 -90（persona 之前最先读到）')
+  assert.equal(typeof section.text, 'string', 'section text 为字符串')
+})
+
+test('注入的中文指令覆盖关键场景', () => {
+  const { sections } = boot()
+  const text = sections[0].text
+  assert.ok(text.includes('思考'), '覆盖思考')
+  assert.ok(text.includes('中文'), '强制中文')
+  assert.ok(text.includes('回复'), '覆盖回复')
+  assert.ok(text.includes('错误消息'), '覆盖英文错误消息场景')
+  assert.ok(text.includes('日志'), '覆盖英文日志/堆栈场景')
+  assert.ok(text.includes('不翻译'), '代码/命令/路径不翻译')
+  assert.ok(text.includes('最高优先级'), '声明最高优先级')
+  assert.equal(text, PROMPT_TEXT, 'PROMPT_TEXT 常量与注入文本一致')
+})
+
+test('inject 声明 systemPrompt 硬依赖', () => {
+  assert.ok(Array.isArray(inject), 'inject 是数组')
+  assert.ok(inject.includes('systemPrompt'), '声明 systemPrompt 硬依赖')
+})
+
+test('apply 输出带 EAC 前缀的启用日志', () => {
+  const { logs } = boot()
+  assert.ok(logs.length >= 1, '至少一条日志')
+  assert.ok(logs[0].startsWith('[dsh-think-zh-expand-eac]'), '日志带 EAC 前缀')
+  assert.ok(logs[0].includes('已启用'), '日志描述已启用行为')
+})
+
+test('缺少 logger 时仍能注册（可选链容错）', () => {
+  const sections = []
+  const ctx = { systemPrompt: { section: (section) => sections.push(section) } }
+  apply(ctx)
+  assert.equal(sections.length, 1, '无 logger 也注册成功')
+})

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/tsconfig.client.json
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/tsconfig.client.json
@@ -1,0 +1,23 @@
+{
+  // dsh-think-zh-expand-eac — client 端构建配置：src/client/index.ts →
+  // lib/.client-build/index.js（CommonJS 单文件，scripts/build.mjs 注入模板）。
+  // CommonJS 产物内联进 __ModuleLoader__ factory 作用域后，
+  // require / exports / module 均为 factory 作用域变量，可直接运行。
+  //
+  // EAC 定制：已移除渲染器替换，故不再需要 react 类型；仅中文化逻辑用 DOM。
+  // lib 需含 DOM.Iterable —— 中文化代码对 NodeList 做迭代。
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "outDir": "lib/.client-build",
+    "rootDir": "src/client",
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": []
+  },
+  "include": ["src/client/**/*.ts"]
+}

--- a/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/tsconfig.json
+++ b/dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  // dsh-think-zh-expand-eac — server 端构建配置：src/*.ts → lib/*.js（tsc 编译产物）。
+  // 产物必须提交（DSH 直接加载 lib/index.js，不在安装时构建）。
+  // client 端构建见 tsconfig.client.json + scripts/build.mjs。
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "lib",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["src/client"]
+}

--- a/dsh-desktop/assets/plugins/dsh-unified-market/CHANGELOG.md
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 本文件记录 dsh-unified-market 对外可见的变更。
 
+## 0.4.0
+
+**profile 配置写入从「单向复写」改为「双边同步」。**
+
+背景：此前市场只经 `dsh plugin add/remove` 间接改配置，由 dsh 内核
+`reconcilePlugins` 按 `dependencies` **整文件重写** `package.json`。整文件重写 =
+「以内存状态覆盖磁盘」：读取之后、写入之前发生的一切外部改动（用户手编、
+其他插件、壳侧 heal、并发会话）都会被丢掉。用户观感就是"页面状态单向复写到
+文件，文件反被覆盖"。
+
+- 新增 `lib/profile-sync.mjs`：profile 配置的唯一写层，语义为双边同步。
+  - **每次重读磁盘**，无模块级缓存，绝不用操作开始前的快照覆盖当前状态；
+  - 以 **id 为键做并集合并**，只增删本层管理的条目；外部行、未知行、注释、
+    空行**原样保留**；
+  - 写前 **CAS**（SHA256 + size + mtime）比对，冲突则重读重合并（最多 3 次），
+    并发写不再互相覆盖；
+  - 同目录临时文件 + `rename` **原子写**（`cordis.patch.yml` 被截断 = 启动死循环）；
+  - 写前**校验**（空 `- insert:` 块、duplicate loader entry、JSON 可解析），
+    非法产出**拒绝落盘**；
+  - 写后**复核**，不一致自动**回滚**到操作前快照。
+- 快照从「只备 `package.json` 且无还原」升级为**同时备 `cordis.patch.yml`**，
+  并新增 `profile.restore` / `profile.snapshots` 还原接口（此前完全没有还原代码）。
+- 新增四个 host 方法：`profile.state`（读实时状态 + 校验 + 快照列表）、
+  `profile.toggle`（启用/禁用，双边同步落盘）、`profile.snapshots`、
+  `profile.restore`。全部以每次重读磁盘为准，不使用页面侧缓存。
+- CLI 操作（安装/卸载）成功后新增**后置同步**：以内核重写后的**磁盘现状**为
+  基准做增量合并，把本次操作的意图落盘，同时保留期间的一切外部改动。
+- 禁用插件改为写**顶层编辑型**行（`- id: X` / `name` / `disabled: true`），
+  而非 `- insert:` 块 —— 桌面壳 boot 期 `removeBundledRowDuplicates`
+  （`dsh-desktop/patch-row-heal.js`）会删除与 bundle 包内 patch 同 id 的
+  insert 块（**即使带 `disabled: true`**），顶层编辑型行不受该去重影响。
+  同时自动移除 insert 块内的同 id 内层条目，避免 duplicate loader entry；
+  并清理因此产生的**孤立空 `- insert:` 块**。
+- 未改动 YAML 解析方式：全程逐行文本手术，**不使用** js-yaml `load → dump`
+  回写（那样会丢注释、改引号风格、破坏 `[]` 空块）。
+
+> 注：`cordis.patch.yml` 中「手写在 `- insert:` 块内的 `disabled: true`」会在
+> 下次启动被桌面壳去重删掉 —— 这是壳侧行为，不是市场行为。请改用本版写出的
+> 顶层编辑型禁用行。
+
 ## 0.3.1
 
 - 修复功能包 CLI 定位失败的误导性报错：0.3.0 及之前，「桌面壳未注入

--- a/dsh-desktop/assets/plugins/dsh-unified-market/README.md
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/README.md
@@ -170,6 +170,7 @@ dsh-unified-market/
 │   ├── client.js           # 浏览器半边：设置页「统一市场」tab
 │   ├── allow-builds.mjs    # pnpm allowBuilds 拦截自动放行
 │   ├── artifact-keep.mjs   # 第三方本地构建产物保留
+│   ├── profile-sync.mjs    # profile 配置的「双边同步」写层（v0.4.0 起）
 │   └── plugin-conflict-scan.mjs  # 安装前冲突预检
 ├── data/catalog-snapshot.json    # 精选目录离线快照（官网不可达时兜底）
 ├── data/packs-snapshot.json      # 功能包市场索引离线快照（v0.3.0 起）
@@ -179,6 +180,56 @@ dsh-unified-market/
 
 通信：client 通过 `POST /api/dsh-unified-market`（兼容 `/api/dsh-market`）调用 host。
 host 半边运行在 `dsh web` 进程（Cordis plugin，注入 `webServer`）。
+
+---
+
+## profile 配置：双边同步（v0.4.0 起）
+
+市场对 profile 配置（`package.json` 的 `dsh.profile.bundles` 与
+`cordis.patch.yml`）的写入**不再是单向复写**。
+
+**旧行为的问题**：市场原先只经 `dsh plugin add/remove` 间接改配置，由 dsh 内核
+`reconcilePlugins` 按 `dependencies` 整文件重写 `package.json`。整文件重写 =
+「以内存状态覆盖磁盘」——读取之后、写入之前发生的任何外部改动（用户手编、
+其他插件、壳侧 heal、并发会话）都会被丢掉。
+
+**新行为**：所有配置写盘收敛到 `lib/profile-sync.mjs` 一个入口，规则如下：
+
+| 规则 | 说明 |
+|---|---|
+| 每次重读磁盘 | 无模块级缓存；绝不用操作开始前的快照覆盖当前状态 |
+| 并集合并 | 以 id 为键，只增删本层管理的条目；外部行/未知行/注释/空行**原样保留** |
+| CAS 校验 | 写前比对 SHA256 + size + mtime，冲突则重读重合并（最多 3 次） |
+| 原子写 | 同目录临时文件 + `rename`（patch 被截断 = 启动死循环） |
+| 写前校验 | 空 `- insert:` 块、duplicate loader entry、JSON 可解析 —— 非法产出拒绝落盘 |
+| 写后复核 | 不一致自动回滚到操作前快照 |
+| 快照 | 同时备 `package.json` 与 `cordis.patch.yml`，并提供 `profile.restore` 还原 |
+
+新增 host 方法：
+
+| 方法 | 作用 |
+|---|---|
+| `profile.state` | 读实时状态（bundles / 禁用 id / patch 合法性 / revision / 快照列表） |
+| `profile.toggle` | 启用或禁用某个插件包，双边同步落盘 |
+| `profile.snapshots` | 列出配置快照 |
+| `profile.restore` | 从指定快照还原配置 |
+
+### 禁用插件的正确写法
+
+禁用必须写**顶层编辑型**行：
+
+```yaml
+# 插件市场（dsh-unified-market）：关闭 <id>
+- id: <id>
+  name: '<pkg>'
+  disabled: true
+```
+
+**不要**写成 `- insert:` 块。桌面壳 boot 期的 `removeBundledRowDuplicates`
+（`dsh-desktop/patch-row-heal.js`）会删除与 bundle 包内 patch 同 id 的 insert 块，
+**即使该块带 `disabled: true`** —— 表现为"手写的禁用行凭空消失、插件又启用了"。
+顶层编辑型行不受该去重影响。市场写禁用时会自动把 insert 块内的同 id 内层条目
+一并移除，并清理因此产生的孤立空 `- insert:` 块。
 
 ---
 

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/host.js
@@ -35,11 +35,20 @@ import { parseBlockedBuildKeys, readAllowBuilds, ensureAllowBuilds } from './all
 // 安装前轻量冲突预检（patch 行/settings 命名空间/核心依赖版本），
 // refuse 直接拒绝、warn 由 UI 红字提醒；只读不写。
 import { scanCandidate, collectProfileState } from './plugin-conflict-scan.mjs'
+// v0.4.0：profile 配置的「双边同步」写层。此前市场只经 `dsh plugin add/remove`
+// 间接改配置，由内核 reconcilePlugins 整文件重写 package.json —— 等于「以内存
+// 状态覆盖磁盘」，任何外部改动（用户手编、其他插件、壳侧 heal、并发会话）都会
+// 被丢掉。本层把配置写盘收敛到唯一入口：每次重读磁盘、以 id 为键并集合并、
+// CAS + 原子写 + 写后校验 + 失败回滚，外部行/注释一律保留。
+import {
+  readProfileConfig, commitProfileConfig, applyPatchToggle, mergeBundles, applyBundles,
+  validatePatchText, listConfigSnapshots, restoreConfigSnapshot,
+} from './profile-sync.mjs'
 
 export const name = 'dsh-unified-market'
 
 /** 本市场自身版本（与 package.json 同步；自更新检测用）。 */
-export const SELF_VERSION = '0.3.1'
+export const SELF_VERSION = '0.4.0'
 
 /** Hard dependency: the HTTP carrier must exist before the route registers. */
 export const inject = ['webServer']
@@ -372,6 +381,25 @@ function startOp(kind, profile, target, label, explicitBin, initialOutput) {
         }
       }
     }
+    if (ok && (op.kind === 'install' || op.kind === 'uninstall')) {
+      // v0.4.0 双边同步：内核已在 CLI 内重写过 profile 配置，这里以「磁盘现状」
+      // 为基准做增量合并 —— 本次操作的意图（启用/禁用 + patch 行）落盘，同时
+      // 保留期间发生的一切外部改动。
+      const pkgName = op.pkg || op.target
+      const id = loaderEntryId(op.profile, pkgName)
+      const disabled = op.kind === 'uninstall'
+      syncProfileConfig(
+        op,
+        (patchText) => {
+          const r = applyPatchToggle(
+            patchText, id, pkgName, disabled,
+            '# 插件市场（dsh-unified-market）：' + (disabled ? '关闭 ' : '启用 ') + id,
+          )
+          return r.changed ? r.text : null
+        },
+        (disabled ? '禁用并移除 ' : '启用 ') + pkgName + '（id: ' + id + '）',
+      )
+    }
     if (ok && op.kind === 'install' && hotCtx !== null) {
       // Trial-boot already proved the bundle boots; hot-mount is the bonus
       // that skips the restart. Failure here only falls back to restart.
@@ -399,6 +427,65 @@ function startOp(kind, profile, target, label, explicitBin, initialOutput) {
 
 /** Host ctx for hot-mounting, set by apply(); null in headless/test contexts. */
 let hotCtx = null
+
+/**
+ * v0.4.0 双边同步：在 CLI（pnpm/dsh plugin）结束后，把「外部可能做过的改动」
+ * 与「本次操作的意图」合并落盘，而不是让任一方覆盖另一方。
+ *
+ * 时序要点：内核 reconcilePlugins 已在 CLI 进程内重写过一次 package.json，
+ * 因此这里必须**在 CLI 退出之后**再重读磁盘，绝不使用操作开始前的快照覆盖。
+ *
+ * @param {object} op - 操作对象（含 kind/target/profile）
+ * @param {(patchText: string) => string|null} producePatch - 基于读到的 patch 产出新 patch（null=不改）
+ * @param {string} summary - 写入说明（落进操作输出）
+ */
+function syncProfileConfig(op, producePatch, summary) {
+  try {
+    const dir = profileDir(op.profile)
+    const res = commitProfileConfig(dir, (cfg) => {
+      // 1) bundles：以磁盘现状为基准做增量并集（保留既有相对顺序与其他改动）
+      let pkgText = cfg.pkgText
+      const name = op.pkg || op.target
+      const enable = op.kind === 'uninstall' ? [] : [name]
+      const disable = op.kind === 'uninstall' ? [name] : []
+      const merged = mergeBundles(cfg.bundles, enable, disable)
+      if (merged.changed) {
+        const built = applyBundles(cfg.pkgText, merged.bundles)
+        if (built.error) return { summary: 'bundles 未改动：' + built.error }
+        pkgText = built.text
+      }
+      // 2) patch：把目标 id 规范为顶层编辑型行（禁用）或复位（启用）
+      let patchText
+      if (typeof producePatch === 'function') {
+        const out = producePatch(cfg.patchText, cfg)
+        if (typeof out === 'string') patchText = out
+      }
+      return { pkgText, patch: patchText, summary }
+    })
+    if (res.ok && res.changed) {
+      appendOutput(op, '\n[同步] 双边同步写入 profile 配置：' + summary + (res.snapshot ? '（快照 ' + res.snapshot + '）' : '') + '\n')
+    } else if (!res.ok) {
+      appendOutput(op, '\n[同步] 配置同步未完成：' + String(res.error || '未知原因') + '（外部改动未被覆盖）\n')
+    }
+    return res
+  } catch (err) {
+    appendOutput(op, '\n[同步] 配置同步异常：' + String((err && err.message) || err) + '\n')
+    return { ok: false, error: String((err && err.message) || err) }
+  }
+}
+
+/**
+ * 找出某个包对应的 loader 条目 id（用于禁用/复位 patch 行）。
+ * 优先取包内 cordis.patch.yml 自己声明的 id —— 那是它挂载时使用的真实 id。
+ */
+function loaderEntryId(profile, pkgName) {
+  try {
+    const patch = readFileSync(join(profileDir(profile), 'node_modules', pkgName, 'cordis.patch.yml'), 'utf8')
+    const m = /^\s*-\s*id:\s*([\w.-]+)\s*$/m.exec(patch)
+    if (m !== null) return m[1]
+  } catch { /* 包未落地或没有 patch */ }
+  return pkgName
+}
 
 /** Abort the live op (used by the panel's kill button). */
 function killOp() {
@@ -753,8 +840,6 @@ function matchInstalledPackage(plugin, installedState) {
 const REGISTRY_URL = 'https://awesome-dsh-plugin.com/plugins.json'
 /** Static page fallback when the JSON API is unreachable. */
 const CATALOG_PAGE_URL = 'https://awesome-dsh-plugin.com/zh/'
-/** EAC-owned recommendations merged into every catalog source. */
-const EAC_RECOMMENDED_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'eac-recommended.json')
 
 function pickLang(lang) {
   return lang === 'en' ? 'en' : 'zh'
@@ -782,6 +867,95 @@ function fromRegistryPlugin(p, lang) {
   }
 }
 
+/** Derive the category chips (incl. the leading "all" chip) from the registry. */
+function registryCats(data, lang) {
+  const cats = []
+  const labels = (data.categories && typeof data.categories === 'object') ? data.categories : {}
+  cats.push({ id: 'all', label: lang === 'en' ? 'All' : '全部', count: Array.isArray(data.plugins) ? data.plugins.length : 0 })
+  for (const id of Object.keys(labels)) {
+    const l = labels[id]
+    const label = (l && (l[lang] || l.zh || l.en)) || id
+    const count = Array.isArray(data.plugins) ? data.plugins.filter((p) => p.category === id).length : 0
+    cats.push({ id, label, count })
+  }
+  return cats
+}
+
+/** Map a parsed plugins.json document onto the catalog card shape. */
+function registryToCatalog(data, lang) {
+  const locale = pickLang(lang)
+  return {
+    plugins: Array.isArray(data.plugins) ? data.plugins.map((p) => fromRegistryPlugin(p, locale)) : [],
+    cats: registryCats(data, locale),
+  }
+}
+
+/**
+ * Load the plugin catalog, mirroring dsh-market's registry + snapshot: the
+ * site's own JSON API first (it carries stars/added), then the static page,
+ * then the bundled snapshot as offline fallback. Cached briefly.
+ * @returns {Promise<{plugins: any[], cats: any[], source: 'live'|'cache'|'snapshot'|'none'}>}
+ */
+async function loadCatalogBase(lang) {
+  const now = Date.now()
+  const locale = pickLang(lang)
+  if (catalogCache && catalogCache.lang === locale && now - catalogCache.at < CATALOG_TTL_MS) {
+    return { ...catalogCache.data, source: 'cache' }
+  }
+  // 1) The site's JSON API — the canonical target data.
+  try {
+    const r = await fetch(REGISTRY_URL, { redirect: 'follow', signal: AbortSignal.timeout(10000) })
+    if (!r.ok) throw new Error('HTTP ' + r.status)
+    const data = await r.json()
+    const parsed = registryToCatalog(data, locale)
+    if (parsed.plugins.length === 0) throw new Error('empty registry')
+    catalogCache = { at: now, lang: locale, data: parsed }
+    return { ...parsed, source: 'live' }
+  } catch {
+    // 2) Static page fallback (same card shape).
+    try {
+      const r = await fetch(CATALOG_PAGE_URL, { redirect: 'follow', signal: AbortSignal.timeout(10000) })
+      if (!r.ok) throw new Error('HTTP ' + r.status)
+      const parsed = parseSite(await r.text())
+      if (parsed.plugins.length === 0) throw new Error('empty catalog')
+      catalogCache = { at: now, lang: locale, data: parsed }
+      return { ...parsed, source: 'live' }
+    } catch {
+      // 3) Bundled offline snapshot.
+      try {
+        const snap = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'catalog-snapshot.json'), 'utf8'))
+        if (Array.isArray(snap.plugins) && snap.plugins.length > 0) return { ...snap, source: 'snapshot' }
+      } catch {}
+      return { plugins: [], cats: [], source: 'none' }
+    }
+  }
+}
+
+/**
+ * EAC 定制包装：在原始目录之上合并本地推荐清单，并把合并结果写入缓存，
+ * 使 live / 静态页 / 离线快照三条路径与缓存命中都带推荐标记。
+ */
+async function loadCatalog(lang) {
+  const locale = pickLang(lang)
+  const now = Date.now()
+  if (catalogCache && catalogCache.lang === locale && now - catalogCache.at < CATALOG_TTL_MS) {
+    return { ...catalogCache.data, source: 'cache' }
+  }
+  const base = await loadCatalogBase(lang)
+  const merged = mergeRecommendedCatalog(base, locale)
+  const out = { ...merged, source: base.source }
+  if (out.source !== 'none' && Array.isArray(out.plugins) && out.plugins.length > 0) {
+    catalogCache = { at: now, lang: locale, data: { plugins: out.plugins, cats: out.cats } }
+  }
+  return out
+}
+
+/**
+ * EAC-owned recommendations merged into every catalog source.
+ * （EAC 定制：本地推荐清单随包分发；上游仓库不含此逻辑。）
+ */
+const EAC_RECOMMENDED_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'eac-recommended.json')
+
 function pluginIdentityKeys(plugin) {
   const keys = []
   const repo = normalizeRepoUrl(plugin && plugin.url)
@@ -807,6 +981,10 @@ function loadEacRecommendations(lang) {
  * Put EAC recommendations first while retaining live metadata for duplicates.
  * URL, install source, and display name are all treated as stable identities.
  */
+/** Catalog cache: 5 minutes; snapshot path is the offline fallback. */
+let catalogCache = null
+const CATALOG_TTL_MS = 5 * 60 * 1000
+
 function mergeRecommendedCatalog(catalog, lang) {
   const recommended = loadEacRecommendations(lang)
   if (recommended.length === 0) return catalog
@@ -853,78 +1031,6 @@ function mergeRecommendedCatalog(catalog, lang) {
   ]
   return { plugins, cats }
 }
-
-/** Derive the category chips (incl. the leading "all" chip) from the registry. */
-function registryCats(data, lang) {
-  const cats = []
-  const labels = (data.categories && typeof data.categories === 'object') ? data.categories : {}
-  cats.push({ id: 'all', label: lang === 'en' ? 'All' : '全部', count: Array.isArray(data.plugins) ? data.plugins.length : 0 })
-  for (const id of Object.keys(labels)) {
-    const l = labels[id]
-    const label = (l && (l[lang] || l.zh || l.en)) || id
-    const count = Array.isArray(data.plugins) ? data.plugins.filter((p) => p.category === id).length : 0
-    cats.push({ id, label, count })
-  }
-  return cats
-}
-
-/** Map a parsed plugins.json document onto the catalog card shape. */
-function registryToCatalog(data, lang) {
-  const locale = pickLang(lang)
-  return {
-    plugins: Array.isArray(data.plugins) ? data.plugins.map((p) => fromRegistryPlugin(p, locale)) : [],
-    cats: registryCats(data, locale),
-  }
-}
-
-/**
- * Load the plugin catalog, mirroring dsh-market's registry + snapshot: the
- * site's own JSON API first (it carries stars/added), then the static page,
- * then the bundled snapshot as offline fallback. Cached briefly.
- * @returns {Promise<{plugins: any[], cats: any[], source: 'live'|'cache'|'snapshot'|'none'}>}
- */
-async function loadCatalog(lang) {
-  const now = Date.now()
-  const locale = pickLang(lang)
-  if (catalogCache && catalogCache.lang === locale && now - catalogCache.at < CATALOG_TTL_MS) {
-    return { ...catalogCache.data, source: 'cache' }
-  }
-  // 1) The site's JSON API — the canonical target data.
-  try {
-    const r = await fetch(REGISTRY_URL, { redirect: 'follow', signal: AbortSignal.timeout(10000) })
-    if (!r.ok) throw new Error('HTTP ' + r.status)
-    const data = await r.json()
-    const parsed = mergeRecommendedCatalog(registryToCatalog(data, locale), locale)
-    if (parsed.plugins.length === 0) throw new Error('empty registry')
-    catalogCache = { at: now, lang: locale, data: parsed }
-    return { ...parsed, source: 'live' }
-  } catch {
-    // 2) Static page fallback (same card shape).
-    try {
-      const r = await fetch(CATALOG_PAGE_URL, { redirect: 'follow', signal: AbortSignal.timeout(10000) })
-      if (!r.ok) throw new Error('HTTP ' + r.status)
-      const parsed = mergeRecommendedCatalog(parseSite(await r.text()), locale)
-      if (parsed.plugins.length === 0) throw new Error('empty catalog')
-      catalogCache = { at: now, lang: locale, data: parsed }
-      return { ...parsed, source: 'live' }
-    } catch {
-      // 3) Bundled offline snapshot.
-      try {
-        const snap = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'data', 'catalog-snapshot.json'), 'utf8'))
-        if (Array.isArray(snap.plugins) && snap.plugins.length > 0) {
-          return { ...mergeRecommendedCatalog(snap, locale), source: 'snapshot' }
-        }
-      } catch {}
-      const local = mergeRecommendedCatalog({ plugins: [], cats: [] }, locale)
-      if (local.plugins.length > 0) return { ...local, source: 'recommended' }
-      return { plugins: [], cats: [], source: 'none' }
-    }
-  }
-}
-
-/** Catalog cache: 5 minutes; snapshot path is the offline fallback. */
-let catalogCache = null
-const CATALOG_TTL_MS = 5 * 60 * 1000
 
 // ── hot mount (restart-free activation) ─────────────────────────────────────
 // Mirrors dsh-market's approach: after a successful install, if the new
@@ -1863,7 +1969,7 @@ async function loadPacksIndex() {
   return { packs: [], source: 'none' }
 }
 
-export { classifyPlugin, runProbe, whitelistSource, loadCatalog, loadEacRecommendations, mergeRecommendedCatalog, parseSimplePatch, checkUpdates, parseSite, registryToCatalog, normalizeRepoUrl, readInstalledProvenance, matchInstalledPackage, resolveProfile, githubList, npmSearch, readZhIntro, selfUpdateCheck, autoUpdateState, setAutoUpdate, desktopProfile, resolveLinkedUpstream, fetchUpstreamVersion, findUpstreamByName, npmLatestInfo, linkedUpdateTarget } // test hooks; cordis only reads name/inject/apply
+export { classifyPlugin, runProbe, whitelistSource, loadCatalog, parseSimplePatch, checkUpdates, parseSite, registryToCatalog, normalizeRepoUrl, readInstalledProvenance, matchInstalledPackage, resolveProfile, githubList, npmSearch, readZhIntro, selfUpdateCheck, autoUpdateState, setAutoUpdate, desktopProfile, resolveLinkedUpstream, fetchUpstreamVersion, findUpstreamByName, npmLatestInfo, linkedUpdateTarget, loadEacRecommendations, mergeRecommendedCatalog } // test hooks; cordis only reads name/inject/apply
 
 export function apply(ctx) {
   const webServer = ctx.get('webServer')
@@ -1906,6 +2012,77 @@ export function apply(ctx) {
             dshBin: dshBin(),
             binProvided: explicit || null,
             binValid,
+          })
+        }
+        // ── v0.4.0：profile 配置的双边同步接口 ──────────────────────────
+        // 全部以「每次重读磁盘」为准，不使用任何页面侧缓存；写操作走 CAS +
+        // 原子写 + 写后校验，外部改动不会被覆盖。
+        if (method === 'profile.state') {
+          const profile = resolveProfile(body.profile)
+          const cfg = readProfileConfig(profileDir(profile))
+          const v = validatePatchText(cfg.patchText)
+          return sendJson(res, 200, {
+            ok: true,
+            profile,
+            bundles: cfg.bundles,
+            dependencies: Object.keys(cfg.dependencies),
+            // 顶层编辑型禁用行（带 disabled: true 的 patch 行 id）
+            disabledIds: cfg.patchBlocks
+              .filter((b) => b.indent === '' && b.lines.some((l) => /^\s*disabled:\s*true\s*$/.test(l)))
+              .map((b) => b.id),
+            patchRowCount: cfg.patchBlocks.length,
+            patchValid: v.ok,
+            patchProblems: v.problems,
+            revision: cfg.revision,
+            snapshots: listConfigSnapshots(profileDir(profile)).slice(0, 20),
+          })
+        }
+        if (method === 'profile.snapshots') {
+          const profile = resolveProfile(body.profile)
+          return sendJson(res, 200, { ok: true, profile, snapshots: listConfigSnapshots(profileDir(profile)) })
+        }
+        if (method === 'profile.restore') {
+          if (!sameOrigin(req)) return sendJson(res, 403, { ok: false, error: 'untrusted origin' })
+          const profile = resolveProfile(body.profile)
+          const stamp = String(body.stamp || '').trim()
+          const file = String(body.file || 'cordis.patch.yml').trim()
+          if (!stamp) return sendJson(res, 400, { ok: false, error: '缺少快照时间戳' })
+          const r = restoreConfigSnapshot(profileDir(profile), stamp, file)
+          return sendJson(res, 200, r.ok
+            ? { ok: true, restored: r.restored, from: r.from }
+            : { ok: false, error: r.error })
+        }
+        if (method === 'profile.toggle') {
+          if (!sameOrigin(req)) return sendJson(res, 403, { ok: false, error: 'untrusted origin' })
+          const profile = resolveProfile(body.profile)
+          const pkgName = String(body.pkg || '').trim()
+          if (!pkgName) return sendJson(res, 400, { ok: false, error: '缺少包名' })
+          const enable = body.enabled !== false
+          const id = loaderEntryId(profile, pkgName)
+          const dir = profileDir(profile)
+          const result = commitProfileConfig(dir, (cfg) => {
+            const merged = mergeBundles(cfg.bundles, enable ? [pkgName] : [], enable ? [] : [pkgName])
+            const built = merged.changed ? applyBundles(cfg.pkgText, merged.bundles) : { text: cfg.pkgText, error: null }
+            if (built.error) return { summary: 'bundles 合并失败：' + built.error }
+            const tog = applyPatchToggle(
+              cfg.patchText, id, pkgName, !enable,
+              '# 插件市场（dsh-unified-market）：' + (enable ? '启用 ' : '关闭 ') + id,
+            )
+            return {
+              pkgText: built.text,
+              patch: tog.changed ? tog.text : cfg.patchText,
+              summary: (enable ? '启用 ' : '关闭 ') + pkgName + '（id: ' + id + '）',
+            }
+          })
+          return sendJson(res, 200, {
+            ok: result.ok,
+            changed: result.changed,
+            enabled: enable,
+            id,
+            summary: result.summary,
+            error: result.error,
+            snapshot: result.snapshot,
+            attempts: result.attempts,
           })
         }
         if (method === 'installed') {

--- a/dsh-desktop/assets/plugins/dsh-unified-market/lib/profile-sync.mjs
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/lib/profile-sync.mjs
@@ -1,0 +1,430 @@
+// dsh-unified-market — profile 配置的「双边同步」写层（v0.4.0 新增）。
+//
+// 为什么需要这一层（根因，非猜测）：
+//   市场原先只通过 `spawn(dsh plugin add/remove)` 间接改配置，由 dsh 内核的
+//   reconcilePlugins 按 dependencies 整文件重写 package.json。整文件重写 =
+//   「以内存状态为准覆盖磁盘」，任何外部改动（用户手编、其他插件写、
+//   壳侧 heal、另一会话操作）都可能被丢掉。用户观感就是「页面状态单向复写
+//   到文件，文件反被覆盖」。
+//
+//   本层把配置写盘收敛为唯一入口，语义改为双边同步：
+//     1. 每次操作**重新读盘**（无模块级缓存），不做「用旧快照覆盖」；
+//     2. 以 id 为键做**并集合并**，只增删本层管理的 id，
+//        外部行、未知行、注释、空行**原样保留**；
+//     3. 写前做 CAS（SHA256+size+mtime）比对，不一致则重读重合并（最多 3 次），
+//        并发写不会互相覆盖；
+//     4. 同目录临时文件 + rename **原子写**（cordis.patch.yml 被截断 = 启动死循环）；
+//     5. 写后**校验可解析**，失败自动回滚到操作前快照；
+//     6. 快照同时覆盖 package.json **与** cordis.patch.yml，并提供 restore
+//        （原实现只有 package.json 快照且没有任何还原代码）。
+//
+// 关键约束（踩过的坑）：
+//   · cordis.patch.yml **禁止** js-yaml load→dump 回写：会丢注释、改引号风格、
+//     破坏 `[]` 空块。本层全程逐行文本手术，parse 只用于校验。
+//   · 禁用插件必须写**顶层编辑型**行：
+//         - id: <id>
+//           name: '<pkg>'
+//           disabled: true
+//     而**不能**写成 `- insert:` 块 —— 桌面壳 boot 期
+//     `removeBundledRowDuplicates`（dsh-desktop/patch-row-heal.js）会把与
+//     bundle 包内 patch 同 id 的 insert 块整块删除，**即使带 disabled: true**。
+//     顶层编辑型行不受该去重影响。本层还负责把 insert 块内的同 id 内层条目
+//     一并移除，避免 duplicate loader entry。
+//
+// 本文件只做文件层读写与合并，不依赖 host.js，便于单独测试。
+'use strict';
+
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import { join } from 'node:path';
+
+const PATCH_FILE = 'cordis.patch.yml';
+const PKG_FILE = 'package.json';
+const CAS_RETRIES = 3;
+/** 本层所写顶层编辑行的注释前缀 —— 写与识别必须用同一常量，否则幂等性失效。 */
+const OWN_COMMENT_PREFIX = '# 插件市场';
+const OWN_COMMENT_RE = /^#\s*插件市场/;
+
+/** 解析出「块」：- id: 行 + 其后的紧邻可见行（name/disabled/config…）。 */
+function blocksOf(text) {
+  const lines = String(text ?? '').split(/\r?\n/);
+  // split 会把结尾换行变成一个空串元素，它不是内容行 —— 剥掉，
+  // 由调用方用「原文是否以换行结尾」自行补回，否则每轮操作都会多出一个空行。
+  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+  const blocks = [];
+  // 同时匹配顶层（`- id:`）与 insert 内层（`  - id:`）；靠前导空白判定层级。
+  const ID_LINE = /^(\s*)-\s*id:\s*([\w.-]+)\s*$/;
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = ID_LINE.exec(lines[i]);
+    if (m === null) continue;
+    const indent = m[1];
+    let end = i + 1;
+    if (indent === '') {
+      // 顶层编辑型行：块体是紧邻的、不以 '-' 开头的缩进行。
+      while (end < lines.length && /^\s+\S/.test(lines[end]) && !/^\s*-\s/.test(lines[end])) end += 1;
+    } else {
+      // insert 内层条目：块体只包含后续缩进更深的行。
+      while (end < lines.length) {
+        const nxt = lines[end];
+        if (!/^\s+\S/.test(nxt)) break;
+        const lead = /^(\s*)/.exec(nxt)[1];
+        if (lead.length <= indent.length) break;
+        end += 1;
+      }
+    }
+    blocks.push({ id: m[2], start: i, end: end - 1, indent, lines: lines.slice(i, end) });
+    i = end - 1;
+  }
+  return { lines, blocks };
+}
+
+/** 块是否为 insert 内层条目（靠缩进判定：内层 id 行有前导空白）。 */
+function isInnerBlock(block) {
+  return block.indent !== '';
+}
+
+/** 块是否带 disabled: true。 */
+function isDisabledBlock(block) {
+  return block.lines.some((l) => /^\s*disabled:\s*true\s*$/.test(l));
+}
+
+/** 从块中读 name（用于顶层编辑行）。 */
+function blockName(block) {
+  for (const l of block.lines) {
+    const m = /^\s*name:\s*['"]?([^'"\s]+)['"]?\s*$/.exec(l);
+    if (m !== null) return m[1];
+  }
+  return null;
+}
+
+/** 读盘（无缓存）——双边同步的第 1 条：永远以磁盘为准。 */
+export function readProfileConfig(profileDir) {
+  const patchPath = join(profileDir, PATCH_FILE);
+  const pkgPath = join(profileDir, PKG_FILE);
+  let patchText = '';
+  let pkgText = '';
+  try { patchText = fs.readFileSync(patchPath, 'utf8'); } catch { patchText = ''; }
+  try { pkgText = fs.readFileSync(pkgPath, 'utf8'); } catch { pkgText = ''; }
+  let pkg = null;
+  try { pkg = JSON.parse(pkgText); } catch { pkg = null; }
+  const bundlesRaw = pkg && pkg.dsh && pkg.dsh.profile && Array.isArray(pkg.dsh.profile.bundles)
+    ? pkg.dsh.profile.bundles
+    : [];
+  const { lines, blocks } = blocksOf(patchText);
+  return {
+    profileDir,
+    patchPath,
+    pkgPath,
+    patchText,
+    pkgText,
+    pkg,
+    bundles: bundlesRaw.filter((b) => typeof b === 'string'),
+    dependencies: (pkg && pkg.dependencies) || {},
+    patchLines: lines,
+    patchBlocks: blocks,
+    revision: {
+      patch: hashOf(patchText),
+      pkg: hashOf(pkgText),
+    },
+  };
+}
+
+/** SHA256 内容哈希（CAS 用）。 */
+export function hashOf(text) {
+  return crypto.createHash('sha256').update(String(text ?? ''), 'utf8').digest('hex');
+}
+
+/** 临时文件 + rename 原子写（同目录，保证同卷）。 */
+export function writeAtomic(file, text) {
+  const tmp = file + '.mktstmp-' + process.pid + '-' + Date.now();
+  fs.writeFileSync(tmp, text, 'utf8');
+  try {
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    try { fs.rmSync(tmp, { force: true }); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
+/**
+ * 快照 package.json + cordis.patch.yml（操作前调用，失败可整组回滚）。
+ * @returns {{stamp: string, files: {src: string, snap: string}[]}|null}
+ */
+export function snapshotProfileConfig(profileDir, stamp) {
+  const at = String(stamp ?? Date.now());
+  const files = [];
+  for (const name of [PKG_FILE, PATCH_FILE]) {
+    const src = join(profileDir, name);
+    if (!fs.existsSync(src)) continue;
+    const snap = src + '.mkts-snapshot-' + at;
+    try {
+      fs.writeFileSync(snap, fs.readFileSync(src, 'utf8'));
+      files.push({ src, snap });
+    } catch { /* 快照失败不阻断，但记录缺失 */ }
+  }
+  return files.length ? { stamp: at, files } : null;
+}
+
+/** 从操作前快照还原（写后校验失败时自动调用）。 */
+export function restoreSnapshot(snap) {
+  if (!snap || !Array.isArray(snap.files)) return false;
+  let ok = true;
+  for (const f of snap.files) {
+    try { fs.writeFileSync(f.src, fs.readFileSync(f.snap, 'utf8')); } catch { ok = false; }
+  }
+  return ok;
+}
+
+/**
+ * 以 id 为键合并 patch：把 <id> 变成**顶层编辑型**行（disabled 或复位），
+ * 同时移除 insert 块内的同 id 内层条目。其余行（含外部/未知条目、注释、空行）
+ * 原样保留 —— 这是「双边同步」的核心：不整文件覆盖。
+ *
+ * @param {string} patchText - 读盘得到的当前内容
+ * @param {string} id - loader 条目 id
+ * @param {string|null} name - 包名（写成顶层行的 name）
+ * @param {boolean} disabled - true 写 disabled: true，false 表示复位为启用
+ * @param {string} comment - 顶层行上方注释（标识这是本工具所写）
+ * @returns {{text: string, changed: boolean, removedInner: string[], action: string}}
+ */
+export function applyPatchToggle(patchText, id, name, disabled, comment) {
+  const text = String(patchText ?? '');
+  const eol = text.includes('\r\n') ? '\r\n' : '\n';
+  const hadTrailing = /\r?\n$/.test(text);
+  const { lines, blocks } = blocksOf(text);
+  const label = comment || `# 插件市场（dsh-unified-market）：${disabled ? '关闭' : '启用'} ${id}`;
+
+  const drop = new Set();
+  const removedInner = [];
+  let managedStart = -1;
+  let managedEnd = -1;
+
+  for (const b of blocks) {
+    if (b.id !== id) continue;
+    const inner = isInnerBlock(b);
+    if (inner) {
+      // insert 内层条目：必须删掉，否则与顶层行构成 duplicate loader entry。
+      for (let i = b.start; i <= b.end; i += 1) drop.add(i);
+      removedInner.push(b.id);
+      continue;
+    }
+    // 顶层编辑型行：本层管理，连同**紧邻上方由本层写的注释**一起整体替换
+    // （否则每次操作都会在旧注释下再叠一条，幂等性被破坏）。
+    let top = b.start;
+    while (top - 1 >= 0 && OWN_COMMENT_RE.test(lines[top - 1])) {
+      top -= 1;
+    }
+    if (managedStart === -1) { managedStart = top; managedEnd = b.end; }
+    for (let i = top; i <= b.end; i += 1) drop.add(i);
+  }
+
+  const built = [];
+  built.push(label);
+  built.push(`- id: ${id}`);
+  if (name) built.push(`  name: '${name}'`);
+  if (disabled) built.push('  disabled: true');
+
+  // 关键：删掉内层条目后，承载它的 `- insert:` 可能变成孤立的空块。
+  // 空 insert 块 = duplicate loader entry / 启动失败，必须整块移除。
+  const insertIdx = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^\s*-\s*insert:\s*$/.test(lines[i])) insertIdx.push(i);
+  }
+  for (let k = insertIdx.length - 1; k >= 0; k -= 1) {
+    const idx = insertIdx[k];
+    if (drop.has(idx)) continue;
+    let end = idx + 1;
+    while (end < lines.length && /^\s+\S/.test(lines[end])) end += 1;
+    let alive = false;
+    for (let j = idx + 1; j < end; j += 1) {
+      if (!drop.has(j)) { alive = true; break; }
+    }
+    if (!alive) {
+      for (let j = idx; j < end; j += 1) drop.add(j);
+    }
+  }
+
+  const out = [];
+  let inserted = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (managedStart !== -1 && i === managedStart) {
+      if (!inserted) { out.push(...built); inserted = true; }
+      continue;
+    }
+    if (drop.has(i)) continue;
+    out.push(lines[i]);
+  }
+  if (!inserted) {
+    while (out.length && out[out.length - 1].trim() === '') out.pop();
+    out.push('', ...built);
+  }
+  let result = out.join(eol);
+  if (hadTrailing || !result.endsWith(eol)) result += eol;
+
+  const changed = result !== text;
+  const action = disabled ? (managedStart === -1 ? 'appended' : 'replaced') : 'reset';
+  return { text: result, changed, removedInner, action };
+}
+
+/**
+ * 以「保持既有相对顺序」的方式合并 bundles：缺失则末尾追加，失效则移除。
+ * 绝不按新数组整体覆盖（那会丢掉外部顺序调整）。
+ */
+export function mergeBundles(existing, desiredEnable, desiredDisable) {
+  const list = Array.isArray(existing) ? existing.filter((x) => typeof x === 'string') : [];
+  const off = new Set(Array.isArray(desiredDisable) ? desiredDisable : []);
+  const out = list.filter((x) => !off.has(x));
+  for (const name of (Array.isArray(desiredEnable) ? desiredEnable : [])) {
+    if (typeof name === 'string' && name && !out.includes(name) && !off.has(name)) out.push(name);
+  }
+  const changed = out.length !== list.length || out.some((x, i) => x !== list[i]);
+  return { bundles: out, changed };
+}
+
+/** 把 bundles 写回 package.json 文本（保留其余字段与既有顺序，整体回写 JSON）。 */
+export function applyBundles(pkgText, bundles) {
+  let pkg = null;
+  try { pkg = JSON.parse(pkgText); } catch { return { text: pkgText, changed: false, error: 'package.json 不可解析' }; }
+  if (!pkg || typeof pkg !== 'object') return { text: pkgText, changed: false, error: 'package.json 非对象' };
+  pkg.dsh = pkg.dsh && typeof pkg.dsh === 'object' ? pkg.dsh : {};
+  pkg.dsh.profile = pkg.dsh.profile && typeof pkg.dsh.profile === 'object' ? pkg.dsh.profile : {};
+  const before = Array.isArray(pkg.dsh.profile.bundles) ? pkg.dsh.profile.bundles.join('\u0000') : '';
+  pkg.dsh.profile.bundles = bundles;
+  const text = JSON.stringify(pkg, null, 2) + '\n';
+  return { text, changed: before !== bundles.join('\u0000') };
+}
+
+/** 写前校验：patch 必须能被块解析且不含空 insert 块；JSON 必须可解析。 */
+export function validatePatchText(text) {
+  const problems = [];
+  const { lines, blocks } = blocksOf(text);
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!/^\s*-\s*insert:\s*$/.test(lines[i])) continue;
+    const next = lines[i + 1];
+    if (next === undefined || !/^\s+\S/.test(next)) problems.push(`第 ${i + 1} 行：- insert: 是空块（= duplicate loader entry 风险）`);
+  }
+  const innerIds = blocks.filter(isInnerBlock).map((b) => b.id);
+  const topIds = blocks.filter((b) => !isInnerBlock(b)).map((b) => b.id);
+  for (const id of innerIds) {
+    if (topIds.includes(id)) problems.push(`id "${id}" 同时存在于 insert 内层与顶层（= duplicate loader entry）`);
+  }
+  const dup = innerIds.filter((id, i) => innerIds.indexOf(id) !== i);
+  for (const id of new Set(dup)) problems.push(`insert 内层 id "${id}" 重复`);
+  return { ok: problems.length === 0, problems };
+}
+
+/**
+ * 双边同步的写事务：读 → 合并 → CAS → 原子写 → 校验 → (失败) 回滚。
+ *
+ * @param {string} profileDir
+ * @param {(cfg: object) => {patch?: string, pkgText?: string, summary: string}} mutator
+ *        基于「刚读到的」配置产出新文本；只改自己管理的部分。
+ * @returns {{ok: boolean, changed: boolean, summary?: string, error?: string,
+ *            snapshot?: string, attempts: number, problems?: string[]}}
+ */
+export function commitProfileConfig(profileDir, mutator) {
+  for (let attempt = 1; attempt <= CAS_RETRIES; attempt += 1) {
+    const before = readProfileConfig(profileDir);
+    let produced;
+    try {
+      produced = mutator(before);
+    } catch (err) {
+      return { ok: false, changed: false, error: '合并阶段异常：' + String(err && err.message ? err.message : err), attempts: attempt };
+    }
+    if (!produced) return { ok: false, changed: false, error: '合并阶段未产出结果', attempts: attempt };
+
+    const nextPatch = produced.patch === undefined ? before.patchText : produced.patch;
+    const nextPkg = produced.pkgText === undefined ? before.pkgText : produced.pkgText;
+    const patchChanged = nextPatch !== before.patchText;
+    const pkgChanged = nextPkg !== before.pkgText;
+    if (!patchChanged && !pkgChanged) {
+      return { ok: true, changed: false, summary: produced.summary || '无变化', attempts: attempt };
+    }
+
+    // 写前校验：坏内容绝不落盘。
+    if (patchChanged) {
+      const v = validatePatchText(nextPatch);
+      if (!v.ok) return { ok: false, changed: false, error: '校验失败，已放弃写入：' + v.problems.join('；'), attempts: attempt, problems: v.problems };
+    }
+    if (pkgChanged) {
+      try { JSON.parse(nextPkg); } catch (err) {
+        return { ok: false, changed: false, error: 'package.json 产出不可解析，已放弃写入', attempts: attempt };
+      }
+    }
+
+    // CAS：确认磁盘仍是刚才读到的版本（双边同步 —— 外部改动不会被覆盖）。
+    const now = readProfileConfig(profileDir);
+    if (now.revision.patch !== before.revision.patch || now.revision.pkg !== before.revision.pkg) {
+      if (attempt < CAS_RETRIES) continue; // 有外部写入 → 重读重合并
+      return { ok: false, changed: false, error: '磁盘配置在写入前被外部修改，已重试 ' + CAS_RETRIES + ' 次仍冲突，本次放弃（未覆盖任何外部改动）', attempts: attempt };
+    }
+
+    const snap = snapshotProfileConfig(profileDir, Date.now());
+    try {
+      if (patchChanged) writeAtomic(before.patchPath, nextPatch);
+      if (pkgChanged) writeAtomic(before.pkgPath, nextPkg);
+    } catch (err) {
+      restoreSnapshot(snap);
+      return { ok: false, changed: false, error: '写入失败：' + String(err && err.message ? err.message : err), attempts: attempt };
+    }
+
+    // 写后复核：落盘内容必须与产出一致且可解析。
+    const after = readProfileConfig(profileDir);
+    const okPatch = !patchChanged || after.patchText === nextPatch;
+    const okPkg = !pkgChanged || after.pkgText === nextPkg;
+    if (okPatch && okPkg && (!patchChanged || validatePatchText(after.patchText).ok)) {
+      return {
+        ok: true,
+        changed: true,
+        summary: produced.summary || '已写入',
+        snapshot: snap ? snap.files.map((f) => f.snap).join(', ') : null,
+        attempts: attempt,
+      };
+    }
+    restoreSnapshot(snap);
+    return { ok: false, changed: false, error: '写后复核不通过，已回滚到操作前快照', attempts: attempt };
+  }
+  return { ok: false, changed: false, error: 'CAS 重试耗尽', attempts: CAS_RETRIES };
+}
+
+/** 列出 profile 根目录下本层产生的配置快照（供还原接口使用）。 */
+export function listConfigSnapshots(profileDir) {
+  const out = [];
+  for (const name of [PKG_FILE, PATCH_FILE]) {
+    const prefix = join(profileDir, name) + '.mkts-snapshot-';
+    try {
+      for (const entry of fs.readdirSync(profileDir)) {
+        if (!entry.startsWith(name + '.mkts-snapshot-')) continue;
+        const full = join(profileDir, entry);
+        const st = fs.statSync(full);
+        out.push({
+          file: name,
+          path: full,
+          stamp: entry.slice((name + '.mkts-snapshot-').length),
+          size: st.size,
+          mtime: st.mtimeMs,
+        });
+      }
+    } catch { /* 目录不可读 */ }
+  }
+  return out.sort((a, b) => b.mtime - a.mtime);
+}
+
+/** 从指定快照还原一个文件（显式调用；本层不自动删快照）。 */
+export function restoreConfigSnapshot(profileDir, stamp, file) {
+  const src = join(profileDir, file === PATCH_FILE ? PATCH_FILE : PKG_FILE);
+  const snap = src + '.mkts-snapshot-' + String(stamp);
+  if (!fs.existsSync(snap)) return { ok: false, error: '快照不存在：' + snap };
+  try {
+    const text = fs.readFileSync(snap, 'utf8');
+    if (src.endsWith(PKG_FILE)) JSON.parse(text); // 还原前校验
+    else {
+      const v = validatePatchText(text);
+      if (!v.ok) return { ok: false, error: '快照内容不合法：' + v.problems.join('；') };
+    }
+    writeAtomic(src, text);
+    return { ok: true, restored: src, from: snap };
+  } catch (err) {
+    return { ok: false, error: String(err && err.message ? err.message : err) };
+  }
+}

--- a/dsh-desktop/assets/plugins/dsh-unified-market/package.json
+++ b/dsh-desktop/assets/plugins/dsh-unified-market/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-unified-market",
-  "description": "统一插件市场（Unified Plugin Market for DeepSeek Harness）：聚合精选目录（awesome-dsh-plugin.com）+ GitHub dsh-plugin 生态 + npm registry 三源；对 DSH Desktop（EAC）特化（web-desktop profile）；来源白名单 + 冲突预检 + 试装验证；后台自动检测 + 可配置自动升级 + 市场自更新；一键检查/全部更新/逐个更新，更新进度窗口；v0.3.0 起集成 EAC 功能包（.dshpack）管理（📦 功能包 tab，交互编排层）",
-  "version": "0.3.1",
+  "description": "统一插件市场（Unified Plugin Market for DeepSeek Harness）：聚合精选目录（awesome-dsh-plugin.com）+ GitHub dsh-plugin 生态 + npm registry 三源；对 DSH Desktop（EAC）特化（web-desktop profile）；来源白名单 + 冲突预检 + 试装验证；后台自动检测 + 可配置自动升级 + 市场自更新；一键检查/全部更新/逐个更新，更新进度窗口；v0.3.0 起集成 EAC 功能包（.dshpack）管理（📦 功能包 tab，交互编排层）；v0.4.0 起 profile 配置改为双边同步写入（CAS + 原子写 + 并集合并，外部改动不再被覆盖）",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "main": "lib/host.js",

--- a/dsh-desktop/lib/desktop/companion-sync.ts
+++ b/dsh-desktop/lib/desktop/companion-sync.ts
@@ -268,6 +268,18 @@ export const COMPANION_PLUGINS: CompanionPluginDef[] = [
   // 多轮并行出「均衡/精简/详尽」三候选择优迭代，可包装 /goal。
   // 纯客户端 + host 半边（loopback 路由），peer 依赖全部由 dsh 宿主提供。
   { id: 'dsh-webui-prompt-optimizer', name: 'dsh-webui-prompt-optimizer', dir: 'dsh-webui-prompt-optimizer' },
+  // 思考增强（中文）：强制 agent 用中文思考与回复（system-prompt section），
+  // 并把界面残留的硬编码英文（Thinking / Tool Call 等）中文化。
+  // 这是上游 baosfeng/dsh-think-zh-expand 的 EAC 定制派生版
+  // （https://github.com/jing-hy/dsh-think-zh-expand-eac，MIT）：**已移除全部
+  // 接管对话渲染器的显示功能**（assistant-step 渲染器抢占、ThinkBlock 默认
+  // 展开、自绘 SVG 图标与样式表），因此可与 dsh-auto-collapse / dsh-turn-fold
+  // 等折叠插件共存 —— 上游版会与他们抢 conversation.chat.node 座位，导致
+  // 折叠失效且不报错。section 名改为 dsh-think-zh-eac，避免与上游版同层同名
+  // 注册抛错拖垮插件树。
+  // 走 patch 行（非 bundles）：用户可在「设置 → 插件 → 管理」关闭；
+  // 其夹带 patch 是普通 insert 行，本行不会被 removeBundledRowDuplicates 去重。
+  { id: 'think-zh-expand-eac', name: 'dsh-think-zh-expand-eac', dir: 'dsh-think-zh-expand-eac' },
 ];
 
 export function companionPluginsForPlatform(platform: NodeJS.Platform = 'win32'): CompanionPluginDef[] {

--- a/dsh-desktop/lib/desktop/plugin-sync-registry.js
+++ b/dsh-desktop/lib/desktop/plugin-sync-registry.js
@@ -1,0 +1,1012 @@
+"use strict";
+// GENERATED FILE — do not edit by hand.
+// Source: .sync/plugins.json (run generate-plugin-registry.mjs).
+// plugin-sync:update-sources {"better-sidebar":{"npm":"dsh-better-sidebar"},"computer-user":{"npm":"computer-user"},"dsh-navbar":{"npm":"@vlln/dsh-navbar"},"dsh-pet":{"npm":"dsh-pet"},"dsh-session-manager":{"npm":"dsh-session-manager"},"dsh-undo":{"github":"lire1131/dsh-undo-savepoint"},"mobile-fix":{"npm":"dsh-web-mobile-fix"},"offpeak":{"npm":"dsh-offpeak"},"picturereader":{"npm":"picturereader"},"soul-md":{"npm":"dsh-soul-md"},"think-zh-expand-eac":{"github":"jing-hy/dsh-think-zh-expand-eac"},"unified-market":{"npm":"dsh-unified-market"}}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PLUGIN_UPDATE_SOURCES = exports.PLUGIN_SYNC_REGISTRY = void 0;
+exports.PLUGIN_SYNC_REGISTRY = {
+    "entries": {
+        "agent-teams": {
+            "class": "patched",
+            "kind": "plugin",
+            "packageName": "@nanmicoder/dsh-agent-teams",
+            "path": "dsh-desktop/assets/plugins/dsh-agent-teams",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "git+https://github.com/NanmiCoder/dsh-agent-teams.git"
+            },
+            "syncMode": "patch-rebase"
+        },
+        "balance": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-balance",
+            "path": "dsh-desktop/assets/plugins/dsh-balance",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-balance",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "better-sidebar": {
+            "class": "patched",
+            "kind": "plugin",
+            "packageName": "dsh-better-sidebar",
+            "path": "dsh-desktop/assets/plugins/dsh-better-sidebar",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-better-sidebar"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-better-sidebar",
+                "repository": "https://github.com/omdsh-dev/DSH-better-sidebar"
+            },
+            "syncMode": "patch-rebase"
+        },
+        "change-review": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-change-review",
+            "path": "dsh-desktop/assets/plugins/dsh-change-review",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "client-file-changes": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-client-file-changes",
+            "path": "dsh-desktop/assets/plugins/dsh-client-file-changes",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-client-file-changes",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "compact": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-compact",
+            "path": "dsh-desktop/assets/plugins/dsh-compact",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "composer-dynamic-island": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-composer-dynamic-island",
+            "path": "dsh-desktop/assets/plugins/dsh-composer-dynamic-island",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "git+https://github.com/says693/dsh-composer-dynamic-island.git"
+            },
+            "syncMode": "mirror"
+        },
+        "computer-user": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "computer-user",
+            "path": "dsh-desktop/assets/plugins/computer-user",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "computer-user"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "computer-user",
+                "repository": "git+https://github.com/jing-hy/computer-user.git"
+            },
+            "syncMode": "mirror"
+        },
+        "conversation-tweaks": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-conversation-tweaks",
+            "path": "dsh-desktop/assets/plugins/dsh-conversation-tweaks",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-conversation-tweaks",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "dock-settings": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-dock-settings",
+            "path": "dsh-desktop/assets/plugins/dsh-dock-settings",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "dsh-dafeiyu": {
+            "class": "resource",
+            "kind": "plugin",
+            "packageName": "dsh-dafeiyu",
+            "path": "dsh-desktop/assets/plugins/dsh-dafeiyu",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "git+https://github.com/QCYTSN/dsh-dafeiyu.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "dsh-feature-toggles": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-feature-toggles",
+            "path": "dsh-desktop/assets/plugins/dsh-feature-toggles",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "dsh-navbar": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "@vlln/dsh-navbar",
+            "path": "dsh-desktop/assets/plugins/dsh-navbar",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "@vlln/dsh-navbar"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "@vlln/dsh-navbar"
+            },
+            "syncMode": "mirror"
+        },
+        "dsh-pet": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-pet",
+            "path": "dsh-desktop/assets/plugins/dsh-pet",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-pet"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-pet",
+                "repository": "git+https://github.com/PC2005-cloud/dsh-pet.git"
+            },
+            "syncMode": "mirror"
+        },
+        "dsh-pet-settings": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-pet-settings",
+            "path": "dsh-desktop/assets/plugins/dsh-pet-settings",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "dsh-phone": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "dsh-phone",
+            "path": "dsh-desktop/assets/plugins/dsh-phone",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "dsh-phone",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "dsh-raw-html": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-raw-html",
+            "path": "dsh-desktop/assets/plugins/dsh-raw-html",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "dsh-raw-html",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "dsh-session-manager": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-session-manager",
+            "path": "dsh-desktop/assets/plugins/dsh-session-manager",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-session-manager"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-session-manager"
+            },
+            "syncMode": "mirror"
+        },
+        "dsh-undo": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-undo-savepoint",
+            "path": "dsh-desktop/assets/plugins/dsh-undo-savepoint",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "github",
+                    "repository": "https://github.com/lire1131/dsh-undo-savepoint"
+                }
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/lire1131/dsh-undo-savepoint"
+            },
+            "syncMode": "mirror"
+        },
+        "dsh-webui-prompt-optimizer": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-webui-prompt-optimizer",
+            "path": "dsh-desktop/assets/plugins/dsh-webui-prompt-optimizer",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "dsh-whale-widget": {
+            "class": "resource",
+            "kind": "plugin",
+            "packageName": "dsh-whale-widget",
+            "path": "dsh-desktop/assets/plugins/dsh-whale-widget",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "git+https://github.com/MeteorNOX/DeepSeek-Balance-Whale-Widget.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "eac-core-bridge": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-eac-core-bridge",
+            "path": "dsh-desktop/assets/plugins/dsh-eac-core-bridge",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "eac-locale-compat": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-eac-locale-compat",
+            "path": "dsh-desktop/assets/plugins/dsh-eac-locale-compat",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "easy-setup": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-easy-setup",
+            "path": "dsh-desktop/assets/plugins/dsh-easy-setup",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-easy-setup",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "file-changes": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-file-changes",
+            "path": "dsh-desktop/assets/plugins/dsh-file-changes",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-file-changes",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "file-drop-eac": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "dsh-file-drop-eac",
+            "path": "dsh-desktop/assets/plugins/dsh-file-drop-eac",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "dsh-file-drop-eac",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "float-window": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-float-window",
+            "path": "dsh-desktop/assets/plugins/dsh-float-window",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-float-window",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "font-custom": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-font-custom",
+            "path": "dsh-desktop/assets/plugins/dsh-font-custom",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "image-paste": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-image-paste",
+            "path": "dsh-desktop/assets/plugins/dsh-image-paste",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "meow-smooth": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "meow-smooth",
+            "path": "dsh-desktop/assets/plugins/dsh-meow-smooth",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "git+https://github.com/Phant0Meow/dsh-meow-smooth.git"
+            },
+            "syncMode": "mirror"
+        },
+        "message-rewind": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-message-rewind",
+            "path": "dsh-desktop/assets/plugins/dsh-message-rewind",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "mobile-fix": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-web-mobile-fix",
+            "path": "dsh-desktop/assets/plugins/dsh-web-mobile-fix",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-web-mobile-fix"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-web-mobile-fix",
+                "repository": "git+https://github.com/AcidGr/dsh-web-mobile-fix.git"
+            },
+            "syncMode": "mirror"
+        },
+        "offpeak": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-offpeak",
+            "path": "dsh-desktop/assets/plugins/dsh-offpeak",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-offpeak"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-offpeak",
+                "repository": "git+https://github.com/christophersmith2737-commits/OffPeak.git"
+            },
+            "syncMode": "mirror"
+        },
+        "openclaw-bridge": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-openclaw-bridge",
+            "path": "dsh-desktop/assets/plugins/dsh-openclaw-bridge",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-openclaw-bridge",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "picturereader": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "picturereader",
+            "path": "dsh-desktop/assets/plugins/picturereader",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "picturereader"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "picturereader",
+                "repository": "https://github.com/jing-hy/picturereader.git"
+            },
+            "syncMode": "mirror"
+        },
+        "plugin-manager": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-plugin-manager",
+            "path": "dsh-desktop/assets/plugins/dsh-plugin-manager",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-plugin-manager",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "plugin-shield": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-plugin-shield",
+            "path": "dsh-desktop/assets/plugins/dsh-plugin-shield",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "plugin-wizard": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-plugin-wizard",
+            "path": "dsh-desktop/assets/plugins/dsh-plugin-wizard",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "prompt-custom": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-prompt-custom",
+            "path": "dsh-desktop/assets/plugins/dsh-prompt-custom",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-prompt-custom",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "sample-sdk-plugin": {
+            "class": "isolated-sdk",
+            "kind": "sdk-plugin",
+            "packageName": "sample-sdk-plugin",
+            "path": "dsh-desktop/assets/sdk-plugins/sample-sdk-plugin",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "sample-sdk-plugin",
+                "reason": "SDK fixture maintained with the desktop repository"
+            },
+            "syncMode": "manual"
+        },
+        "settings-groups": {
+            "class": "manual",
+            "kind": "plugin",
+            "packageName": "dsh-settings-groups",
+            "path": "dsh-desktop/assets/plugins/dsh-settings-groups",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "unknown",
+                "reason": "package.json does not declare a source repository; do not infer one from the directory name"
+            },
+            "syncMode": "manual"
+        },
+        "settings-scroll-fix": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "dsh-settings-scroll-fix",
+            "path": "dsh-desktop/assets/plugins/dsh-settings-scroll-fix",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "dsh-settings-scroll-fix",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "side-session": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@dsh-external/dsh-side-session",
+            "path": "dsh-desktop/assets/plugins/dsh-side-session",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@dsh-external/dsh-side-session",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "skin-switch": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-skin-switch",
+            "path": "dsh-desktop/assets/plugins/dsh-skin-switch",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-skin-switch",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "soul-md": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-soul-md",
+            "path": "dsh-desktop/assets/plugins/dsh-soul-md",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-soul-md"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-soul-md",
+                "repository": "git+https://github.com/Scorp1o117/dsh-soul-md.git"
+            },
+            "syncMode": "mirror"
+        },
+        "terminal": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "@deepseek-ai/dsh-terminal",
+            "path": "dsh-desktop/assets/plugins/dsh-terminal",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@deepseek-ai/dsh-terminal",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        },
+        "think-zh-expand-eac": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-think-zh-expand-eac",
+            "path": "dsh-desktop/assets/plugins/dsh-think-zh-expand-eac",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "github",
+                    "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+                }
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+            },
+            "syncMode": "mirror"
+        },
+        "ui-skin-blue-fantasy": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-blue-fantasy",
+            "path": "dsh-desktop/assets/skins/blue-fantasy",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-dragon-heir": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-dragon-heir",
+            "path": "dsh-desktop/assets/skins/dragon-heir",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-maid-atelier": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@dsh-external/dsh-client-ui-skin-maid-atelier",
+            "path": "dsh-desktop/assets/skins/maid-atelier",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "@dsh-external/dsh-client-ui-skin-maid-atelier",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-miku": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-miku",
+            "path": "dsh-desktop/assets/skins/miku",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-minecraft": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-minecraft",
+            "path": "dsh-desktop/assets/skins/minecraft",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-qq98": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-qq98",
+            "path": "dsh-desktop/assets/skins/qq98",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-ths": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-ths",
+            "path": "dsh-desktop/assets/skins/ths",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-trading": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-trading",
+            "path": "dsh-desktop/assets/skins/trading",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-whale-song": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-whale-song",
+            "path": "dsh-desktop/assets/skins/whale-song",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "ui-skin-xp": {
+            "class": "resource",
+            "kind": "skin",
+            "packageName": "@linxin666/dsh-client-ui-skin-xp",
+            "path": "dsh-desktop/assets/skins/xp",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "github",
+                "repository": "https://github.com/zhu1090093659/dsh-web-ui.git"
+            },
+            "syncMode": "metadata-only"
+        },
+        "unified-market": {
+            "class": "follow-upstream",
+            "kind": "plugin",
+            "packageName": "dsh-unified-market",
+            "path": "dsh-desktop/assets/plugins/dsh-unified-market",
+            "runtimeUpdate": {
+                "allowed": true,
+                "defaultAction": "prompt",
+                "source": {
+                    "kind": "npm",
+                    "name": "dsh-unified-market"
+                }
+            },
+            "source": {
+                "kind": "npm",
+                "name": "dsh-unified-market",
+                "repository": "git+https://github.com/jing-hy/dsh-unified-market.git"
+            },
+            "syncMode": "mirror"
+        },
+        "viewport-lock": {
+            "class": "internal",
+            "kind": "plugin",
+            "packageName": "dsh-viewport-lock",
+            "path": "dsh-desktop/assets/plugins/dsh-viewport-lock",
+            "runtimeUpdate": {
+                "allowed": false,
+                "defaultAction": "prompt"
+            },
+            "source": {
+                "kind": "internal",
+                "name": "dsh-viewport-lock",
+                "reason": "maintained in this repository; no external source is declared"
+            },
+            "syncMode": "manual"
+        }
+    },
+    "manifest": ".sync/plugins.json",
+    "schemaVersion": 1,
+    "updateSources": {
+        "better-sidebar": {
+            "npm": "dsh-better-sidebar"
+        },
+        "computer-user": {
+            "npm": "computer-user"
+        },
+        "dsh-navbar": {
+            "npm": "@vlln/dsh-navbar"
+        },
+        "dsh-pet": {
+            "npm": "dsh-pet"
+        },
+        "dsh-session-manager": {
+            "npm": "dsh-session-manager"
+        },
+        "dsh-undo": {
+            "github": "lire1131/dsh-undo-savepoint"
+        },
+        "mobile-fix": {
+            "npm": "dsh-web-mobile-fix"
+        },
+        "offpeak": {
+            "npm": "dsh-offpeak"
+        },
+        "picturereader": {
+            "npm": "picturereader"
+        },
+        "soul-md": {
+            "npm": "dsh-soul-md"
+        },
+        "think-zh-expand-eac": {
+            "github": "jing-hy/dsh-think-zh-expand-eac"
+        },
+        "unified-market": {
+            "npm": "dsh-unified-market"
+        }
+    }
+};
+exports.PLUGIN_UPDATE_SOURCES = exports.PLUGIN_SYNC_REGISTRY.updateSources;
+exports.default = exports.PLUGIN_SYNC_REGISTRY;

--- a/dsh-desktop/lib/desktop/plugin-sync-registry.ts
+++ b/dsh-desktop/lib/desktop/plugin-sync-registry.ts
@@ -1,6 +1,6 @@
 // GENERATED FILE — do not edit by hand.
 // Source: .sync/plugins.json (run generate-plugin-registry.mjs).
-// plugin-sync:update-sources {"better-sidebar":{"npm":"dsh-better-sidebar"},"computer-user":{"npm":"computer-user"},"dsh-navbar":{"npm":"@vlln/dsh-navbar"},"dsh-pet":{"npm":"dsh-pet"},"dsh-session-manager":{"npm":"dsh-session-manager"},"dsh-undo":{"github":"lire1131/dsh-undo-savepoint"},"mobile-fix":{"npm":"dsh-web-mobile-fix"},"offpeak":{"npm":"dsh-offpeak"},"picturereader":{"npm":"picturereader"},"soul-md":{"npm":"dsh-soul-md"},"unified-market":{"npm":"dsh-unified-market"}}
+// plugin-sync:update-sources {"better-sidebar":{"npm":"dsh-better-sidebar"},"computer-user":{"npm":"computer-user"},"dsh-navbar":{"npm":"@vlln/dsh-navbar"},"dsh-pet":{"npm":"dsh-pet"},"dsh-session-manager":{"npm":"dsh-session-manager"},"dsh-undo":{"github":"lire1131/dsh-undo-savepoint"},"mobile-fix":{"npm":"dsh-web-mobile-fix"},"offpeak":{"npm":"dsh-offpeak"},"picturereader":{"npm":"picturereader"},"soul-md":{"npm":"dsh-soul-md"},"think-zh-expand-eac":{"github":"jing-hy/dsh-think-zh-expand-eac"},"unified-market":{"npm":"dsh-unified-market"}}
 
 export const PLUGIN_SYNC_REGISTRY = {
   "entries": {
@@ -758,6 +758,25 @@ export const PLUGIN_SYNC_REGISTRY = {
       },
       "syncMode": "manual"
     },
+    "think-zh-expand-eac": {
+      "class": "follow-upstream",
+      "kind": "plugin",
+      "packageName": "dsh-think-zh-expand-eac",
+      "path": "dsh-desktop/assets/plugins/dsh-think-zh-expand-eac",
+      "runtimeUpdate": {
+        "allowed": true,
+        "defaultAction": "prompt",
+        "source": {
+          "kind": "github",
+          "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+        }
+      },
+      "source": {
+        "kind": "github",
+        "repository": "https://github.com/jing-hy/dsh-think-zh-expand-eac"
+      },
+      "syncMode": "mirror"
+    },
     "ui-skin-blue-fantasy": {
       "class": "resource",
       "kind": "skin",
@@ -978,6 +997,9 @@ export const PLUGIN_SYNC_REGISTRY = {
     },
     "soul-md": {
       "npm": "dsh-soul-md"
+    },
+    "think-zh-expand-eac": {
+      "github": "jing-hy/dsh-think-zh-expand-eac"
     },
     "unified-market": {
       "npm": "dsh-unified-market"

--- a/dsh-desktop/package-lock.json
+++ b/dsh-desktop/package-lock.json
@@ -793,7 +793,7 @@
     "node_modules/@deepseek-ai/cordis-plugin-include": {
       "version": "1.0.7",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-cordis-plugin-include-1.0.7.tgz",
-      "integrity": "sha512-L17Iqo7YRAeGKNyf9NjAaWAVdv2P5oi3CnVKvK0jgGMecMO1kBwCwXN8guViWEAa7vqo1f8EdbdfMgWLttfUcw==",
+      "integrity": "sha512-EIOko9nSdFx9ZPBbJq4wyA7FKLsZUy5xlqRk9VJ56BCbYQh+R/mxX4QlEO7MtKwLFAwL95H18K75egcde8O6xQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.3",
@@ -843,7 +843,7 @@
     "node_modules/@deepseek-ai/dsh": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-nBUef95xs0LZKqqC7oxzUBxZRkyqmHVS/anpPJhWi/ooL7XFWVEtFe93HhXQyFDQUhthtbQnMBGXGShGw9Ewcg==",
+      "integrity": "sha512-xwUfM56IfKC4Sk1IGMaGmD49V4wHdkOaGMLqcasYjNxkhTU1v5zUhxxiRmUcxgE3Ej/xo9VgjsKOKIgA5SXDgw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -925,7 +925,7 @@
     "node_modules/@deepseek-ai/dsh-acp": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-acp-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-LWuS1GFjKiHEXkm+HfngqYu8VdSHb+4WVLUfsA/jjKvzKbCIaTso9sF7LuGGRnMuL1Zu/tfa04b8oN8BpNfWRg==",
+      "integrity": "sha512-bhu9++bZckpOUfJghCR6nltr2sMfemcYtFOsjv9spH7Ghf25VWpj37Y9fr/WNjPoaTDo7TojKUF100fQpjHrbw==",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.4.0",
@@ -952,7 +952,7 @@
     "node_modules/@deepseek-ai/dsh-acp-app": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-acp-app-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-H12xJxiErLNn357dEYq8433w36KCwrXkotYCvicWZMjtmtPCDiEsvB4/NpippoDWvPukf6Rg8NSnwBFyCusyPQ==",
+      "integrity": "sha512-G6mzKosqC/B+s0nwdCxuRDRZ1C+DVfjM4wTNC2pBezzUpD3LdKim8wAoASWzmCY8k2Q4COAqx2NysAhOaEIoqQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-acp": "^0.1.3-alpha.1",
@@ -966,7 +966,7 @@
     "node_modules/@deepseek-ai/dsh-agent": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-agent-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-eVE7phPAEL2vASXP+MXW5Y0zEQzrNXIouKA+bJFaAu/iXpBodDSU9kr/Sn1kiXoKXsLOeDQSUMVDB+dm8Kt17A==",
+      "integrity": "sha512-fwoR/F5468k/QHQJtVGK1IvdMvv+eov1iHVxvA1vhHw/3PlxUX/ILUJ6SAn4ZUZgPK9HV4e1zE+OcF2AiAml+A==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -982,7 +982,7 @@
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-agent-default-model-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-siyz/yZ+tcO1/vD3QMRk8+8xrFHdSGxbI5QbsgyRDcTYmy2QhjN7ynWLO/UerPLuHGAD/XPCFZLQL3oVRGDjwA==",
+      "integrity": "sha512-Mbu28DpLHN71NbFn0cOZ0c5q63hNAfc7gg5IdK94xDLPu7gg+kil3pJYs/mPU02e+0tHbKAhAShUb+pAum1aAg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -997,7 +997,7 @@
     "node_modules/@deepseek-ai/dsh-agent-instructions": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-agent-instructions-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-yLFzWlhGMDrv+p/tzHAae5XI0T1b410R11qym6Kl/EWcZ1HISyhcM+5X8yCleqbk7RqsyW6TEguyU3VzOnCciA==",
+      "integrity": "sha512-43MHrpyRyLxpK+4ICwYWkurYJVy+WSPNhKuyvIn7NVh8bgbJf3pjQ/fdvcngWZm058j58RBqc41tPG7k3xgmuA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -1017,7 +1017,7 @@
     "node_modules/@deepseek-ai/dsh-agent-loop": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-agent-loop-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-IZIz76VzXVUe9s+I4XefQ1VE2XkJ7ZxBVqsQQXxy5gvdmE7BkNQZvPqGw1hkD0gT2duyJq2HX+j3y07Sy1v1VQ==",
+      "integrity": "sha512-/xxo01tS5p1fG6LlXZ+0fI6Kdxz7p9pkjdHBz2xb7dhwj92fWs+MQqdt9I7jSK4UdO4f1xTlw0KJWhbk1ttGCg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -1042,7 +1042,7 @@
     "node_modules/@deepseek-ai/dsh-agent-presets": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-agent-presets-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-SNDYoFVU61k9wu0/NkCn2sO/K/kf5majo3Yq0Z9wIi+BbGuJJzFDIUPg4sLz9gSOhg65mWUKa2a5tkVbUFj6Bg==",
+      "integrity": "sha512-KXAslj1Tfvu/T3GsrUWdFOJA1O5luxCIRphjeRJ198QwZcxZv8Tq6Gh1OtNznY1FgzIbPRaNtynOQQv41MD8GQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -1069,7 +1069,7 @@
     "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-agent-tool-presentation-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-IuTe/v4QJTWxyvEZaSaR5IOseKZD2CBMFjamjDmwKvTe2EUiKSUb3Whv1Wch9PBrZ2NKe+cvAT4n5fnppJcdYw==",
+      "integrity": "sha512-8tRBBu6fH/A+UdK46SYV9ZXXpKQ5M3mc5DgcSXs2/fLyI9Z/1k51UchaujKpnglDHX1HMQbyTX8mi2WW0PWfeg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -1082,7 +1082,7 @@
     "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-anonymous-user-id-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-dGjjhUnkOr2kmR+zVzWqxRl8pChvIjZnB/VhkoW+OMMZLUg3cRrNjKyEPwbYcRXOkaRBgrV4T8P6hgk4X2KPpw==",
+      "integrity": "sha512-9MTr7F4QARJhU/F5dZQttlxrP47wqOMkOAQ9TrP+5J0LLnA0qjYHIh9TujEEeWWmDJbLqnzmov8L2dx3zuXpQA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1093,7 +1093,7 @@
     "node_modules/@deepseek-ai/dsh-api-gateway": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-api-gateway-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-37gfciiBCKtgJbHi9G0/isQie1MlvmojMfU3rOIf8xv7JuOk9QLDdBglZJZky9WqkKidARGedYVenY5qQAhvNA==",
+      "integrity": "sha512-ot9kgREr4JLsS+4/BLOOt8QEnuHdh1dgYLEVo9uxPvcFvuiAKEuOfy5s3EmsXgnaolQa5GzCXGFr2v5VP1HLBQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-deque": "^0.1.3-alpha.1",
@@ -1109,7 +1109,7 @@
     "node_modules/@deepseek-ai/dsh-api-remotes": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-api-remotes-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-pLMUjAqTb31zGeNH7W5R8ksvzhLFLwPxxbDkp/lgMEmtuC73YNolge0y0rBBr7w0TWqMVUOvk3VKSui+CGMnWw==",
+      "integrity": "sha512-DzDbNnQJtqJPvL8JmHq8eCsqBLKDfAp4akcJpYFqulNjsc7g3DHWj1YXbvYOAJCww/GCgkCY1GZZ2to9bgGOkA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-deque": "^0.1.3-alpha.1",
@@ -1124,7 +1124,7 @@
     "node_modules/@deepseek-ai/dsh-api-session-controller": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-api-session-controller-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-c/hjU1sIr3xGOoJue6r5G64+MYq4wbwLhJX0dbTexyJpgnJnITslLAuMWQcsXAMgpxgd0CZBkC8iO3yy5Koi6w==",
+      "integrity": "sha512-5pqu0G9o9edAzOcqhEgqvI6s8nplr7R1aPt9f/EF1LfUbuUecJib5fypfDvvcGAj/H3pA3oAmKtR3zQj0Jg3sg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -1176,7 +1176,7 @@
     "node_modules/@deepseek-ai/dsh-api-settings-controller": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-api-settings-controller-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-26k9g9Hfn+Z3kwhbTRvZoI53Fea5qeiPMKxsdQtnOfRPVSSRMDuUBdAEZJ6nLDsiooFM7Fpp/PqXm0q2olygrA==",
+      "integrity": "sha512-0hNxmbP2Zp868oDU4Oigp5rXIX8zFE96SIIu4cMQYsi/5sE0EHOaXd6nxluaPX7l5/KZA+oTc0wfELzIQAzQ0Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -1195,7 +1195,7 @@
     "node_modules/@deepseek-ai/dsh-api-workspace-controller": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-api-workspace-controller-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Wq8m9w7OayUflmd8h37O9APb92Gh10HKoOmqcxqCnr6U4deeqTlT21xwqPccdp6r8QCHpqfYuAkbXwn6oJ5gLg==",
+      "integrity": "sha512-qAWHtiXP+JTZ+ylm6kjUZ5GCF4fwQUbxK3H4aXVoi+/Lbead+G08y3Hux+pRS1eKsDVM/AHwEZGAtSVR+9nKuQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-deque": "^0.1.3-alpha.1",
@@ -1215,7 +1215,7 @@
     "node_modules/@deepseek-ai/dsh-app-boot": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-app-boot-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-xOlI06/ScTbPkw57J0z9Tjj6nmoatUC0wmtyacjH/6FDSVkeEWhd+Qx9TFmzBRj+NYmO8jn/XYImBnRC7YwnDg==",
+      "integrity": "sha512-yHJ7+B1jaQ8D8WwOHOhuheTCljuXrUrO6Px0aAnNE15eFB1XRqHHers31ObHCF4tnVKU6ZJ9Ap0RcMqicYx2vQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-atomic-write": "^0.1.3-alpha.1",
@@ -1260,7 +1260,7 @@
     "node_modules/@deepseek-ai/dsh-attachment-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-attachment-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-xYzh+PqTSkXiT8WKx1tgerQNG55gOdBs6iuV6MPEpX8h5E3QaxXhUxk1Ex7iwqUloyHvs8DENL08YWi1tj8erw==",
+      "integrity": "sha512-6p3hR904QKTLZWVW6ByYdcCiPaYsiif8ZSnt5AQJsA+XnXL3uslqn+98mLIq7ee+oHYXOonKv+Q39+Kg/M2naQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -1275,7 +1275,7 @@
     "node_modules/@deepseek-ai/dsh-authorization": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-authorization-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-JpUu1gdtkrvS8pxXg7aM/cvSHQ8iqLuYkK+4CzfrpbSMVmL7X2toENpfXuQD0DyGEI6OxRvkFEzjWhuhhUA8Gw==",
+      "integrity": "sha512-Bp4h9Nr2iSvJ/AZpZ4IdmBaHokJgbEOnoDmC7CzX7cY5ycASVhgLxDUakr/Swsr8iW9IZon1N9uvQ0gM6wFQ/w==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1287,7 +1287,7 @@
     "node_modules/@deepseek-ai/dsh-base": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-base-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-lmIB6UR5fkQ74GcoBsl6iZ/k54061B40lPLNBxaNPnSVVj2o16UHrsKKuFUGn9F8y0k0GenVUU3xYy0sxVU6WQ==",
+      "integrity": "sha512-DsQb9yYFR1jFncaXZitm8Lldc5slBIG5kj5GoqrtsZCw9+ZdU3oMJeK4wRoiWzwq7OqN3yzc1XOyM+d6WMreiQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
@@ -1382,7 +1382,7 @@
     "node_modules/@deepseek-ai/dsh-bash-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-bash-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-S4dOQ0DyL8fqsZ/HPfDAwaARr7LBFaTZ9EBmUZXlxA+S9Y5kcy7VG+8O/EFsKrFp4yEdhdPv6uRBeXXHJb0aAA==",
+      "integrity": "sha512-z8VhaHt/MialPTNFO/aOpZSv0PKx1S/8H8cxG6zzKrGhucG7lb6u0OXCAU9Yof0oFp3u/EFodWw7bonTOfqENg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -1398,7 +1398,7 @@
     "node_modules/@deepseek-ai/dsh-bash-sandbox": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-bash-sandbox-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-cmcMclnmIfkfLnbvKiCF7xqKMgAsH7KNIr5mDPtpQGlPgH+ac6P3QAqfmE2/hRKN0dy4UdCNhiuKigNi6tdbhQ==",
+      "integrity": "sha512-YuobJXpQNn92HovrbklJfWiCSbjIOIArGU435nIqybgheD0n4lv6U2mbrt+JyLeza5nIdcOFFy5HHuUug/0cug==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1420,7 +1420,7 @@
     "node_modules/@deepseek-ai/dsh-client-connection": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-connection-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-ja1XCBDk7bVMqUD8pDudaFVa3OrF5yl2l234/idssjzQt5EBqRaW9Y2r7xEG07Ze80kl7MVksb+A+NP5CsWiog==",
+      "integrity": "sha512-iOVm3mf4ytMwdbThwvfV9CtOlw9PvqLApSsyi0PwnAlNC6PXzTBoFCW3WXEAadCosN1w2YdLG6QBJwpGWqI75w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-credentials": "^0.1.3-alpha.1",
@@ -1434,7 +1434,7 @@
     "node_modules/@deepseek-ai/dsh-client-file-upload": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-file-upload-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Ej3GvTOIAxqfMn76sDgCbGwqEAtUcJOTnXLM9tea8TWAkXx3sq+F0S0ITzf0RPXTjbVKoArXqaKVTUH+zVatcg==",
+      "integrity": "sha512-TcfpuWewczRbiLwP7E61e5tHcTKV6vhuJSwMSxQ7UcyzNqG9rp+EqIw2Y9Iu410Q3II2EGQAct9e62UVJhOKxA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -1449,7 +1449,7 @@
     "node_modules/@deepseek-ai/dsh-client-hmr": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-hmr-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-G9KUQ9pn/Ab6K+9qjBE2qlVAHfCKFcNpEKszt4fU/9hTFi5NhIbX2qez7eeLweHhP3T0NNPZn3qJupmMpzywPw==",
+      "integrity": "sha512-MC8k1o3GekYkLw7do7v4AjVmdG0AQbBT/sWboT/X/bGHnnSuqSQnr1wPViGYeh1IPwUkW7BNDESvczTrPAaUtQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -1461,7 +1461,7 @@
     "node_modules/@deepseek-ai/dsh-client-locale": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-locale-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-aYiMMzJv1RAJxwZqim6S12pk5QoDKUfxBPv73rm3UCbMbK5Psz2KpSIg/JQIxxt063bT4G3cKgAbdYnIDBAI+Q==",
+      "integrity": "sha512-Wf/PiQcZYXe6Qx06W7ZXnlwcsgasQNUh9hNqv7mzb8taPFbi9qlOqHiXawQjBCQqHiDy3aK89J6z/cTfrYD4qw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -1473,7 +1473,7 @@
     "node_modules/@deepseek-ai/dsh-client-modules": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-modules-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-1vHI3UMcpos7Y6q9kKzU3V/T5wQSaBG6hGbJNq6sYXDKoRwY4S7w2G7kIJwmauvGLwzddqXANBgbkPmfCo3IxA==",
+      "integrity": "sha512-IFUiuJsV+pptK+ZsDtnQMLGzoQnhEogcRweEeMPi1ilgbFY8Bub2qhw421nhW8UsNsBp2tqDmTzsbxljJzzhkQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1495,7 +1495,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-agent-preset-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Zl3ZSYiOXzI/+VXqaWu28g0JDTALmfAyjUCOYF75NNclSYClg5HlWheLIwv0yLs3hZWz0CXfuhwZfmNEsQcoJQ==",
+      "integrity": "sha512-TmLQV0qJPSz5ZmsWkAHVhudZU36MW0zoSJApGM95dBwzlquS1tQ1rqlI8A9RllnX1+aZuG3Ca4VLWEejUdVpMQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1504,7 +1504,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-approval": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-approval-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-08rY+JQzDpEAzK36XdMjQHbdBbros9acEDPwaZ5avzOkjZkKY/VZ5GU8xDDAgGr0D4r1OyuAieeQrUmRYBTKUA==",
+      "integrity": "sha512-GGpu9yCvJ3ynE6o2/53foIhkc/yKVfGBPU/pPWJ1yiUr7mNgKpOxLNHNWxsffsfw2oYzj1/mUtXfhOjKem2KxQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1513,7 +1513,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-attachment-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Ho2wml8gN6vYdvlI1g8vJEyzjnDBPxyOoqiJoWCLUEEYitpkq0FP6Na+u2gJYIRlAdVrEUSyxofZMdQdQnuykw==",
+      "integrity": "sha512-DbD9rmjL+eFkvCBhMtH1beokEjZmek1kjD0EjSidrWf8apQQnrh8Y7xu33YwqnmFlLC413NHOyPXArZTY6ppIg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1525,7 +1525,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-brand-official-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-aBiThbARCjOp5Dd9mPefc0keFTkDX3OZV6LoC5fBw8OnQX35TmttzG8JYpi6jXOLlPl772S89agw+DsGU8QijA==",
+      "integrity": "sha512-ULuZLauQHSUdkgYW9Ysy31MuDK20qDN4cbMD2yfBEREaKaYjNxpylBY8HGW5l/a/WCnhQmFGQQraJsdPXubBtg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1534,7 +1534,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-chat": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-chat-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-aSj7HAM7g2VzB35HNUSOumvLDF40SpCYC4aISj55KuRVl3kM0s1/AvLeekD9ZqBz7DxQG3+bqwKugXSMrMjG7A==",
+      "integrity": "sha512-5Ked2kG0Ptgs+gsabCiXfq1GvyYv0lxgUCtYL8QsI2hKv2NSlEWFjwATkiC4CAnsU+iTAIQfcUlrhoXhfpbd+A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -1546,7 +1546,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-commands": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-commands-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-LgSEkytAWRUw4uItls/+iR3MSyqTChmWyq/Q20h954m8cwGTHhaizqKa3q7NSttKAk5/H6qRwkOGt45MyY0tEw==",
+      "integrity": "sha512-bAY5fdzzrhuKmAqhP/OoFqg13ltpcyc0oSrfP1xJIIb5835DRvDYWvZ2P7djL2VsfFSDaW+DVhNdwhsU4wJmlw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1558,7 +1558,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-conversation-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-OXnNwQMn7seL+vIhEyosPilLttr7IDuwZcQYsEcGMuSUW2JT+BCcxDAyefOyne06cevpGziTcU8nm9phB3B6KQ==",
+      "integrity": "sha512-iGqfI5KOkJiD5D2BqwJENxvqUXFRssnltwaLpPakv+Y6boVkHNMZ+xMGfnS84x5m1NumaLboOSkeys5s1iam9g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -1576,7 +1576,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-cordis-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-2YMYsc0o/q6W0OFX6U+SoH0lk8VFI3fu/njfqXkYpTe7nDfxmzjvw+tzDoepXF7q8k60DX5t+6APHtgAJVvT7w==",
+      "integrity": "sha512-rV68FQrBh3n50KGRkyNYncLV3Xf709Jy4rfa4+p7HljqBbF1NZVSb0H8SLt1w3K/LhMSDw1pJ0dDic0NwP8jXg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1585,7 +1585,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-deliverables-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-9RJiWki03AR0CgPJpGPK1BfQlMT6UGFoU3DYD/kVXb8F5oeJ6sxo9+l2vq4G5mdvbvM4GmFl6tEpDUu/e6lzvA==",
+      "integrity": "sha512-73TPDZ3ig8ijNhSvK10RBd3g5oLHBrZYwkDl6FChn0vxsIfIJE91blzESGMDhOJiBnUurB5G19bA0tzPzmFikg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1594,7 +1594,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-directory-picker-browse-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-jtebEXQ3ZQM4lTFoD4v4hnd2pHGdpFVLHDvgUrTgNMZGSa5QiSvHIm+XbS47e5ProKdU6x44Kij1B5alpIzk3Q==",
+      "integrity": "sha512-OIIcPsLALvZNa2OsnjZ5aBtWwBFZG//GgLAMITM13DzRgRvAq3WOmp/L599mKJqkp78tmue78uhax2FjKPwTLw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1606,7 +1606,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-directory-picker-native-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-pey8+e7TBZr4cFFp+P/v2tfzQtb3XAupcOEcXRqpodVibVt4y+6lQbcEb9mPlC6nJucW2n/m5waHJ0kSWoL87Q==",
+      "integrity": "sha512-z++1HSNe02Z8pjrTHF6wEueiEKJmEGy7FD8xUJCCakTqgPPi98DjClbrEwhjgMabPx6i32nEKF3SV130kx53Fw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1615,7 +1615,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-goal": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-goal-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-n+B2XVaCuAgzBd8lTGmsPEgij347KOfQqnVzPFs6jo+tybmcUltyjZlTtxNCgwnypgZbW6hdFsbhAVxCLiBwMA==",
+      "integrity": "sha512-3A6wV15rJG4dlXmvxxIvb6AlgVWAh8IvYupXQKY/7cGxImr9F/M0xmbcVxL+aSiO0MWxkyV7VSxqwosLiLcQfQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1624,7 +1624,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-input-trigger-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-D+3fJPEb9hKLTBiX7uEG/LaWkZyEy6z4KAi+ITT2zQ9SQH3eUIdosB1cKCaG49+NvhHicC2us1vnfq+pR4ivIg==",
+      "integrity": "sha512-QU36a0LiJHr3dASWKVFI513b6J7Vyh/bYfgRSt+3Hj4Vfzi2K4IIj4xVWKzIsL/3OzBIX3kq+XwZqV+cBi/glg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1636,7 +1636,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-jobs-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-yD86MeOUMJAWqAW5IjxL7aWhQaymmxS2g3BO3PmyBJEkHNfTLC/IxjrwiKQNi4zCdmR54Z0+rGsOC5gei2ZhFg==",
+      "integrity": "sha512-MocsKfS2B/XxURdQgwOlqN/XV56l1jdw2l1wlw98qzkPCpC7mHrJeQ3IlF770SHph1n0cfLSBwSzFtPgaIvkWg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1645,7 +1645,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-layout": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-layout-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-SGMq/B6cahXqBNiVeAbWb0dtTwtk2huEvTVdQB1CSvYEV2ajyX7p+IeAgWN2k3EhBOIIQoaY6ML8JH0aaFmh4w==",
+      "integrity": "sha512-5l5CrBULluox/zv5td9JY+T4TJFWFmJv/oAlhZL2cegQhgq4LA5sjFOlFpRY9UFQye+DIE7TM9k+gMl82lD59Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1654,7 +1654,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-message-feedback-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-EwlU2dn0515E7l5K+HXZGlzEJjT0j2M3WV7ESaL4qjmNwKkPOqmyQHRveeT1oRavUWc2w5ageCEXqTCsq6XbtQ==",
+      "integrity": "sha512-hghNc4hyd6OUeEP5c+a4pXBgycCRpqRWnl7p2EoD7kWB/ra/5lI8K+jnbPO1ilPepqS21sIeX2WaoCWStB87zA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1663,7 +1663,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-model-selection-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-lPmhgViQCQMm9ibamLA9sFW+A1D05hcO4wiioqmF6oAcN4EPPG/fH8UKBdbU1Z2vaTPE58u/DSkJYM/NRiHOcg==",
+      "integrity": "sha512-ZQIl5/5cheAszvd65VJtWfgyc8Vc6QTQtl1kBh2z7AXMWtPx+6833/ixQwgGITJqFKnhFZJ7gl68ozstPiG99A==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
@@ -1675,7 +1675,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-permission-presets-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-HbtJi9IJsT64G0ixfdHsSVt5NY7TLKEMJXu5pMjX1fwdTZuv+aBbkQcNV92XVB4dzP5shl/pt7WGMLEJEXBaCw==",
+      "integrity": "sha512-jrMVn2tB9lypOgLuGrrZwpVwBCHXUXBanp51He0Z8J8S2HNPvLOsrM1WfZlcNW5jFD2obKpWC3AnrvxYaIHopQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1684,7 +1684,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-plan": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-plan-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-iHU4MUM9qryaLwo2asrRNPXf3Q9SZpHyP7rG19ZyYqOdUXVdpvQYLGS1k8DM73Qz3oBAy733jdD8yvFok+LIXA==",
+      "integrity": "sha512-x2IgyM1xFIinodWhuYL8THda3U4JDoPXiM4FkuW5W9PZNAHHMPyoaCeiwuF3X9uNbtpTBulcvbsuhxZ6YJHmww==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1724,7 +1724,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-reference": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-reference-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-r0y+pShIqkIesnfckygHJZDDOLBf058ah+RWN9LuKMZPnyppbbYjrvZNg9VpvX9aPeaw0AXvAMGsI0pS/H9kpQ==",
+      "integrity": "sha512-WbsEMIceGqCnOcQsyzsFdGDsDHXOYTTD52U3rWBwbFAd7Ux5BTZY5NDele7boEsMy0j/Av+vXcwXPcNj9zR4rg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1733,7 +1733,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-renderer-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-6xV6+URKrs2ejCdF9tRX2rcAnRnKzYMndWELxPvDCVGbSsvs+TlQiciqOYDBL+/M37QSmG+n2n2yOa0wpMOFbg==",
+      "integrity": "sha512-TKe1HG0/T3DozI4QflxGySCyvUp+/46LFH/Aw+xryzI0VdcxBfAW+d8TAvxcYfV+TKcyynjBkPyVauX02K7BLA==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
@@ -1745,7 +1745,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-schedule-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-eSWVSklyxiHMGD3D+TgC69xhmLQ/RbYR2hDv7UiiOByIx9nsJGXXr/upaAu/qEHRbdDYNEOq3E+DL5leitx5mQ==",
+      "integrity": "sha512-njQsIz8uFUsIBVxHOfUw7iJiv8nhYEMaPBpr4SW0eW05xNpEYzmKPVKKLsLJ+g7kiifU1yIV20woPJo0VyDCIw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1754,7 +1754,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-session": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-session-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-ucSbmnLsACqfDF8GsGSgBp5T+ei2vGpQd9BswJN+xpqQEBKItvR3QLpQO1w2hfKF1UABqYo+sIkoCcjJE3OrZQ==",
+      "integrity": "sha512-0evOGyrksD4y07yO6Lo+d4csXNfLoLS6uyams2pfWIWA0zj0ghvj0nZIz6h2A/ev5vb/a7SJYpTjKL2IDFlBtw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1763,7 +1763,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-settings": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-settings-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-DsPsmcHq+r77BHTrPcxpzUdHFsEUp3bqdqw3XM6MJT2pMgVuCMqAmj06H6qyckRPuRyghneI8VszsVKzQrux9Q==",
+      "integrity": "sha512-ywn7MvHsxuueThddJ7DqRNAbOkJfcHWG06Flox5ndPJxc/vKM8Phl362E+0Id6jiz4wGLadJs4W0cFL832CJDA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1772,7 +1772,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-settings-general-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-TyR1lw/hrQgjrHaDr/2rkTFW1gkLeKOkMX9D6OOYkSTJwRXIIFdeyTVm1FnEi9vyNDpQXTyYT5F1xOdrr79unA==",
+      "integrity": "sha512-H4tcsazFMUzK6wkp0o8LgU5VWT3id9XT6Fp3NSPX/06D93oLGK8/jCdU0VUwD7XHTXmOftC2+4wIwix9gdOhXw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -1785,7 +1785,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-settings-models-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-kHFe0NieJ32bV3EftIrrGG7YS9L6+Y6pONqb1+bsTXBqB9B12UZLSdzV/8Bm3EDMNlVz/8zTxYGHiBN+BvxOzg==",
+      "integrity": "sha512-rxkcD6EWrd8ApHlFOXhxv9jwfDCFCApKiuXNdcvw2+TYEJ5Wfx67QUjMy+ZL5mptIrUHIqD6kPGhMq7XkVTLOg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1794,7 +1794,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-settings-plugin-inventory-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-IDA9iqyZCG9/IvlqbIP4wWgDXX7B9RDHgZ3dTVm1DQd6WSK3YyaS3T6q0HPUSupfmTApLqW96TPenKA+gi8pxA==",
+      "integrity": "sha512-OnHBbbSDDiN2ZsXrR2DVOTXKNNQL/bP29bYASihI7PGu+TG8a4OATRGiydjW15LRmA9GQLaoWXFIo4ecDUjYOw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1803,7 +1803,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-settings-plugins-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-16hE4mIB9dgMIhvB24cVCkZ/9CMVzzOW+APoDJAbio2KgBMzKdTZ2Es2o85eQxGVi734QgmCKnuIosDJoVl/2A==",
+      "integrity": "sha512-Su0byUGYNJzPSLOnYv2u2XZ4+XLADMKPOnSXZ/PdHASwuzTrd6I6JVNYXOFa++KRX2Rtg94UJIXBT1fInwR46g==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1815,7 +1815,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-sidebar-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-cpCxJJ/XPvVjUhMZ5Ht6oLfkS6b0ddpWy3WYQGTSUKF29r8DMK+Wq1dPIqPvGjEHExlgqsFIgumetKuMs8eM/g==",
+      "integrity": "sha512-P+USB8WH+QKm6PBcVEKu7Fju9tCGNyj2u0xEZ0vM8dkWdwvH35HGJDC6EjQtD/i+L6TMzVrAoReZfdjbKRh0vg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1827,7 +1827,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-skill": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-skill-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Fapoab/6bKAoFrJUOOei0OU6agd9nU+Lk5nLRWT8xe4SAuZK3aP/B3PsUdbJUx7/CKrotqeko/bAHii4upsW8A==",
+      "integrity": "sha512-XVVW7QzRbRmagdRm0UofXKPLlAJ52t9TIycnCFlFfVw6ep7Tzq8CptuIRIbnVRJq5TJ+z/Qgh9cSNvNAFvAz8w==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1845,7 +1845,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-subagent-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-P8vJo8s4EwTxNuMaCYWtLvVm7wzU/hgEz8DmHBPBUifLzLWXi5bbg8mlBavSkCTHMGb7dd2tnWKfrLb4H5tEOQ==",
+      "integrity": "sha512-K2KQvKgO/wTxvB9EJiaynEB0tk2td6wgYb1TTLZ4JUyiLOqyYnZ+S0ofWyemHAt/HzGQaVTcbRh0A84jBdOXGw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1854,7 +1854,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-theme": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-theme-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-ook02y2H70ynBLANJDLbR0izjDWyChwhRNXDTHtCahQur8a8k5qVPfITxyfSYBhR8x6XERmWache07nsIZKu0w==",
+      "integrity": "sha512-rV+9Kev6KJC/x8fQ71uKbjmK63JNBlB3XhtEEdH9Vk8VnInz+qS50TEtXYUAXaz6feP3WJN6IXBpA+AYcM5Ssw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -1867,7 +1867,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-tool": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-tool-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-POUj3GjaPOYEzOGz6RQIBXcFJqueinOIU0njugxTDyn5hESKyz1VIBfFXMnnOrdJSgkvPot7qcO5yPqJCwx3dg==",
+      "integrity": "sha512-f61+UkKNR96i1vXiutih0NBWCCtdGY0qBzEPy2plz8waBvccO36GheWPZ5D9VDJHESfIh7/aYlwhZLPuWQSOkA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1879,7 +1879,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-trajectory-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-dJZB5W+MDSITbzSdvqTekKckyCBZTIT/DmfdCTKEdVsAhD7WCGTNIHXUiah+EOWyi3gC7UswzNycHnbqQEvI+w==",
+      "integrity": "sha512-aCm3IhiF+Spp3Fh5qz8jmvARXK9AORZ/cRwuXU7TokU/G4/A7vzrCk1NxboIgHsP3JtG2qP27x4b8MhiNPLVFw==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.9",
@@ -1892,7 +1892,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-user-questions-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-UPUdM9U5aCAdTHGw5jzR3hNjpPu1OjOudl0YfdXc/7iGEOlCLYkUrJhbCl02lrXqciENNQAkS3jdP8Y2713KwQ==",
+      "integrity": "sha512-gUK1t+3vpxLGqqgfmaeT7xN0OrjjBHmmxTUWblJKyeKPCgaPl0WO007GwkiSi1YsuNGiRZm/hkpSoLFZkrta2Q==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1904,7 +1904,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-workflow-run-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-y8mCeZpk0QELHnej265oNgdB+7a/DM6VKi7FykuK7j9NqEpOsCZeDF4CJbTd1naBo0q9rtUMqV237lTbs/dpWg==",
+      "integrity": "sha512-f8d6GKZvadTmVpc6feKhIi0y0ZCqSZ+Bc90If0dzPeSkpzxDizGl94GrOAiemLp0MIS3EqVcJEXyDXh1eE4hWg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -1913,7 +1913,7 @@
     "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-client-ui-workspace-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-rvAXQL2TkVvsrw1vVp+EmXp58vwUX+OQfav0wOdkT/PZ3NawDKeRYPzj+N6vsp7v2RRypfOV3BIt5k6Fqh3d3A==",
+      "integrity": "sha512-IlRHaaH3efFvihlrBro/Di7D2f9Dxr558C2/oFzYs8tKO+wXakg5f3UETJ0JD9gJsvfoi+4PnBOWRyyHVXK4QA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0"
@@ -1925,7 +1925,7 @@
     "node_modules/@deepseek-ai/dsh-cmdline": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-cmdline-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-44w1xCLjdIEOESpuioNx4RuE5RuQ08cU2RS2HdVaHSuPE/azmzTq1jbJBBaexDnSrIDsSgVOhfj6NX4N5hjrHQ==",
+      "integrity": "sha512-WnM359WHdOy1lfs6YK8eIE3a80pRoPQ1MYpsi1AkM3AENgUeHKmQlmrhiRW1Noq3ttCIirea2gQp5ITgEV+rlw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1944,7 +1944,7 @@
     "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-code-runtime-worker-thread-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-4pAb40TDjSjmEW6OeKNtlxMl0u9RBJarxBUw6kabViPntpZ2trl33SpPlTSJhT+TgSF6CEA0wYq0OCe6GgZjqg==",
+      "integrity": "sha512-9ggqebW+yjgSOhxZ9lzBk4K0tW9eNtmV7i7EveHV5tH1tnQaBSJ2d3tW6p4ruAaFYmy19/sSlOkh5pa/aezbmw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -1960,7 +1960,7 @@
     "node_modules/@deepseek-ai/dsh-command-compact": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-command-compact-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-fXsCtx1vpGbFka4Xnoe1Lc5wydsnf7sqIweQTCZW7bAv198+xAFljpzyHmH9if500r4MnVp/sS34dmM3t4COGA==",
+      "integrity": "sha512-yeBMm1PKoce5f1mqjCMcXxMDCxk8vJd4eRjajEeFSwx+aMH+uxLzsyj3BxWv/AmcMxzQLt/H3Uwc7u0FzRLeCA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1971,7 +1971,7 @@
     "node_modules/@deepseek-ai/dsh-command-feedback": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-command-feedback-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-kirWDYd6UipQeEwkzbjL+hDc5VCb2ZpMIWdbR4QHY2D10bHSJ4jDyUGbq5jlSiqUaLPDHGd/rxM3YxgvHvdEJw==",
+      "integrity": "sha512-8HzlbaZgAyJhwjwZxo4zdebZRS2lDfpSsRwEKtD2j3iVNtEZf0A9VWhm4L7LzSXv+TECCiR26qdhwWubk5NFFw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1984,7 +1984,7 @@
     "node_modules/@deepseek-ai/dsh-command-goal": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-command-goal-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-vajLBBjwEeA/UoVez8/CPPJFGwgFldpCVhX9Hwp/6vyX72d+MY7ad1k4xrHPpIRz2+fJP50pvRR37nBVdGBpSw==",
+      "integrity": "sha512-q3tb8awp/7mjvbpGBKRX9rcDupXZ7kZAZu7n6vOw6HuT2F2gt5gTvKUMEFtI9E4vx6mcMEk09DUVSjqOQdo7TQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -1996,7 +1996,7 @@
     "node_modules/@deepseek-ai/dsh-commands": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-commands-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-TDqs29Gwk2siAabgweMsESBE8Map+kG5rxA7uAOeQzR5cewuOkuPZU//v6XqZEIK31B14knYQgaDI+KIkOstbg==",
+      "integrity": "sha512-Ti/SlRXWaTxSV+WBg/56dUUsH58IMTzPySuxYhvtE3LNNeOROfKU8iaP4/sTWEu3SkHEDNxd219fqdtRUwKwfA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-crypto": "^0.1.3-alpha.1",
@@ -2017,7 +2017,7 @@
     "node_modules/@deepseek-ai/dsh-compaction": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-compaction-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-3+jWL6F3vU4mn8eRRB5wtRRnqsHlS7PgMJr8/rYdAkzxZe19cQEZNHhEAUZ5cF5wfzXgmPP003kzMgFiJZS0Bw==",
+      "integrity": "sha512-wmQeEegu8caQMnlsl4MqWmUT780gULH8tdHdrgCVL4n/leTJoOr/G9pvyf0G6QL9OYownTkr8n0+WBHknBJnsg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2031,7 +2031,7 @@
     "node_modules/@deepseek-ai/dsh-compaction-basic": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-compaction-basic-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-D/ogob7cWy9fMQXGMvZtKiAfNZH3nNxkD/g1bKmUGi2ehAAGCsm+E9bN/h1SHryABUbDYxqZm7aO8ET+gugVHg==",
+      "integrity": "sha512-XLyZVEOiAiEAOxkTNlQmcLHH5Unmoy8qJLKFbs+DYd1sTk4d2gUgPgGTY3POXd1A+0kkdhzWYsbH7lfDu/p9OA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -2056,7 +2056,7 @@
     "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-compaction-tool-result-pruner-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-U/irLCZO6XMWEfkwAwMmkzUQH+eTwBMjsUC3wAXh644jCAbHBLlk7DkN7kaUcmv0NmtP7eLBV4qmzyoMJGkKKw==",
+      "integrity": "sha512-eKJkToZAFshTOqDgLg64ngfc4goucMcaIrOkyQOw3q/CYpGjCOtMliHA3r7KSzcb9mRgWwCSVP+WoCimIU6rnQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -2073,7 +2073,7 @@
     "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-cordis-client-runner-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-hn10+NghrFzItkWsAhB9Q4J9/BgHNODZLhf2eeRU+YTbAb/x8WvQ2z1OFOAJ91U03woiBlED1M7UIozSIjsEpQ==",
+      "integrity": "sha512-VTb884IDAgXXV/YFHKwpT+5+GiREjrhjLZBG8SsWEBxTBlNL2PWwHSU5eq8++FDMKQ8N7r6b57MWUMrF3I1Ywg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
@@ -2082,7 +2082,7 @@
     "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-cordis-host-runner-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-GcS1gCOYqUr/8AsZgaRrMuoyilWCL9NNPqb2p71P/zvL61Mdc2Ydem0ZaBgREe8moAfG5ZBz2tgEK3ic2aw4zA==",
+      "integrity": "sha512-jrLuFvfr+KVY7TY+2kidb+WYMmwz0EbEsP3T9Zj0YoLtuZTFoW9Bcswin0I4YQCZuIFFROEXfskszfizAYBYQg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -2116,7 +2116,7 @@
     "node_modules/@deepseek-ai/dsh-credentials-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-credentials-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-M2CJQFXPlCZxsQiLLtORbPOGSkcW4gD/bQ85XLyKXLslLa1ovdqOkqY0WtShqtRsqv/cqv2KJJUAZnUmkBUSaA==",
+      "integrity": "sha512-rH5utx3e1HJLwdgo3BcPV9Gp8lLvUd8DwP9Voj93hqd1wvubl8TRg66DVtT5v53UIaX5TVcqMtCOxLWBhrAiAA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2152,7 +2152,7 @@
     "node_modules/@deepseek-ai/dsh-file-reference": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-file-reference-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-C6v68NN+qi+poocU2+NMEJqxtTuxS7j4xHmQt/qyU+mvepXXUTse0PWm1yBkBpnOQuVqxj4rBGZwfiyyMMBoWQ==",
+      "integrity": "sha512-GnNSwdIS6SSLN35mFbW8pFp6VqtT3lyoYzhkrtK/gP5H9O1XlgyXG7jm/0BvK8au2i3wC1ct+Gyo41a+hWkmWA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2162,7 +2162,7 @@
     "node_modules/@deepseek-ai/dsh-file-reference-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-file-reference-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-1wYuU7X3kLdYfef809CusCaJRNLQhyADl4LgfDT4QPPkJtFLaTxIv71QN51eRGYwZ9WVZXX17ZEUffvq9kumSA==",
+      "integrity": "sha512-818sQiqM8ti6naX65BNlgKC7QRopNl3GEhgkvl/dgPFahtz3VL6XfXWOt2vZx9AQv5d9D3RhXv7a1sj4sDa/WQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2178,7 +2178,7 @@
     "node_modules/@deepseek-ai/dsh-fs": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-fs-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-pU4ZnCgT1NXpJ1TTATTCasd8VrK5zQnXbkBXo2SFaua5YWC2iADZQ9jtdiwCFACJLBwcujJQemWd6nUUAwLOyw==",
+      "integrity": "sha512-yBsAAHkUD+qI4SSK1nltaNGr2Pw7XYbR58B8WABobhKcSov2L6u/tJhf/E/WZXQlIQzgNWSgPx6dGYDcnpAFZg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2215,7 +2215,7 @@
     "node_modules/@deepseek-ai/dsh-fs-sandbox": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-fs-sandbox-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-1xAr7ArawSamsOsRZpRBakuo60F7ie4BwaL3tzS1kyaCxw3dl4HO3jfvu+76GAwJsXhQZIC9RI9+yOvFJxG4zw==",
+      "integrity": "sha512-ouBcpsr3SCIOicFtohTHehuDrborzUyoG4OwYk9XkvTquXk2CHeD7Lhs2VVQtaOsVPozfWbkxHYCyM1vHL7oQw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2228,7 +2228,7 @@
     "node_modules/@deepseek-ai/dsh-goal": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-goal-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-IBmZyaZUB64Z/AYwvEI3g+qnTpRdZ3d1mBavp2cQZjv0q5014zgZFcCq2zzItPORiPrqOEgcCQ+N91eA1khZQg==",
+      "integrity": "sha512-8jIqcrl1iHW43PftETwhrYbqO/yF+ypCtCt8tRdVEWTtmsrn7nPKSiqrg2u7LvgXD+mlND4sXqaD+9jWX/2Y2w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2249,7 +2249,7 @@
     "node_modules/@deepseek-ai/dsh-goal-round-driver": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-goal-round-driver-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-x55XFOfO7mtCq///9J/yY7+9KiZuE8+diDcrjkRSRooEGCuL54Q5ZUTT+L+LNrblmzHCfyYah1fbXECgzNEgow==",
+      "integrity": "sha512-p3PZ7NI49o2r9cPJUAu2G+BxdLA+hgf5+B0JF5T2gzP8FbjpFQCVVpV/09FUMZLrEiZ74WsLh4lvq4G+5ldcIw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2263,7 +2263,7 @@
     "node_modules/@deepseek-ai/dsh-headless": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-headless-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-w3fAOwh8AzIisDP3mZ7j7viXWqfsDz3zcMxtD47i4bDlW9cTaq/K3+ID0BXPHFJ+qaEwcddAOLxwha4n1o71qw==",
+      "integrity": "sha512-bhUIqinI9NsuJ3LKm0WsOjWLytd9aQ7MlLCz5++yPa+n6X+LmtxgE/kN7qqtlj9GUtMx76/kaCqK67TGx1i3BQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -2294,7 +2294,7 @@
     "node_modules/@deepseek-ai/dsh-hook-protocol": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-hook-protocol-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-VSQwdUJCRcVNfAVNQbaM0wrq5NfAraIRk9MiNYi7v7KFwHWtpWfeHV+QRj/EW3bJAaqhjGwbwCsoh0srqntrMg==",
+      "integrity": "sha512-F4+nnD5jPvqv72t/oYiYeqlhAIfA4L3Iz6KTJlSEL3N0AtfEb7LGi3KX4PA4r30F95OCJIdK+lMMMD6kcIPFfw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2306,7 +2306,7 @@
     "node_modules/@deepseek-ai/dsh-hooks-claude-code": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-hooks-claude-code-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-gL1+WaIXHByt75kxe3XSrmOeBIv+gg7VsUFRvWDGViIGcEtcp8x5+B02jLLnMhBgBQN+NP32ecZ8qc6efgWcZQ==",
+      "integrity": "sha512-frZG1+3R+Hi+Zfo10zqxIa9nHKkUISXT/qLocE2KQbvyMroGxz8CU5E25C+avQ5lkBko0YgqK3dczroyjMStoQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2325,7 +2325,7 @@
     "node_modules/@deepseek-ai/dsh-hooks-codex": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-hooks-codex-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-BrPtvym8etjQI9oy2OZMPsCW0rBwCTV8lM8fSfcu9fO8Do8At8pHg6UeOSB0HJ8YfTGvPGV+5thMZjSJjy7Niw==",
+      "integrity": "sha512-qEtXdhXwfWzUroylPIaSuClYU1uUrqeTri8i/xH8+gHyKRc23OG2fnfDAn/zONFGHHYkXRj5YHLiadshNTzZ7g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2352,7 +2352,7 @@
     "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-host-directory-picker-auto-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-ddI+bJvZxKR971odE4FQNsWQaHnQ6o65wHVtyppk+PJcfzfw8HaEc7xSct/qBDXCZujoRZ6pLgzsijBtdIRyGA==",
+      "integrity": "sha512-qAbFQurhhPyKA/orqs68HNyPH5uAmjWozf5GcJ2iBERORE069WJDaygV2+FvD2nnG0tbN4wd7UCTo6IJ+23xpg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2394,7 +2394,7 @@
     "node_modules/@deepseek-ai/dsh-host-frontend-static": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-host-frontend-static-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-tU0KRCJFXmAcJcHeV0YukyVEQ0eIpRB0hpjF0sNjdPJYNQbPTigWXwv1qNxbG+54RNkCucIEi+KXw1YRFRUcWg==",
+      "integrity": "sha512-osv8+pEARk4aawfdRNYemhjPkIlZmCHSlV1C4MGcqHHneN8ZRmepjyNiEg+HZH1gnS2Or4TpCeYakgDoZf9flg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2408,7 +2408,7 @@
     "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-host-plugin-inventory-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-WbDCjbby/wEfO1FYGrKfWAnIQhmvgiuICQCaXUWvdcMtfi6KtsQoTyepJAmdctS3i/lqgKDIcWk56/b0xlrelg==",
+      "integrity": "sha512-guS8jq5ug+e8rvUzzqHIy8z/Xy7lF759LcisuhbQlbS+NZ+RGLf1ndG6eJLbCuwFmlr+YSBTnzqoUxx9H+w7SA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2467,7 +2467,7 @@
     "node_modules/@deepseek-ai/dsh-jobs": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-jobs-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-DH1HZBSJLwvpSTotFg3ZAzO/l/jEo2ht+QzKVS4GYp0AI+Hqi3owGtVyX6y9WyRECwR6iaOYd4yCuZxSsdHMhA==",
+      "integrity": "sha512-+MakopZMP4IijrGqjkv8D+DAZgegPf21XyBOjBnppGPHFUPzaUwhlx1WQeW0/wSXMey/mKt8LlUdgVCs1vv09g==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2480,7 +2480,7 @@
     "node_modules/@deepseek-ai/dsh-jobs-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-jobs-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-kFd8i2lYZy9uJGJ0tFl1MPE0euoKgW/eKdzvujAkS15gpiC6pPx6xVIoLOXrx3QiyQYMtNiKx5X2l7jR4aS0ew==",
+      "integrity": "sha512-3wxbfs25nCzbfA1qJ+CRziVMoxKgnf5p96gEwwnq3yXBCsyU8K+bzJm7IhTTVhJpWkMC6/1Gx7zMRiYHQCk5hw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2505,7 +2505,7 @@
     "node_modules/@deepseek-ai/dsh-llm": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-llm-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-IlPXDt4mtGzYsEAFemfE0xfALRNjkXZ2P5GNM+IMaw2LiR1D1jYHt2Kgo9gEFk4EXG+dUngvpseUmolBlFc+pw==",
+      "integrity": "sha512-81GDc12uyoNHlecnZBQ+QLyUKAGJyBLWOGDg2BMhfGqmnfh/ThksQdz83kCIiAD5rXPm+QnVyTrFVsIBYam26A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -2523,7 +2523,7 @@
     "node_modules/@deepseek-ai/dsh-llm-deepseek": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-llm-deepseek-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-4LdtCUCikcVMRT8vPrBf5/l3rz57TRGeDTDJpuLG1xoCFQdogoQbgpfkKBEHU7I0zmVnADhOiUepDf03U4Vg3w==",
+      "integrity": "sha512-2VKuLQPFuOOJaXwF8WYowo+HSserkycHEbxYFYAvX0yt3CmpXfW7e//J8wuvNLktQQ2UMkREq8ZIPahGfcxcSg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -2549,7 +2549,7 @@
     "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-llm-pi-ai-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-j4RXZvaeKyQKkd2H7nY7yjK1yFegxZgI1hNIgYEMKkjlhXSNdyY709rsNHyWuDHVcXadQ8/9/lhgYS4aDS4YXQ==",
+      "integrity": "sha512-GFdfCXMbz2u9ACsKySh0/4NtjsRv2CoNls2GOtjSE8oAnQzqxuflR+8LV/MpZ/J4aXT7ubxNNASXcvN+pzbyjQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -2572,7 +2572,7 @@
     "node_modules/@deepseek-ai/dsh-llm-retry": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-llm-retry-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-tREkY9tstCVX7t2LY6Yw9D8JjUhosLZ862/jz2xODfONkEQrEOI6vobVnd9itr2Y84lWQqj1S8145vY0ci3ITA==",
+      "integrity": "sha512-Z6OVhl5dUyM7xuxldVibG85OdUZpHUenyAGmdB5zxy51t3itHy8g+lio/8ov0pVmQ2fBh+w0cPNywL6yJqiexA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2592,7 +2592,7 @@
     "node_modules/@deepseek-ai/dsh-mcp-client": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-mcp-client-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-l5Ua7oeUKYzjRB+iG/LGwRA/2SzgjnOB62Fm+6vfvIfDdCvZZGRMDkP9Ryh4XG5TziL46EOaPGcw7f/FR/AQ4w==",
+      "integrity": "sha512-ZiO1qMRT7f2TF+Q1Af5cTOPjJAdCkdT1HSNRe/VtiAIpPEIp5x3+nK3veIsi3jZIxLGPd8nlOD1m+96z4YYIow==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2612,7 +2612,7 @@
     "node_modules/@deepseek-ai/dsh-message-feedback": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-message-feedback-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-jNyXl24Z0AoCSlW6y3THSzq0y7V8Rh3A9lS1ZNBDIaGp3WEeb9fAV81ZsPiq9duBfgYlGQEsZOhtUFMqzMZm5g==",
+      "integrity": "sha512-ArL50l4p38tZqzQRnj6BkqvnGAv8st7tnRLK5G1TAgH3d7nL8yr4L5W90MZuH355AWSyEiHys3iIb+8B+HVtXg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2649,7 +2649,7 @@
     "node_modules/@deepseek-ai/dsh-permission-presets": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-permission-presets-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-W23MrVOihSxzYJniDMqx5dZVVGwben1O1uOjtD5UtOAlbX0iLRpG4LB8fhM/KKvcpAxKEAa4xW+Nh/YcEcjsnQ==",
+      "integrity": "sha512-5cb/Lbf8Pg6NJfNjklI5fSNzmsJjyer2mu6FYOKTFwxPi7DXjPwaJwYe/NZdujkFjTya2OD8z1g8+Av6oswAsw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2671,7 +2671,7 @@
     "node_modules/@deepseek-ai/dsh-persona": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-persona-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-B8+dBXkCPdnMWXLu29fTUUMCXMW1sw9yBIZKdEbyOt0BdPCN/+WsBnA0hc8BV07G9GUDX8+v2pCy5FkqPW8f3w==",
+      "integrity": "sha512-ULUzGpkhyOZmowOfxDzHAJSwVEi8eOvQThEsAeShQE4K0051l4JCu7HhIsi2YSDf59lN4QYSxiZ2sA0DisbtjQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2684,7 +2684,7 @@
     "node_modules/@deepseek-ai/dsh-plan-mode": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-plan-mode-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-SgTGCKBLaPvCkcFFjwPX52g9uzb2rFmf6AILYF/YkbCBn9S/GF7Gx6GALjtFDrmiqGTJrRDuSlBUakRmmvSmYw==",
+      "integrity": "sha512-AXWkky4g+8a6fmmS02gYKO2RQciVZ6ft+2Zve83BXBoDKbrIcHghqTFfP0Yeb4G/06JpFE0FOqRIezdjO2Pnsg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2710,7 +2710,7 @@
     "node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-plugin-package-inventory-deepseek-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-zVmr3Pywx08K5o0boNFx+3G1s5scyA4j1Drw87ejwXhk8QAS6v6z2iD2wPG6FUZ3yyuw8WgSqgoO194sTgtWGQ==",
+      "integrity": "sha512-i4UKRGUC/Q0UYa7d4aiu9TT1VGbjmxe1OD+kPMGfBc54pwHVnEPbGVzD14SKqDaa9XV1WiNBjsvTM6RmFSZYhQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -2733,7 +2733,7 @@
     "node_modules/@deepseek-ai/dsh-pwsh-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-pwsh-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-t1g+ZzVGFqed0n3zSqUGYhlaEZleT7dCCcx2I5XKvR5VpEvJltdBkdvEDGHslmXUXLe7u+C94V+zfkDN2zUKPg==",
+      "integrity": "sha512-Zc+iw+MnM/LhHDAIY72gwwgMjcn3msfp1/FJIPC7htoMq3+tnOgHA5ZkSdqv4B5BmuzO7kwCnBHyyWvFXiFkrQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2749,7 +2749,7 @@
     "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-pwsh-sandbox-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-trtpB5a4T3zq/Ch2S3AIhOuSyKKcFRjWwnpsWg8bF5Ifo5msYXQp86uLKUX214/PBarQ/SBLY2wCqNhjJPayeA==",
+      "integrity": "sha512-q39wXywEGhjyllP0S13X54vOBcWVsf0xNIAuN402EyAjCnDjRW5R+DZQwfQem+2hqjMJtl9cqEvTgAVEhxdl2Q==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -2762,7 +2762,7 @@
     "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-repeat-tool-reminder-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-upkpiNwT+2V4yUe0BP0dvgq89mHw4mJ4ZON9/Mr8YdQd1hsD5Z+T6NpX5I1+qwk2/BLb4kxPwlN1oSRV/IZL+w==",
+      "integrity": "sha512-//Omsek1ojBP3IMN1ZzilUGthmvLoCZNW91I0XnXutTYFFNdKgOcL9041UN8guiGV8tuAw+cu2G4GSk5lg0p5Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -2776,7 +2776,7 @@
     "node_modules/@deepseek-ai/dsh-sandbox": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sandbox-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Et0A4UWKV4hGgqCQH1YWLw9SmgBFFzetky0nkRyneh18Jg9w1lzJWR5+l0Q+NSODwWjVxPJ6/CMJsofFzlONig==",
+      "integrity": "sha512-Jk5K1C6s8LdZyT8PdpC3smkJukzcf8Qc8o1J1RZOHPcWr0bskewsRXN11JCLzheVT1Q4lmvdiX6qvU4Cby9lYg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1"
@@ -2790,7 +2790,7 @@
     "node_modules/@deepseek-ai/dsh-sandbox-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sandbox-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-K9nfbD6O56m8XqEWt0cKj+mEJDRgzw9GlBcuelYlgdLmo3KqB/WYXFqd6VWQC3MNXx88FZXDcKJBsY20GimWAg==",
+      "integrity": "sha512-ktorqmosBDwdiLVIDfZMI6ddTHSla0JuCkg49b26g86r8xrnqN0zLoxSJUi4PreKjSA25AHph+G5v2ujZMWshw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.3-alpha.1",
@@ -2808,7 +2808,7 @@
     "node_modules/@deepseek-ai/dsh-sandbox-policy": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sandbox-policy-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-qCS9GSj/yNns9saK3kgdtnTrCPDrnLf5ABydw1hHte6VTw45HrYFT4RWDzgUyefI4noGkNDBdKqntvHBxKoaRw==",
+      "integrity": "sha512-iQLG5cztFnK6NGMm2Qy0ymChEbwYXaoQHDQhrG7hbGa375s7dsW4tB9dOzr7n0Uho5j563mSsSXYvZBlx0RIQw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -2827,7 +2827,7 @@
     "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sandbox-windows-acl-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Mm4P7Je+o3tG2QE+STyyxbsx6Y+mSrCKmM8paurZ+MRV+GTuNsWCXCneEuUrPOq05NfkQ6/pQCAZj2hrPKrz3A==",
+      "integrity": "sha512-ss+EcdzYDXaGgpcD2nTMqtZBEjsqk6ZwiKOJnvLGMX+izXzMNYRp9fQ0xjgwrrylkpSafLIF3kyTOhoZuOsJFg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-win32-process": "^0.1.3-alpha.1",
@@ -2840,7 +2840,7 @@
     "node_modules/@deepseek-ai/dsh-schedule": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-schedule-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-QTAgFDJOrgjJYUgYv/dc6QYvfyu8Ys3DTr6hPp87f3CVmuogobhU9Gkh3h8kDE/Ydmm7S2GunL+Whycg6RBY8A==",
+      "integrity": "sha512-w2CebaaPg8IbedT3AQ1imbuWjJnRXsCujgzsAtACbBv40riGU3TfrX3l42BQO87UMSAgNoqQozQFNxh3zxWZgQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -2870,7 +2870,7 @@
     "node_modules/@deepseek-ai/dsh-sdk-app": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sdk-app-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-BiSjtEiqLgPVgzbmTxKX4InAIIZhQGBAOBs89sTGCnnRoivqXel8UrbVatTHBKmLsegwLfZOLH0A5vxJvjNCag==",
+      "integrity": "sha512-d1USjyA18CpBPGR2aL2Ecrb/0emZHx4oUFdZCmenuDlngJWw2RQwxlmxpL4wgIM2sz3mVzlWBKwUChlsyfV49Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-cmdline": "^0.1.3-alpha.1",
@@ -2885,7 +2885,7 @@
     "node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sdk-jsonrpc-server-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-7QQUIixqITJQOuY8zEia/3NYIJpi1ZYIQh8WaewrJxGTLEVxGaXZbrFvkPY/9wwNUYj0sirT66Mlm0TCk4+Rww==",
+      "integrity": "sha512-3oIjogkJaYEAawJOhtCxV5nzjHtX/LEr4KivReB/fnG6c0xob59vBLzUEyc1yoaReLuAwSHRx1gO1w0710bGSQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -2906,7 +2906,7 @@
     "node_modules/@deepseek-ai/dsh-sdk-minimal": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-sdk-minimal-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-/1SkwWMn5LMWV9yUbbSDU7jV2+Ii5mWAlmySJNAcx87i9+2IFUWXY5pe8WUz/qn2AjubmyG3g19TUObHaNdG/w==",
+      "integrity": "sha512-x2dEWfmx31g9tu9gHAQyJPeNBzk/m5T5/TKG+MuB2PZV0/ZGPz8964z3QNoFAWtUPpYF4FdS5FtlkzpisBX2LQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
@@ -2973,7 +2973,7 @@
     "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-checkpoint-policy-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-taQHR0490pJgJ7zNS4Ola3udahZRvBNrZiOgVoqo26PAUZKAzf5mkAy6bgwUN1JK3K8ai+HgFKQoZn7Mp5G7Tw==",
+      "integrity": "sha512-qonPIB4XxMrgCPNlKyDRUQxUdI8c6VnQakVv2iguuEdFhdu+9QgaH1BikO661e3rNsIpnqs/PtamARuqCV5DIQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3014,7 +3014,7 @@
     "node_modules/@deepseek-ai/dsh-session-format-v0-to-v1": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-format-v0-to-v1-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-uDR9mSPURPuxwXVNljidXfy/1SGK2EXrxWQAN2gQ/5S3O7OkSr1bO8T6pXwTPoSVjrJz0oGBo+R4KtSU2N1jZQ==",
+      "integrity": "sha512-gm+U2Nt5NL5vlcASgZP0/lBglkQELLNzcc6VrASgo8JRY/vYajelGGkwE04C4PuyRe5Ck7+X8ezQPa0AAe0ojw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-session-format": "^0.1.3-alpha.1",
@@ -3027,7 +3027,7 @@
     "node_modules/@deepseek-ai/dsh-session-format-v1-to-v2": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-format-v1-to-v2-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-QDYlHNEvCRj4GZJXW6ZtJbe/FfJfdvfp3w0g1egSUu/+e0GAldJ0bmDJiCVFwPaBELVtDbCYqm5JTjwQ5PyOCQ==",
+      "integrity": "sha512-sLPgls36xdC44yQuxfHPWwZ19cdzFIAzEKBsi3YbyAI7842ZHavugP0h6EHHUi0+BfJnSqXqanncS6KQ6VLTYA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-llm": "^0.1.3-alpha.1",
@@ -3042,7 +3042,7 @@
     "node_modules/@deepseek-ai/dsh-session-log-deepseek": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-log-deepseek-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-aZAGe3MPI4wnCyr1ZfG9+DzQFOz+DWBFqzz+f+CRFXv9Iz70x5JvnkpgAW2WMZD8pY28w/55iOk0+0wKt9oYBw==",
+      "integrity": "sha512-60SlyHsyQmUjZc5rw2KhArmZjQCyGwwjSfxU2r0uWdBM93MTMms+bByzOBNhMZKipUQgCYinKm9hqO6s1JaZ5g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -3059,7 +3059,7 @@
     "node_modules/@deepseek-ai/dsh-session-log-export": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-log-export-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-qtpt3a1iGavAlQXh5WBoIk4hbYgNYW/7eGluCMKBQsvozCeuKsxAj55Q2CPbVbhJ9UaD7kuzKCB7QSVEpGXZcg==",
+      "integrity": "sha512-V6Zib6KBu5JU4LL0AVuOEof19FAfyDnVCABt9666Tb6VV7VWl+D+hugkHGt0ZNSZ0WOB60nSiE8xtvoDdFxyVw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -3076,7 +3076,7 @@
     "node_modules/@deepseek-ai/dsh-session-persistence": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-persistence-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-456w5iN9SXJ0sAKcGWq1FsOFOzYl6FRx3npoieDzGUGcXwA8omJ3zoLGlUwaqaQrGMlmVY3KFY0lxSK8MGBGIw==",
+      "integrity": "sha512-5zXDK18n1gGzvs3RV889OCqvy4f2uRkaxKKpBgtFz5SFDzL6dAoI6R1uONoXcImUrluG0EoukubQpP/mlCQBZw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1"
@@ -3091,7 +3091,7 @@
     "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-persistence-jsonl-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-mHLKHfZTqMnButptXjdVxQ6983ehgjdE2KHIs3uG0W0oFzErsQU6PewA7oFqzONXiScKiTTdeUenoqmSrePTQQ==",
+      "integrity": "sha512-kAJdcCFUVTEVfP4X0J8CzCOrzw94qXsKwHJPGoyleqeXDSKbGm4KzPEAVXRaqKeW6ru3wI3Zgx+Nwe95rn8VCQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-session-format": "^0.1.3-alpha.1",
@@ -3109,7 +3109,7 @@
     "node_modules/@deepseek-ai/dsh-session-projection": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-projection-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-ZkpT5RvNp579thdTth2VzhpUOkTzITOf4nhklnsvH8NErJxxyVFa9/3qls/sKWkU7TM/gejST3a/uFSB/NU1hA==",
+      "integrity": "sha512-g/ZFZaBts/TbaYXgn1Pk6RGw3b6YvPiV3sWte85E+Dl17lufnVJfim3FiY6dB2pk8AgshaREMYWjcKsDbkJSmQ==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -3122,7 +3122,7 @@
     "node_modules/@deepseek-ai/dsh-session-projection-cache": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-projection-cache-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-desxQzRNZPsLtMZAHYSnJiGOgxCg7HXS3Hsmx14SUWEct9eeAHisCMyEKkXsLS7W0awr69p/k/gieZiUStk4XQ==",
+      "integrity": "sha512-0AkLxxoB/QZRvHnUHXRm93RckVbhURDWkx4ojChzZVP/zTOu9dq1gajnAXZt0queuYS/4BydK3+blDxdazQZfQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3139,7 +3139,7 @@
     "node_modules/@deepseek-ai/dsh-session-query": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-query-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-FD60suWybg1249jAvZCoLWXFSmLgcSg2uu3ZG7VBb5uIDrdI37TeS31JfSvB6R+aSloVrxlOfyDEWxlovR1aGQ==",
+      "integrity": "sha512-7U5WgDUFrrWpGDMntdJGJEHybVDuJtoe2Z3jqYAtA2Xk+OxCQwd+w/fbedafn5ZnKkwmYs86U0adkA/0oN//CQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3167,7 +3167,7 @@
     "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-query-sqlite-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-/U+FmpEqnPdeWTDl9d7GUauT5QQ8+YLMGccIyGnIsoX5QBNyn2DQMmLNd9T70+H7ZAszFYO5rg4og7Iv9jwqeg==",
+      "integrity": "sha512-/c34jgNhW1ka/XhQ7tRqyv64fa2wJDbKjLBRmpNOtGjqLFNGxbt4dtfY+Tt6NTuP2MnzgKisAQK6VsUUFwqJCg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3187,7 +3187,7 @@
     "node_modules/@deepseek-ai/dsh-session-reference": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-reference-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-+n3+TAVl38FRXVFMdpAXdkhgbJRXdAc3cT+iIXbYCjxzWyvZOsQHwv57xVggWxjd8EqCVMo/+fflZjMOSL8TnA==",
+      "integrity": "sha512-2prt5Sn5tt99UtV6RHMjYSexp18/yqdUyGDxZmdenaa4+3ZjIfX8aqyp7xsoH16h7FBrmhc2LWqWp4+CROF7fw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -3217,7 +3217,7 @@
     "node_modules/@deepseek-ai/dsh-session-stats": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-stats-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-kGvBo5u7b0xj51pqRGKkaspH7gjKTDAgRdwKO2kj4ODihBPDCus2Cle6dyejLKRpZeBg3zL/OQU5b5uKZX8yzA==",
+      "integrity": "sha512-AUb5dx1E7reHHnF3+30sMLY/RXS2Rk1nqx7ZD6uehQFfZRfNTeH9akOVAJxH2sqy/uNkf59A723917bP/rKslw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -3232,7 +3232,7 @@
     "node_modules/@deepseek-ai/dsh-session-telemetry": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-telemetry-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-VxBtQWw4M/iFanzIdZFFD/QLjDzHLuVtxw/KaEqWAVsVQ1MTBoQb8DGRVrfejfopOOIx4XmsY1U/59jrxI2aFw==",
+      "integrity": "sha512-7Bcmjj24ip8GArGovSfj/8XyZMJpoZjvpAS5TG5zkEeBlLXt0CrWSlIcebTyW3iTwZ58ZsdM2Fl7pleCeKLrNg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3243,7 +3243,7 @@
     "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-telemetry-otel-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-D6Vexh0jw15dkNgJeziV/+E+pq27N1r5UHgrQZKGxyMmc2jPNrNCTsY9XHBEbOqOrC67apPNOE6F57NRXLMSOw==",
+      "integrity": "sha512-2TG1YCkOA8OOgyao5sh0hWYA2cB6/PJMv6QB++h0lFlHB/DBda2yGXCjX/CsxmLiHreoIL3vYaTJ3HwIjc2X5g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -3266,7 +3266,7 @@
     "node_modules/@deepseek-ai/dsh-session-title": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-title-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-ly32rE7SYIm3ziAf6i5riBhdnKvo32lrIC8xXuTpyJg1OQhkQ6Mk2Occs2YbEL2mWUyctWjZj2gWt1gswKMTSA==",
+      "integrity": "sha512-W+t4OReLirMu9Y+EVR6jDEGtLHqVUoU3Gc1pwZrbPhCxsu85E1l+OZV6jj3kMaircWUQqGT/IJceoNpWNa7e9A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3286,7 +3286,7 @@
     "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-title-first-prompt-llm-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-FchrDhPnDwtADvvesxWIpLNRo1j9yU9h0ZEwNKDLbXhzZ18bxy1N0ngnE3+nCZ6yI5L4YhNv9mfKxoApZ3vJTg==",
+      "integrity": "sha512-GFWxlQ8tsCMEGJBE/hp/ogWg42JD+E75UmRi+S1i6iLPE+9s91XxdE5B1wSy6vVfi+MWxIr9XWLMJApUvY956Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3302,7 +3302,7 @@
     "node_modules/@deepseek-ai/dsh-session-title-llm": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-title-llm-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-8+VjiYQ4D8hBepBEiThD/igyhdq4jzNkJbRYJq/osHxRHoSxhJCxqGENV8xt3bBW77va9oKX6AzRTUUpnEQ4TQ==",
+      "integrity": "sha512-xvDdzDT7D6M4pdqZW6b7ctMPOPOOI7mqrbHm94JWcXjpoebjITvBmUpDS4VAJjvL1EkUbGfVtYPzWNCywxghrQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3319,7 +3319,7 @@
     "node_modules/@deepseek-ai/dsh-session-turn-outline": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-session-turn-outline-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-yJGnW4Xj/KX06d1ZNpiCXtj7F+2WoL5lR1grFbyBc2oLqU0E1E09ZeAR/OqeULgQsQZKQSlwfmMLSSLqhdxXKQ==",
+      "integrity": "sha512-8Ay+c/uw96OY61nkKSSpTLFItaH7YOksqVvPUeEgn3OK1VOi1eR/Avrp82va/IhgfEy/IUfkEI2seAhLNQ+8tA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -3334,7 +3334,7 @@
     "node_modules/@deepseek-ai/dsh-settings": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-settings-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-aLddaI2j7AxaKXGnW3VMC3r5Hze+RWbRu3FVUjYHwHzXjOO2F7bEz7/i5VDHTggBq49dDPHhz/kpyBvxKlEvWQ==",
+      "integrity": "sha512-vCluW2Bc+TfM8MUnB3Cf+p0VgCC5ZfFAhkX/2Iy7GnhIewbuY9djbxQPuGmcS0rmKkCM9ZqZ+Y6XTQpSlpLR1Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1"
@@ -3350,7 +3350,7 @@
     "node_modules/@deepseek-ai/dsh-settings-file": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-settings-file-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-bsGd6goU6+lvWpM738JLE575CA3wb2Wf0YU/F2oFdvXx2UE5sykhoJTd0XDTf5WzMuYDEDhzNpEc+x3mtEeOGw==",
+      "integrity": "sha512-NJEpGXk/aOkrgXObrQsGIefOD88JrM0E8P9Mt/d03sDfnBKTgyAv9rIPQoj4YNJ5XL56gyg3b1UrvtrFpGXg/A==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3368,7 +3368,7 @@
     "node_modules/@deepseek-ai/dsh-shell": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-shell-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-POyXuttEEjFHY67rFIG1rkkcQAZxXe9Xx2RNvpIM6uhjpygjL0w0OADk66bnvZgbzTu4YIoK7ybH5/c1mN9HCA==",
+      "integrity": "sha512-ZOwdme9laUdH+StXfG7a7DTRvfRdlIGIt+L6RGsN0g+qS5su6Acq0fI0b5NMlJUao3QBbJnFM1RvXqUEnTUQqA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3380,7 +3380,7 @@
     "node_modules/@deepseek-ai/dsh-shell-env": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-shell-env-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-L5MODMbZ70yufecKlq0AcXsoMbVbGtggHJfcDimnlcl9tzwfOxKcW/dNKvqsCxaFl70CR1220y9J4TGFjhZ3lA==",
+      "integrity": "sha512-eXgO1JbaVVGxxLga2C0PqbXY9dnpbRkIDvzuy/1HV63Bhr5d+1LhxADYFzbA/gpQe/w5MB0qCHgf7vNqanvHAg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3395,7 +3395,7 @@
     "node_modules/@deepseek-ai/dsh-skill": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-skill-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-uXKo6amzPPJ/gce8dgrZwfiT0pAO6svTOoWR4O9WkRhXhDFY1lsyQ20c4eHJdgNsmt7ADcw7m2LwegS0U7aQSg==",
+      "integrity": "sha512-bBw69JOeodFBpmpnkNmiOncVJdvm0jvSiaWpJTWXBz5mIQe5cqIUUr+hftBaLnC7Oyb9Qjq+4wpYv73QKEwwcA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3420,7 +3420,7 @@
     "node_modules/@deepseek-ai/dsh-skill-filesystem": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-skill-filesystem-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-V1hlOEtFIWTB3t14F8Bvt7sQAnCa+fwDqlf2TgXaxbHduBETDhpOY7u+l49Lb7y1TC0ibA9hT0KOJTEA2CLKuw==",
+      "integrity": "sha512-0aSLZpkQyPYFI2qPZu8mQLr6KFJ0y3nkJyeg+2bkJfNPvYQWUEkpM+fQrbH/iRgBX4OF48nipa+hEvtkvyVY/w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -3465,7 +3465,7 @@
     "node_modules/@deepseek-ai/dsh-spill": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-spill-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-wPygnfWJsOzoVHr/BtB//xBwKIZHxZiuHb9EfETPnmZCvqMyOBDuRfXAkeMx3WaxCWyj56Cv9glMRzU6WJGUIQ==",
+      "integrity": "sha512-QQhmk654ajjhVCbOEPPa/eFLe7Q2xeKY3AVZwRlRzi0z2P+kYTy9/vMCDuHB339/3q5LQQprrkNDxWmEHp1drg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3477,7 +3477,7 @@
     "node_modules/@deepseek-ai/dsh-spill-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-spill-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-vJTWFjAWhtTJIyxinYL8q3Dn00LXCyZE1WLnKrv9LDDSOY4YUh7yNo8iK4UdWBw8JX7IsrAalwmC+EYqKWw3nA==",
+      "integrity": "sha512-mZvVgOWfg5FZlzr8ye09Cvzf+JG/8OHeG/sorZsZSWShczD7l4W4Yj+S4v3IVRYW72h4HukM3nNDAPTOFFMvNA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3490,7 +3490,7 @@
     "node_modules/@deepseek-ai/dsh-spill-policy": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-spill-policy-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-BS+G1CT66ZO4MXJwP+sbDG/tbL9ajf5fiwtwrWxQHYjaJHUWUes1EVDFYvzPQ1CpJKyx3Q4Pj3QQIhvgSqAMjw==",
+      "integrity": "sha512-vjHEA9Bo5BPClffhVyZmugmgW4I/pcKAs9Wrr5s/CgK+jXwDssrZ9RBfLM79lPF9GJtJqLLP9iFDmW8Bjzj8hw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3516,7 +3516,7 @@
     "node_modules/@deepseek-ai/dsh-storage-domain": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-storage-domain-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-337CAfEUsBQKvPyKRikufN6OB+NmeJQfRt3IGyA4fv014TbiVm1CcG01QjYqznIcUrz4VebTaO2T8rHfK+vQmw==",
+      "integrity": "sha512-k+jOwRE6nMIavMW9u+rRjkwJ8q+yoHoxFl7XlkuacuruN/ObkBfwj5TbQmL2VdyCNz4J3yqHV0Y+KN8t+CRtQw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -3531,7 +3531,7 @@
     "node_modules/@deepseek-ai/dsh-storage-json": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-storage-json-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-nAKCmP6RuX+KTyqyLpKYtpRpsGLwwDVu4y8O5cXKEosSk0tNrBaZc8bmVAx4r7zngnfgsmHG3UG9TmO4XSJOlw==",
+      "integrity": "sha512-pH5wC4ZYGLquLrcn0yJaDDoRyNWv7Di544xL82wE9IWA9YtBmOzbUNQaeumMOucy0QTiz5+xWnEAQHFMAY5mnA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3544,7 +3544,7 @@
     "node_modules/@deepseek-ai/dsh-subagent": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-subagent-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-MSqymaXfBmDd1NgQoDD67rZbME5ufjU96G0H6fIU9/lCEA1+fAVyZZze6zr2qA5Sp8AiXI6tdQ/l9EtDlzlreA==",
+      "integrity": "sha512-E232Wei71vwVuzKDeMzzC5QJOThATjYNq9frtjHacrBcd+ftA6+mCUo6HsZcwSuPdRbvjf9RaxgZ8SlqGcb8/w==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -3606,7 +3606,7 @@
     "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-subagent-fork-in-process-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-pFLiMEy+9CRSxW7fwV5wpPzYmLuaRGQ4joZrzbpPdyRlUTaruXZiE56xwSZFyVank7BZQJQYD1gqV4P9b8vytQ==",
+      "integrity": "sha512-Umi+46lhcL2tQCqvXZns7X8bGpfE3BUS/1tgAhmF82xqKUhy3S0Dm6xCOFynky4SypaMLkBb05B5LSIuZk+TAw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3622,7 +3622,7 @@
     "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-subagent-in-process-driver-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-tjLukWmEY/IXmEKQhiz9ypLz6EmSUEIsbKXKPLC2+KtkCtTRN5HjZ/L02Dcr3va+lgddwwCfJi6rFEaDtW6hRw==",
+      "integrity": "sha512-vTrvjcjLq1EVESn15go06NtspTJ5eNmwLXzTpkfz7GetFm3FqimdfVmnZESbSd/FI0BPgZwN0pDUT4//VU4Axg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1"
@@ -3640,7 +3640,7 @@
     "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-subagent-spawn-in-process-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Tub6b8U9CjbyrS5ROAlIP9cpRsm8Yb3LDKY/uSYfsSpETE7MYxRqO5AJFHQMS9S1oQ95CL6t9Tjo9cRJd4rM/g==",
+      "integrity": "sha512-wOsx0dVpydwFaYgtvPkx+UC6aAaLUR2b05Vux13GIMSZkQId0UWvkhXU41q3Muzh8K6vloYeihmitYQplQoS6g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3654,7 +3654,7 @@
     "node_modules/@deepseek-ai/dsh-subprocess": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-subprocess-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-IrvxvQbHLxMrqR7T0iEy8mcyNTjhMcNPGrQbtOw3Orqg+8vn/SjsvSPRe4Awb7gjWMAlt9XmQYChAW60WdT7gg==",
+      "integrity": "sha512-9inaVQ/sXmpWyWC7S/1TT0iCX85Rn2cY22zgdRiNIHzjCY06UofWWR32qSP//0Y8oRF/f0OKkx4aLLOX6/Sbbg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3664,7 +3664,7 @@
     "node_modules/@deepseek-ai/dsh-subprocess-local": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-subprocess-local-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-OOlLbCrzQJUilDeUNzFaWE108JQaa4zRU28yhjQ6PRETLMi9lggrG+PjVQOGA0nvThXaPKgiyVZj53xJWTTTuw==",
+      "integrity": "sha512-MzUu3lwPL7FPMKRPDYSDQf++hluNnfmpCvQNCa36Any4r5W3VCTggh6Eovr4WAI54Fjx2cKb4hYKjhkt8JDA5A==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3695,7 +3695,7 @@
     "node_modules/@deepseek-ai/dsh-terminal": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-terminal-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-4W5zx6twH53I2ttz7htMxI6YzBQemvUHNLhqmhgUXEfWUgBWAJj/qGSZE0gsTYKLT7Pl3oMgV6fO6h0aPPYZcA==",
+      "integrity": "sha512-BsH42rbRedqeeW2mRtzolIhsG5G3sfuDTCutrkexuL66/Hk7kRlySI1c2vZPNyrUXarINpu4Hojn0Y0njRBGhw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3706,7 +3706,7 @@
     "node_modules/@deepseek-ai/dsh-terminal-bash": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-terminal-bash-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-GaOOGaeL+lgaKR9y3ionkcQs4ugW67i7DY5P4THzk+kyItuYldp4qU6e18r3RWYs8Ms8H03teqIyJUmBX91lAA==",
+      "integrity": "sha512-8p5vaselZ4uu2bmrgcRR04GTphM9byxNi2sfwh/z8sGvc9Z32RjTLxg7NmFYlZhIO24BWhOMfhnt8RufavpxVQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-pwsh-local": "^0.1.3-alpha.1",
@@ -3727,7 +3727,7 @@
     "node_modules/@deepseek-ai/dsh-time-context": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-time-context-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-vnCRakKA/s218CZFa05vEYbnljwh+DvGmjfFAmAnYdbRDyciSjBv+b3GsKDOL6FHypn8zTbKRXZUI6xy4Id3AA==",
+      "integrity": "sha512-XU6KKXq1i92n4zdv5QRu0E1ATZJy8tG+N7cNIDQgGNTW9y+oDi8mXZl4upFEunP/2onCVduGYG20VM7TnEh/ig==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3755,7 +3755,7 @@
     "node_modules/@deepseek-ai/dsh-tmux-context": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tmux-context-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-fOvuppR09iEQfYMS1M104VW3SLijV+Uexn8B7vyW7buPZ5ZYMWZkcFXEUaOP4TjHXwX1XFUE2qbbA2s27iPs8w==",
+      "integrity": "sha512-JRChaLSGLNXhDSN3B2wtQxF9VBTBCQWcv4wKK3Yjv0GZbQf4WfKCoz/tjGyfjwgQjK6QZAyb2/G5fW+9UrYOSg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -3772,7 +3772,7 @@
     "node_modules/@deepseek-ai/dsh-token-meter": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-token-meter-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-nufyxa/9/fpd0Hy0YX4A4A+ss8boKIfwZl5BGc6d1uYpUxr6gy+4s7lmfLiIhgL9NILBu/+xENhQoxfy4OxvsQ==",
+      "integrity": "sha512-BQ/xipa/2y1OToFvM+svD0yLxprFiamKgj++aRhkv8BbS8kg+hyRhZ1PFzChrITZ2cW5b+Lb64xQbK4c8K3hhw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -3791,7 +3791,7 @@
     "node_modules/@deepseek-ai/dsh-tool-ask-user": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-ask-user-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-8GxGcbuvoqFAxG7IbWcDyPAIHRPTsp65WsubYARLQgGMI+El2YZ6yVOcOrH4jKHLbpIGWZijLvnXxMZ8RiWnPw==",
+      "integrity": "sha512-ex3kcoKw/5hjCZYDZZrYDikRVqY+kyl2HMxNmW2PCgFznI3s+BcjBRcti4UQYCmanAdOZfez4AV4/SIVRN9zZQ==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3803,7 +3803,7 @@
     "node_modules/@deepseek-ai/dsh-tool-bash": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-bash-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-JwGAn3ttBlTchZ3rBw/trBVYFhhHgwiiB3lTjmi4GYwU1HGVJ4+q1K7UC3yH6yHpLZHTsbddVrdux/4uDoZ1mg==",
+      "integrity": "sha512-O8OMKmHST/q/amUnroTtXrkzewnwn4LLQqUT5OqnJxI7jcsKZAdveWsivhcfuxw/pYGhUCgbSHeOa6P+Uz3U8g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3825,7 +3825,7 @@
     "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-bash-persistent-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-0vScx9XWXiAZVn8P2fdaWvr/pP4dZ9u3DYdWNz8L6Exiecp97VqRKgSU2nLa3DZ0Owpfa6OV8QhbPj7DMUNTQw==",
+      "integrity": "sha512-bMLkt5nTIkzCf8ABQXlmdexLrE9oKaEEITbrwj2pF+Kbtrhbzcv//5HK2USm7ixV3MmFmxuOZbzfLqMqVsM25Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3841,7 +3841,7 @@
     "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-call-timeout-policy-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-/+Y0HEocM/Jxejz7m4aY1bXE5j5j1dhUuwf2wJoJu8KmL3Sd4w9hhSHmt0PPcx1zYBlZkRLeQFQhIKUxdz4VvA==",
+      "integrity": "sha512-Tc58WibsbTuewkoGODkhDPv+iT99m7nPgsSX87kbMO96XV0Ba/A7M2dVXpB366Z40g6Jr5C5PKdpM//fBpl3KA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3853,7 +3853,7 @@
     "node_modules/@deepseek-ai/dsh-tool-cordis": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-cordis-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-EK0HlBsTZSi76yvdl9QZNXiKgxmfi3dyTCFWon/3BLz/N1eQhBNKEOCVesHzY1OeFKnUlKpE2t6Fdwcw+o4SAQ==",
+      "integrity": "sha512-7gGMrKOJwj7wZS2thJkto2f/VWa2xA0biGOsIufBNAaAX88Y/yTM3R0QUgmV6qEMm54v4jbbnX2mSVuykfB3jg==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -3869,7 +3869,7 @@
     "node_modules/@deepseek-ai/dsh-tool-fs": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-fs-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-oCzJnIUjeAHNrqbfDX9cHuJcbguwS/ckuYTkwX44tHj7IbCSj+CQUVKaz0Ame3/j/XJ0nzMGgdMKn39Ov+4omQ==",
+      "integrity": "sha512-BPBWJ96j2GxmfbRDhcResF7zoIWLPtv2jUeA3nlMGmZNzQG2ahlh1lHEWYQgCnD2zMLrFyV8xnADljJGpcPCWg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -3891,7 +3891,7 @@
     "node_modules/@deepseek-ai/dsh-tool-fs-search": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-fs-search-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-XY5xgLkC6cdQVdKkgbLgYddfvrU7nKVjJFosJnDKFwb4AeMHUAtUy7Amvq1Ph0Um19YdKoQT1NjeMKDSGuNIyA==",
+      "integrity": "sha512-78ZRY1KV4hsB/s/6D+N6Dv+CIqwUuCT+hIUHjjlKDtAbPFf09WB6+jf2RZssr9XEFa9IFAUiUrZqPToO30cosQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -3912,7 +3912,7 @@
     "node_modules/@deepseek-ai/dsh-tool-goal": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-goal-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-CPHZXz+an6FP8/kQIGTz9bNI2DznI36emKABUm/CULZG4Vn+fPXnLK9ybpcag1nR5SIOJ+VWWdSwpEAYzeVjnA==",
+      "integrity": "sha512-i2xhagEICnH1wRb6G8FJe0nKLcbMPw3GTSk3cgMxM2O5l/Zb9yEC0yjskfQa2xmDkrcqmuTiEoOd3Y88W/hL3g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3931,7 +3931,7 @@
     "node_modules/@deepseek-ai/dsh-tool-jobs": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-jobs-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-eOc8BH+oiwegDpAjit5kmncy3ZiSE5EqnN6JshSlFfSYBQYDqf8+f9fu/2/mgmim8W7iEBIp0+3ox6Zq6aBigw==",
+      "integrity": "sha512-t3jXhWb3FSzt3t/mDy6v02bkzMgbKpLPB7dAgV5LhjCTxEWbN+TKWorKZZTROfACxM7lf5mceoMSEbPT4fqzLA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3949,7 +3949,7 @@
     "node_modules/@deepseek-ai/dsh-tool-pwsh": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-pwsh-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-P/oRWhsqn0abDatqdwXLxd+5HpqG7UeOKmtZ6ryk3ZzFfeYLxAkrQEpdR3g8uxMNb1JyD3WTHvY+1rT3i9cgig==",
+      "integrity": "sha512-ViGfowY5iD6Kpc2pHboiiUJtMep4A2EL4URYgGIX+vSOHdUv0rWR/E7TTkkW/tQ7/vk4EtEtPkIEawxxSWr/oQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3971,7 +3971,7 @@
     "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-pwsh-persistent-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-sU8xsP63aHMy0RJF+zwY+rh0CH406LKmpWvh0fKFT78gJAW1DDtZ+5GHHrdY/WE36pwALhV1k/W58gw5sgfCOg==",
+      "integrity": "sha512-F+VFwr+hN27dJs2jzDcUcbmacOcNw5Php57fXPGyLkIWTVKvVsRRF1FiGMNbgpkcTbMiKqjYLx9M2CCoG2ON5Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -3987,7 +3987,7 @@
     "node_modules/@deepseek-ai/dsh-tool-ralph": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-ralph-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-1ijV4eC13v7ALIONSOPCmwbCPaRkbKhfvdgqv4DA3nqNe3pMeaLXKCr5wIAcLkXQ8hfEi6XZIfSX9YB0mneYLA==",
+      "integrity": "sha512-2aRs+gVGplFZg3ul1MxYPUFVl5To+BNomCZU7wSXZTnPmfSdK7F+tLyKnNU1acuBKIaoFSJitQ0SgKrxqFVFog==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4005,7 +4005,7 @@
     "node_modules/@deepseek-ai/dsh-tool-skill": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-skill-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-eLzc182k9NwjIArfYpb3QP96JsXMyasL66yTqgEMxNzXzmWI1iUfi1X+KbL62116+5GztQosTTpb3q8HBUZW6w==",
+      "integrity": "sha512-gAfmUqSuJWty7ZuOoPxZ2x6V3Pnreso0Y3ppP/aSRYiX2dqJr1ewGqEcm8s/qTQxGxfU4WMpATTbjbGei4SCwA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4021,7 +4021,7 @@
     "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-str-replace-editor-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-UCvr23NIMrAvlBevZlCZqTMDKbNhmarTtfRqPgHnJe2/HaKtZqdCxnfXMSb8JuNIOloiZmEn/oUDgxBKxWR2Og==",
+      "integrity": "sha512-gKfLiqwy+1tc80lAxTtGS8JyOyLugCkV6FLlhKXj9r1eRh5bfiVebYUY8s+1Rcnpb9qtle5Rhi1mhfNym5n+SQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4037,7 +4037,7 @@
     "node_modules/@deepseek-ai/dsh-tool-subagent": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-subagent-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Kr1QMDti8MVOdYdxRxO5aFQNNCdV+Drk+h8qc/WxOaaNT9LAl3FKhG1ZUU2I9RmV7jHZ/qi35cAJEzrpsuc9zA==",
+      "integrity": "sha512-c/Uw2RR7MGPQHnxnPzEacOjU0iShC4jq6lp560ebRQmXdIDqz6jcwbTZdaUyolX9C+8vt0HwsxlGg7a3fiwvjg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -4061,7 +4061,7 @@
     "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-subagent-control-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-funcRMLg9Zde3rvg2oxeuvSs6PGlLQM8/ONihrvWuHBZNKeRajKBHxxkXwL7sH4Axi2qgD1chdtGWjf+2bueBA==",
+      "integrity": "sha512-G6NsewYCKsH/QyO92g28sOeg7GTLqEy1QMjwNVUPa/YifC0jexPxSAXQbzHSLNYITjYuuZp10RJaCr7kRCsP+Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -4078,7 +4078,7 @@
     "node_modules/@deepseek-ai/dsh-tool-todo": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-todo-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-jsx3mt+nHGg6N7EFLRd3Y6XhwroXXVOs1aOHfHodBhCfpXN21Vkzo0b8DuGgM7Shq3MUpLW0FUiqDjmqKJpGVw==",
+      "integrity": "sha512-PvXw34N+HWMuCUZ2VXJchtIZH/dZVCMmp49N4+1cZGt4SSE8DDPnO0dIv/Ri8zGnDLFOyLlKoDoyTXVSpmb5Fg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -4096,7 +4096,7 @@
     "node_modules/@deepseek-ai/dsh-tool-web": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-web-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-9tNZ+hJdD92pOUGiHTLF9k3aEo0U6NHb9DnQ6SWhhvy/oOJgE/s6Q3eseJNblXjrCulhkhvzKKEX/tzODH1egg==",
+      "integrity": "sha512-3okUBqeYCT6UK5dkYsPRE6xWJ6PZ/xtFNHU4zM09HpUB+VAHYkmHVcMPbaJdQoIZS7mgA8glCugmMsCIVGJkWg==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -4115,7 +4115,7 @@
     "node_modules/@deepseek-ai/dsh-tool-workflow": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tool-workflow-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-OCFPI//9D9TulvosVrVOWCaL6BJpLCV4QnX7BVMOSc6/0dKzBEecBo7dzNiTwtp6IFT36rPkjIG3+9dEoFbk2Q==",
+      "integrity": "sha512-JXdVXm/FoOWmB3AxT1m2fcihLyzgNcxo0gh9ZVmv/wXgWdQJquJhlSZSABr3g2ok5Ii5uUlMm8qeXDn2hlVyCA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4134,7 +4134,7 @@
     "node_modules/@deepseek-ai/dsh-tools": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-tools-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-TOXN9wLYTFL68HEHZCxMZQKwYzBEOBY3l0HdHZPbebL4xsQPUyqJ7KCuZjOcb9ykEB0P6+QhKCINTUd8+iEsjw==",
+      "integrity": "sha512-D4AdGBBMEkWpUPC63mQsjI/oUnTKOolYUM5LsAyJ1LHeT9L7Fu/ZkaMTWPtNdygtvr2SaVki0/QQSR36GMJ2+Q==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -4156,7 +4156,7 @@
     "node_modules/@deepseek-ai/dsh-typert-loader": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-typert-loader-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-pxUfZtP1UGfuMRPvSnK6QEAwzmOPQ46I+gacr+52vamTudMRcGwzwX7Unm059bp/id+9ZeIOzV83qlDyvRha/w==",
+      "integrity": "sha512-alz8Dx56sTe+mdtU1CayLOolRw4k76l8+qcwvUJ5Xlo5gYmL4V3Attp+5LDadzlCfZMXPixQ7EP8Rzsu2+GFCQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4179,7 +4179,7 @@
     "node_modules/@deepseek-ai/dsh-typert-registry": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-typert-registry-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-QFx1WteLgX/VV4Vl1rjwkiMpJDfdw4brATUYiGP+oLmSKOnSuD7TvXX90g7GaFoGD+UFM4chcpArZzgHbJSAaQ==",
+      "integrity": "sha512-9mJWBnpVA420JQxRYBBoZ8+md8k8qcIjb9PqWnGrjm2hqqedScOjH/8kM9wGlfTp7suOeOq/lTSzI0PRSRUKww==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
@@ -4191,7 +4191,7 @@
     "node_modules/@deepseek-ai/dsh-user-approval": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-user-approval-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-2US0GZh+yeo+7UKQUHSEoNHAeFOwLFcMl4hFjPAZM7ukUDHBN9m5Sx8dsi+yOXdnbcZeRuDuxEC1ZL25L5ObzQ==",
+      "integrity": "sha512-jCkl5kKoo+2C2nBPCYeioai87lvIS5cPEBBfHaRMqQDUGrhchXwcbYb8QUhOrHXfpsD5NL3ekMM2zspc8SexLw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4210,7 +4210,7 @@
     "node_modules/@deepseek-ai/dsh-user-questions": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-user-questions-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-+37oxXptnVu/G6KD+zg4TsmQtITdv9H7SacizevWqeGVD/g9lnlP/xRqjaDZr3M17E160gdeguOp27RR7+/H/Q==",
+      "integrity": "sha512-xolAR7orWvlOwDyvD5UgL2PIxz0eRvWb6ryx61snrbbcuXW4GL7ChwvGy3NEBDCrASouyorLHdYq6RPZjPDaMA==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -4271,7 +4271,7 @@
     "node_modules/@deepseek-ai/dsh-web-app": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-web-app-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-58sI90BJ3ZsNXKo2cuzvB2i2mka9/zoJb5zfdNVjve1en4MhQqNbHtl8VLyYZiRn0IDIUQvxDY+YZS5Ao4Zw1g==",
+      "integrity": "sha512-YgmKjjAvaOlW1OfL7LvfJaL2/08gV6IQH9LLhGP3gVEIbU9G7cPSz1cJB4RBfUpP0ogMzZ/Ra3cBZc9fwhggDw==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-agent-presets": "^0.1.3-alpha.1",
@@ -4358,7 +4358,7 @@
     "node_modules/@deepseek-ai/dsh-web-fetch-http": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-web-fetch-http-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-RnNRMo4zNHO01Rz+y3XmXzyOKfPh2mEpkeEe6WUCtlsz30E1gpNa1dLOx44RAMRHuUZAIjvpi92zbaoDkJJG7Q==",
+      "integrity": "sha512-AncRQnGLoaJZmVeJNzob+PDr18/Abz9NKMxdh7zaO/SmqQUDNnK1cXmdVqBFWjq2dPHCDp/X9M4qgIcj8eKgiA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2",
@@ -4375,13 +4375,13 @@
     "node_modules/@deepseek-ai/dsh-web-frontend": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-web-frontend-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Q8vVUzvRdXZwdA2NNv+o2U+GiDCa0Q+8jtT+Y6+dYsRcosYqQsinXnlhWiwLggNdubPcbIdEkvk/6cF/K+LUog==",
+      "integrity": "sha512-NY5ZgzlzM7SfLw/Sx9F1SB+N/i6lewF1388Pg65/GAhTQLGGlbct4BDyh6K0wVYb2/hx3JYF7b2AAs1UwQwJQg==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-web-search-deepseek-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-WSxCSrZ67n7fTsvM+7+H2QkS6VzyJRELKV8GfheSk6Sp3ILEicLf+cMXDN8t4wtjx+tabiIKo05KtQSjALox8w==",
+      "integrity": "sha512-BERHJPmZ2peQHlpst2jnIkDnyz5uBVsam55VJx5P5Z/TAujO9ue02fuTKp6X7dULqzv4/OIA8m55zN9pIDM3YQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
@@ -4399,7 +4399,7 @@
     "node_modules/@deepseek-ai/dsh-webhook": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-webhook-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-aDidLRWZE18VNcRmrO7+57lERGIbWOlAskYEb+Sq7Er51n7dkf2tNegKdkY7d0vZbCkJvvAm/8Y9PUK2iK0EyA==",
+      "integrity": "sha512-+pgenPxC7xjcg0YrV+Ydvq4Rt1sBDDLLXTXPal6jTHWhSOyHjRFgN0bC7We+1TvkL3ac08aJMVqba3K/VpkQXQ==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -4421,7 +4421,7 @@
     "node_modules/@deepseek-ai/dsh-webhook-github": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-webhook-github-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-hTCuqy4pc5HN/Aiw3SPk9YY4Z1IFnGdxZ6D6N9hhlVCOJxj/sBxTToCCzfuCQPEnYJ3aQV5sjRmGsdAyHWdOPw==",
+      "integrity": "sha512-Hok2foYoOcBFghaj6yxdUn6ag4gySyt3k9Fl81+XZTWCOxbLyA7ZFdTyql/rXucHwQNFTIrVzuxFKu5g0q8AdA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-util-values": "^0.1.3-alpha.1",
@@ -4451,7 +4451,7 @@
     "node_modules/@deepseek-ai/dsh-workflow": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-workflow-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-YdUP+JPtG3vSmsmxC82xvUzb91XQeX+tIlmgxlVaqQAcbT5NLITp3MV72r9BaaDkNa3QcnHvtstsHui8HfNcBg==",
+      "integrity": "sha512-NdKuVnUGokmVicWDywTb1nOqiZCIPW0xH7x1MdrqKEIxIIonxmveYcWUnsQPRYegOzqi0dk+rP3UuJPxSed7Uw==",
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
@@ -4465,7 +4465,7 @@
     "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-workflow-worker-thread-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-Hl8WdzQsMhjLClGkXXYIh07+S2rytJMTktv3hZpGMpKm19Yo1eAproE0XkvLgRsyxY0BHO99W/pUEROx4Fo5Bg==",
+      "integrity": "sha512-eIE+evrZBRlZrCzEU3z0BjNmkHX33S90C65FbXH0o1GoVcqumCu87W0mvm8RmgpClNStuxKzoLvRkKVB6S4K2g==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",
@@ -4485,7 +4485,7 @@
     "node_modules/@deepseek-ai/dsh-workspace": {
       "version": "0.1.3-alpha.1",
       "resolved": "file:vendor/kernel/0.1.3-alpha.1/deepseek-ai-dsh-workspace-0.1.3-alpha.1.tgz",
-      "integrity": "sha512-VdoMhxn7x/X4QAc1+7wOEN7+5Q5KRuWm5Y0gpdOiNkiPda6b5TFoamIPAJx5Yv1q4LC4Y67gMx/5GNh+QBUVbA==",
+      "integrity": "sha512-TH3RuXXcafNm/ojUL9OG+kXqRVvQBy5lrehp8JWFB1OCTds69jQp0a1UV4SX2ICDvw8SdSY/Sjq4TRI4Mok9oA==",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/dsh-brand": "^0.1.3-alpha.1",

--- a/dsh-desktop/test/companion-plugins-registry.test.ts
+++ b/dsh-desktop/test/companion-plugins-registry.test.ts
@@ -151,7 +151,7 @@ test('manifest covers every bundled plugin, skin, and SDK directory exactly once
     { kind: 'sdk-plugin', path: 'dsh-desktop/assets/sdk-plugins', manifestKey: 'sdkPlugins' },
   ]);
   const entries = allManifestEntries();
-  assert.equal(manifest.plugins.length, 47);
+  assert.equal(manifest.plugins.length, 48);
   assert.equal(manifest.skins.length, 10);
   assert.equal(manifest.sdkPlugins.length, 1);
   assert.equal(new Set(entries.map((entry) => entry.id)).size, entries.length, 'manifest ids must be unique');
@@ -164,7 +164,7 @@ test('manifest covers every bundled plugin, skin, and SDK directory exactly once
 
 test('manifest plugin rows map one-to-one to COMPANION_PLUGINS', () => {
   const registrations = companionRows();
-  assert.equal(registrations.length, 47);
+  assert.equal(registrations.length, 48);
   assert.equal(new Set(registrations.map((row) => row.id)).size, registrations.length, 'companion ids must be unique');
   assert.deepEqual(
     manifest.plugins.map((entry) => entry.id).sort(),
@@ -215,7 +215,7 @@ test('manifest entries agree with package metadata and use explicit source polic
 test('all legacy plugin update sources map to exactly one manifest entry', () => {
   const sources = updateSourceRows();
   const entries = allManifestEntries();
-  assert.equal(sources.length, 11);
+  assert.equal(sources.length, 12);
   assert.equal(policies.runtimeUpdates.legacySourceCount, sources.length);
   assert.equal(policies.runtimeUpdates.sourceMapMustBeOneToOne, true);
   for (const source of sources) {

--- a/dsh-desktop/test/plugin-sync.test.ts
+++ b/dsh-desktop/test/plugin-sync.test.ts
@@ -94,7 +94,7 @@ test('validate-manifest accepts the checked-in inventory without network access'
   const result = run(['validate-manifest']);
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /manifest valid/);
-  assert.match(result.stdout, /plugins=47/);
+  assert.match(result.stdout, /plugins=48/);
   assert.match(result.stdout, /skins=10/);
   assert.match(result.stdout, /sdkPlugins=1/);
 });
@@ -272,7 +272,7 @@ test('generate-lock and validate --locked enforce completeness and digests', () 
   assert.equal(generated.status, 0, generated.stderr || generated.stdout);
   const lockPath = join(repoRoot, '.sync', 'plugins.lock.json');
   const lock = JSON.parse(readFileSync(lockPath, 'utf8'));
-  assert.equal(Object.keys(lock.plugins).length, 58);
+  assert.equal(Object.keys(lock.plugins).length, 59);
   assert.equal(run(['validate', '--locked']).status, 0);
 
   const original = readFileSync(lockPath);

--- a/dsh-desktop/test/plugin-updater.test.ts
+++ b/dsh-desktop/test/plugin-updater.test.ts
@@ -33,7 +33,7 @@ function generatedUpdateSources() {
 }
 
 describe('版本判定', () => {
-  it('generated registry preserves the existing eleven runtime update sources', () => {
+  it('generated registry preserves the existing twelve runtime update sources', () => {
     assert.deepEqual(generatedUpdateSources(), {
       'picturereader': { npm: 'picturereader' },
       'computer-user': { npm: 'computer-user' },
@@ -46,6 +46,8 @@ describe('版本判定', () => {
       'unified-market': { npm: 'dsh-unified-market' },
       'dsh-session-manager': { npm: 'dsh-session-manager' },
       'dsh-undo': { github: 'lire1131/dsh-undo-savepoint' },
+      // 5.4.x 新增：内置「中文思考增强」EAC 派生版（GitHub 源，未发 npm）
+      'think-zh-expand-eac': { github: 'jing-hy/dsh-think-zh-expand-eac' },
     });
   });
 


### PR DESCRIPTION
## 背景

本 PR 做两件事：**内置一个不与折叠插件冲突的中文思考增强插件**，以及**把内置插件市场同步到 0.4.0**（并保留 EAC 独有定制）。

### 为什么要另做一版思考增强插件

上游 `baosfeng/dsh-think-zh-expand` 以 `priority:-1` 接手 `conversation.chat.node` 的 `assistant-step` 渲染器并自绘思考块（默认展开、流式强制展开）。这与折叠类插件产生**结构性冲突**：

- `dsh-turn-fold` 同样以 `priority:-1` 抢占同一座位 —— 两者只能有一个生效；
- `dsh-auto-collapse` 依赖 DOM 锚点 `data-chat-flow-key` / `data-turn-process` 定位折叠目标，而上游自绘的思考块**不产生这些锚点**，导致其折叠逻辑对该段**静默失明**。

用户侧表现是「装了折叠插件但思考收不起来」，且不报错，排查困难。实测链路：`conversationEvents` 服务在 0.1.3-alpha.1 中已不存在、上游的 rc.6 硬绑定渲染器在现内核上无法工作。

### 为什么市场不能直接覆盖

内置市场含 **EAC 独有展示定制**（`data/eac-recommended.json` 本地推荐清单合并 + 「EAC 推荐」徽章），该逻辑**从未进入上游仓库**（上游 npm 包不含）。直接用上游 0.4.0 覆盖会丢失这部分定制。

## 改动

### 1. 新增内置插件 `dsh-desktop/assets/plugins/dsh-think-zh-expand-eac/`

派生自上游 `0.4.8`（`https://github.com/jing-hy/dsh-think-zh-expand-eac`，README 含来源引用与 MIT 许可）：

- **移除**全部接管对话渲染器的显示功能：`assistant-step` 渲染器注册、`ThinkBlock`（默认展开/流式强制展开）、`AssistantStepView` 自绘、官方 SVG 内联图标、`.dsh-think-zh-expand-*` 样式表、`dsh-md-render` 与 `react` 依赖
- **保留**：强制中文思考/回复（`system-prompt` section，`order -90`）+ 界面标签中文化（DOM 精准文本替换，**不改动 DOM 结构**）
- `system-prompt` section 名由 `dsh-think-zh` 改为 **`dsh-think-zh-eac`**：DSH 对同层重复 name 的 section 注册会抛错，改名后与上游版可共存（避免拖垮插件树）

### 2. 注册与默认启用（三项登记）

| 位置 | 内容 |
|---|---|
| `.sync/plugins.json` | 更新源条目：`class: follow-upstream`、GitHub 源、`runtimeUpdate.allowed: true` |
| `dsh-desktop/assets/SOURCES.json` | 台账条目 **C114**（`origin: upstream`、`registryStatus: 注册表默认启用`、记录 fork 来源） |
| `lib/desktop/companion-sync.ts` | `COMPANION_PLUGINS` 加入该插件行 → 随启动播种 patch 行，**默认启用**且用户可在「设置 → 插件 → 管理」关闭 |

> 走 patch 行而非 `BUNDLED_BUILTIN_PLUGINS`（bundles 播种）：前者用户在设置页可关闭，且其包内 patch 是普通 `insert` 行，不会被壳侧 `removeBundledRowDuplicates` 去重；后者（如 `dsh-raw-html`）的 overlay 行会被去重删除。

### 3. 内置插件市场同步 0.4.0

- `lib/host.js` / `lib/client.js` / `package.json` / `README.md` / `CHANGELOG.md` / `cordis.patch.yml` / `data/*` 整体替换为 0.4.0
- 0.4.0 核心：profile 配置写入改为**双边同步**（`lib/profile-sync.mjs`）—— 每次重读磁盘、以 id 并集合并、写前 CAS（SHA256+size+mtime）、原子写、写前校验（空 insert 块 / duplicate loader entry 拒绝落盘）、写后复核失败回滚、双文件快照与还原；新增 `profile.state|toggle|snapshots|restore` 四个 host 方法；CLI 操作后新增增量同步
- **重新施加 EAC 独有定制**：
  - `data/eac-recommended.json` 随包保留
  - `host.js` 补回 `EAC_RECOMMENDED_PATH` / `pluginIdentityKeys` / `loadEacRecommendations` / `mergeRecommendedCatalog`，并以 `loadCatalog` 包装器把推荐合并进 live / 静态页 / 离线快照三条路径**及缓存命中**（原实现只覆盖部分路径）
  - `client.js` 补回 zh/en 的 `eacRecommended` 文案、`.mkts-rec` 样式与卡片推荐徽章
- 导出 `loadEacRecommendations` / `mergeRecommendedCatalog` 以匹配既有契约测试 `test/market-recommended.test.ts`
- `dsh-plugin.json` 与台账 C042 版本同步 0.4.0

### 4. 契约测试同步（计数随新增条目递增，属预期变更）

| 文件 | 变更 |
|---|---|
| `.sync/policies.json` | `runtimeUpdates.legacySourceCount` 11 → 12 |
| `test/plugin-updater.test.ts` | 运行时更新源 11 → 12 |
| `test/companion-plugins-registry.test.ts` | 更新源 11 → 12；manifest 与 `COMPANION_PLUGINS` 行数 47 → 48 |
| `test/plugin-sync.test.ts` | lock 条目 58 → 59；`plugins=47` → 48 |

## 验证

- **编译**：`tsc -p tsconfig.json` 通过；改动的 3 个 JS 文件 `node --check` 通过
- **全量测试**：`node scripts/test-runner.js test/*.test.ts` → **863 项 / 858 通过 / 0 失败 / 5 跳过**
- **EAC 专属契约**：`test/market-recommended.test.ts` **3/3 通过**
- **运行时验证**（真实 `import` 内置 market 的 `host.js`，非仅语法）：`loadCatalog` 返回 **3055 条**；EAC 推荐 `Archify` 带 `eacRecommended:true` 且**排首位**；`skill` 分类标签为「技能包」；无重复条目；**缓存命中路径同样带标记**
- **EAC 插件包**：`lib/client.js` 中 `slots.register` / `slots.inject` / `createElement` / `useState` **均为 0 次**（确认不再接管渲染器）；host 端冒烟测试 **7/7 通过**
- **清单一致性**：`SOURCES.json` 114 条、无重复 id；registry 重新生成后 `.sync/plugins.lock.json` 由 `generate-lock` 重新生成，`validate --locked` 通过

## 未验证（环境限制，如实说明）

- 未做 NSIS / 便携包构建与**真实安装树升级验收**（V5）
- 未在真机启动客户端确认插件树加载与推荐徽章实际渲染（需完整运行时环境）；已用真实 `import` + 目录加载 + 卡片渲染数据链路做替代验证

## 影响面

- 仅内置插件副本（`assets/plugins/`）、`.sync/` 清单与台账、`companion-sync.ts` 注册表、契约测试
- 不涉及 L1 Rust 壳、sidecar、bridge 契约
- `assets/SOURCES.json` 与 `.sync/plugins.json` 为整体重新序列化（内容等价，字段完整），diff 较大但语义仅新增条目与版本更新
