### PR TITLE
fix(release): 版本 5.4.1 + 内置插件内核兼容门禁（3.3.3 修复可识别、同类事故拦在 CI）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
       - name: 获取内置运行时（node.exe + npm CLI）
         run: npm run fetch-runtime
 
+      - name: 内置插件内核兼容门禁（静态导入内核不存在的导出会拖垮整棵插件树）
+        run: node scripts/plugin-kernel-compat.mjs
+
       - name: 类型检查（tsc --noEmit 零错误）
         run: npm run typecheck
 
@@ -170,6 +173,9 @@ jobs:
 
       - name: 安装依赖并获取 Linux runtime
         run: npm run ci:install && npm run fetch-runtime
+
+      - name: 内置插件内核兼容门禁（静态导入内核不存在的导出会拖垮整棵插件树）
+        run: node scripts/plugin-kernel-compat.mjs
 
       - name: 类型检查与全量测试
         run: npm run typecheck && npm test

--- a/dsh-desktop/CHANGELOG.md
+++ b/dsh-desktop/CHANGELOG.md
@@ -47,6 +47,40 @@ next2（功能包体系：.dshpack 打包分发插件+预设+技能，声明官�
 官方版本升级自动检出并一键迁移/回滚 —— 核心在 L2 功能包引擎 + CLI，
 交互集成进 dsh-unified-market 插件；详见下方「功能包体系（Feature Pack）」批次）
 
+## 5.4.1（picturereader 3.3.3 内置修复 + 内置插件内核兼容门禁）· 2026-09-12
+
+### 修复：5.4.0 产物内置的 picturereader 3.3.2 与内核 0.1.3 不兼容，会拖垮整棵插件树
+
+- 内核 0.1.3 起 `@deepseek-ai/dsh-settings` 不再导出 `settingsNamespace()` 品牌函数
+  （命名空间校验收进 `register()` 内部），而 3.3.2 仍在 `src/index.js` 顶层
+  `import { settingsNamespace } from '@deepseek-ai/dsh-settings'`。ESM 具名导入在**链接期**
+  解析，缺失导出会让该模块整体加载失败（`SyntaxError: The requested module
+  '@deepseek-ai/dsh-settings' does not provide an export named 'settingsNamespace'`）。
+- 失败冒泡到 `cordis:include` 层 → `dsh web` 以退出码 1 退出 → 保护中心记 `boot-failed`
+  事故 → 救援链/恢复中心进入安全模式（`safeModePatch` 只留核心行），用户侧表现为
+  「一对话就报错」+ 插件大范围消失。
+- 内置插件升级至 **3.3.3**：改用 `sctx.settings.register(NS, Config, { base: config })`，
+  `register()` 内部完成命名空间校验（见 PR #353，2026-09-11 合入）。
+
+### 版本号 5.4.0 → 5.4.1：让修复产物可识别
+
+- 3.3.3 适配合入 main 的时间（2026-09-11 20:01）**晚于** 5.4.0 产物的描述符生成时间
+  （`distribution-descriptor.json` → `generatedAt: 2026-09-11T10:21:17Z`，pin
+  `pkg:github/jing-hy/picturereader@3.3.2`）。因此**同一个 5.4.0 版本号下同时存在
+  「带病 3.3.2」与「已修 3.3.3」两种内容**，从版本号无法分辨。bump 补丁号后，
+  带 3.3.2 的旧产物与修复产物可区分（`dsh-desktop/package.json`、
+  `dsh-desktop/package-lock.json`、`tauri-shell/tauri.conf.json` 同步更新）。
+
+### 新增：内置插件 ↔ 内核导出兼容门禁（防止同类事故再犯）
+
+- 新增 `scripts/plugin-kernel-compat.mjs`：零依赖静态比对 —— 把 `assets/plugins/**`
+  源码里对 `@deepseek-ai/*` 内核包的具名 `import { … } from` / `export { … } from`
+  与随包内核的真实导出集合对照，命中即报错退出（只读文件，绝不执行插件代码）。
+- 新增 `test/plugin-kernel-compat.test.ts`：① 对真实内置插件树 + 随包内核回归断言零命中；
+  ② 用合成夹具断言门禁本身能报出「导入不存在的导出」（防止门禁静默失效）。
+- CI（`.github/workflows/ci.yml` 的 Windows 与 Linux 两个 job）在依赖安装后各新增一步
+  运行该门禁：同类问题在 CI 阶段拦截，不再等到用户机器上以安全模式剥插件行收场。
+
 ## 5.4.0（picturereader 3.3.2 内置更新）· 2026-09-06
 
 - 内置 `picturereader` 升级至 3.3.2：图片在纯文本模型入口被预先改写为 `attachment sha256` 提示时，桥接层会仅从本地附件对象库定位唯一对象、校验文件头并导出为受支持图片，随后注入 `image_scan` / `image_ocr` 本地分析路径；缺失、歧义或非图片对象保持原提示。

--- a/dsh-desktop/package-lock.json
+++ b/dsh-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-desktop",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-desktop",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/dsh-desktop/package.json
+++ b/dsh-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-desktop",
   "productName": "Deepseek Harness EAC",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "DeepSeek Harness (dsh) 开箱即用的 Windows 桌面客户端：内置 dsh CLI 与 Node 运行时，一键启动 Web UI",
   "author": "DSH Desktop",
   "license": "MIT",
@@ -9,6 +9,7 @@
   "scripts": {
     "ci:install": "node scripts/npm-ci-with-kernel.mjs",
     "ledger:check": "node scripts/plugin-ledger.mjs",
+    "plugin:kernel-compat": "node scripts/plugin-kernel-compat.mjs",
     "fetch-node": "npm run build && node scripts/fetch-node.js",
     "postinstall": "npm run build && node scripts/patch-deps.js || exit 0",
     "fetch-npm": "npm run build && node scripts/fetch-npm.js",

--- a/dsh-desktop/scripts/plugin-kernel-compat.mjs
+++ b/dsh-desktop/scripts/plugin-kernel-compat.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * 内置插件 ↔ 内核导出兼容门禁（零依赖，CI / 本地均可直接跑）
+ *
+ * 事故背景（5.4.0）：内置 picturereader 3.3.2 顶层写了
+ *     import { settingsNamespace } from '@deepseek-ai/dsh-settings'
+ * 而内核 0.1.3 起 dsh-settings 只导出 SettingsConflictError / SettingsProvider /
+ * default / redactSecrets（命名空间校验收进 register() 内部）。ESM 具名导入在
+ * 「链接期」解析：缺失导出会让该模块整体加载失败
+ *     SyntaxError: The requested module '@deepseek-ai/dsh-settings'
+ *     does not provide an export named 'settingsNamespace'
+ * 失败冒泡到 cordis:include 组 → dsh web 退出码 1 → 保护中心记 boot-failed 事故 →
+ * 救援链进入安全模式（safeModePatch 只留核心行），用户侧表现为「一对话就报错」
+ * 且插件大范围消失。本门禁把同类问题拦在 CI 阶段。
+ *
+ * 做法（只读文件 + 正则，绝不 import / 执行插件代码）：
+ *   1. 扫 assets/plugins 下 .js/.mjs/.cjs 的具名导入与重导出：
+ *        import { a, b as c } from '@deepseek-ai/<pkg>'
+ *        export { a } from '@deepseek-ai/<pkg>'
+ *   2. 只对「插件真正引用到的」内核包解析导出集合
+ *      （内核位于 node_modules/@deepseek-ai，由 vendored tarball 安装）
+ *   3. 逐个比对：引用符号不在该包导出集合里 → 报告并退出码 1
+ *
+ * 防假阳性取舍（宁可漏判、绝不误判，避免 CI 无故变红）：
+ *   · 导出集合按「包目录下所有 JS 文件的导出声明求并集」—— 是真实导出的超集，
+ *     因此最多漏判，不会把存在的导出误判为缺失。
+ *   · 无法静态枚举导出的包（CJS / 解析不出任何导出名）整包跳过并计入 skipped。
+ *   · 注释里的示例 import 会被剥除，不参与判定。
+ *   · 只判具名导入；default / 命名空间导入与运行时 API 语义差异不在本门禁范围。
+ *
+ * 用法：
+ *   node scripts/plugin-kernel-compat.mjs
+ *   node scripts/plugin-kernel-compat.mjs --json
+ *   node scripts/plugin-kernel-compat.mjs --kernel <dir> --plugins <dir>   # 夹具 / 测试
+ * 退出码：0 = 通过；1 = 命中不兼容，或环境不满足（内核未安装）。
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = join(HERE, '..');
+
+export const DEFAULT_KERNEL_ROOT = join(DESKTOP_ROOT, 'node_modules', '@deepseek-ai');
+export const DEFAULT_PLUGINS_ROOT = join(DESKTOP_ROOT, 'assets', 'plugins');
+
+const KERNEL_SCOPE = '@deepseek-ai/';
+const CODE_EXT = /\.(?:c|m)?js$/i;
+// 不参与扫描：依赖树、随包分发的浏览器 vendor 产物、更新包缓存
+const SKIP_DIRS = new Set(['node_modules', 'vendor', 'releases', '.git', '.pnpm']);
+
+const RE_EXPORT_LIST = /export\s*\{([^}]*)\}/g;
+const RE_EXPORT_DECL = /export\s+(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)/g;
+const RE_EXPORT_STAR_AS = /export\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s*from/g;
+const RE_NAMED_FROM = /(?:^|[^\w$.])(?:import|export)\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+
+/** 剥除块注释与行注释（保守：字符串里的 `//` 可能被一并剥掉 → 最多漏判）。 */
+function stripComments(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:"'\\])\/\/[^\n]*/g, '$1');
+}
+
+function readTextSafe(file) {
+  try { return readFileSync(file, 'utf8'); } catch { return ''; }
+}
+
+function readJsonSafe(file) {
+  try { return JSON.parse(readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+/** 递归收集目录下的源码文件（不跟随符号链接，避免目录闭环）。 */
+function walkFiles(root, out = []) {
+  let entries;
+  try { entries = readdirSync(root, { withFileTypes: true }); } catch { return out; }
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walkFiles(full, out);
+    } else if (entry.isFile() && CODE_EXT.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** 从源码文本收集导出名（包目录内所有文件求并集 = 真实导出的超集）。 */
+export function collectExportNames(text, into = new Set()) {
+  for (const m of text.matchAll(RE_EXPORT_LIST)) {
+    for (const piece of m[1].split(',')) {
+      const raw = piece.trim().replace(/^type\s+/, '');
+      if (!raw) continue;
+      const as = /\bas\s+([A-Za-z_$][\w$]*)$/.exec(raw);
+      into.add(as ? as[1] : raw);
+    }
+  }
+  for (const m of text.matchAll(RE_EXPORT_DECL)) into.add(m[1]);
+  for (const m of text.matchAll(RE_EXPORT_STAR_AS)) into.add(m[1]);
+  if (/\bexport\s+default\b/.test(text)) into.add('default');
+  return into;
+}
+
+/** 解析「具名 from」语句里被引用的符号：`a` / `a as b` 都要求被导入方导出 `a`。 */
+function symbolOf(piece) {
+  const raw = piece.trim().replace(/^type\s+/, '');
+  if (!raw) return '';
+  const as = /\bas\s+([A-Za-z_$][\w$]*)$/.exec(raw);
+  const symbol = (as ? raw.slice(0, raw.length - as[0].length) : raw).trim();
+  return /^[A-Za-z_$][\w$]*$/.test(symbol) ? symbol : '';
+}
+
+/**
+ * 解析指定内核包的导出集合。
+ * @returns Map<包名, {dir, exists, exports:Set<string>, skipped:boolean, reason:string}>
+ */
+export function collectKernelExports(kernelRoot, packageNames) {
+  const result = new Map();
+  for (const pkg of packageNames) {
+    const dir = join(kernelRoot, pkg);
+    const dirExists = existsSync(dir);
+    const pkgJson = readJsonSafe(join(dir, 'package.json'));
+    const names = new Set();
+    let hasEsmSyntax = false;
+    if (dirExists) {
+      for (const file of walkFiles(dir)) {
+        const text = stripComments(readTextSafe(file));
+        if (/(?:^|\n)\s*(?:import|export)\s/m.test(text) || /\bexport\s*[[{*]/.test(text)) hasEsmSyntax = true;
+        collectExportNames(text, names);
+      }
+    }
+    const isEsm = pkgJson?.type === 'module' || hasEsmSyntax;
+    let reason = '';
+    if (!dirExists) reason = 'missing';
+    else if (!isEsm) reason = 'cjs';
+    else if (names.size === 0) reason = 'no-static-exports';
+    result.set(pkg, {
+      dir,
+      exists: dirExists,
+      exports: names,
+      skipped: dirExists && reason !== 'missing' && reason !== '',
+      reason,
+    });
+  }
+  return result;
+}
+
+/**
+ * 客户端（浏览器侧）bundle 的排除判定。
+ *
+ * 插件的 `lib/client/**`、`client.js`（package.json exports["./client"] 指向的入口）
+ * 是被内核 Web 前端加载面送进浏览器的代码，其 `@deepseek-ai/dsh-client-*`
+ * 导入既不由 Node 解析、也不参与服务端 ESM 链接期 —— 即使写错也只影响前端渲染，
+ * 不会拖垮插件树。本门禁只对「服务端（host）侧源码」判定，故整块排除。
+ */
+function clientSideExcluder(pluginDir, pkgJson) {
+  const dirs = new Set();
+  const files = new Set();
+  const toPosix = (p) => p.replace(/\\/g, '/');
+  const clientExport = pkgJson && pkgJson.exports && pkgJson.exports['./client'];
+  const spec = typeof clientExport === 'string'
+    ? clientExport
+    : (clientExport && (clientExport.default || clientExport.import || clientExport.require));
+  if (typeof spec === 'string' && spec) {
+    const abs = toPosix(join(pluginDir, spec));
+    files.add(abs);
+    const dir = abs.slice(0, abs.lastIndexOf('/'));
+    // 入口就在插件根（如 ./client.js）时不排除整个插件目录
+    if (dir && dir !== toPosix(pluginDir)) dirs.add(dir + '/');
+  }
+  return (file) => {
+    const p = toPosix(file);
+    if (files.has(p)) return true;
+    for (const d of dirs) if (p.startsWith(d)) return true;
+    if (p.includes('/client/')) return true;
+    return /(^|\/)client\.(?:c|m)?js$/i.test(p);
+  };
+}
+
+/** 扫描内置插件源码里的内核具名导入（只判服务端侧，见 clientSideExcluder）。 */
+export function scanPluginImports(pluginsRoot) {
+  const refs = [];
+  let pluginCount = 0;
+  let fileCount = 0;
+  let clientFileCount = 0;
+  let dirs = [];
+  try { dirs = readdirSync(pluginsRoot, { withFileTypes: true }); } catch { return { refs, pluginCount, fileCount, clientFileCount }; }
+  for (const entry of dirs) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    pluginCount += 1;
+    const pluginDir = join(pluginsRoot, entry.name);
+    const isClientSide = clientSideExcluder(pluginDir, readJsonSafe(join(pluginDir, 'package.json')));
+    for (const file of walkFiles(pluginDir)) {
+      if (isClientSide(file)) { clientFileCount += 1; continue; }
+      fileCount += 1;
+      const text = stripComments(readTextSafe(file));
+      if (!text.includes(KERNEL_SCOPE)) continue;
+      for (const m of text.matchAll(RE_NAMED_FROM)) {
+        const spec = m[2];
+        if (!spec.startsWith(KERNEL_SCOPE)) continue;
+        const pkg = spec.slice(KERNEL_SCOPE.length).split('/')[0];
+        for (const piece of m[1].split(',')) {
+          const symbol = symbolOf(piece);
+          if (!symbol) continue;
+          refs.push({ plugin: entry.name, file: relative(pluginsRoot, file), spec, pkg, symbol });
+        }
+      }
+    }
+  }
+  return { refs, pluginCount, fileCount, clientFileCount };
+}
+
+/** 门禁主体：返回 { ok, hits, skipped, stats, kernelRoot, pluginsRoot, kernelExists }。 */
+export function checkCompatibility(opts = {}) {
+  const kernelRoot = opts.kernelRoot || DEFAULT_KERNEL_ROOT;
+  const pluginsRoot = opts.pluginsRoot || DEFAULT_PLUGINS_ROOT;
+  const kernelExists = existsSync(kernelRoot);
+  const scan = scanPluginImports(pluginsRoot);
+  const packages = [...new Set(scan.refs.map((r) => r.pkg))].sort();
+  const kernel = collectKernelExports(kernelRoot, packages);
+
+  const hits = [];
+  const skipped = [];
+  let checkedPackages = 0;
+  for (const [pkg, info] of kernel) {
+    if (info.skipped) skipped.push({ pkg, reason: info.reason });
+    else checkedPackages += 1;
+  }
+  for (const ref of scan.refs) {
+    const info = kernel.get(ref.pkg);
+    if (!info) continue;
+    if (!info.exists) {
+      hits.push({ ...ref, type: 'missing-package', available: [] });
+      continue;
+    }
+    if (info.skipped) continue; // 无法静态枚举导出：按通过处理（防假阳性）
+    if (!info.exports.has(ref.symbol)) {
+      hits.push({ ...ref, type: 'missing-export', available: [...info.exports].sort().slice(0, 12) });
+    }
+  }
+
+  return {
+    ok: hits.length === 0,
+    kernelRoot,
+    pluginsRoot,
+    kernelExists,
+    hits,
+    skipped,
+    stats: {
+      pluginCount: scan.pluginCount,
+      fileCount: scan.fileCount,
+      clientFileCount: scan.clientFileCount,
+      referencedPackages: packages.length,
+      checkedPackages,
+      refCount: scan.refs.length,
+    },
+  };
+}
+
+export function formatReport(result) {
+  const lines = ['[plugin-kernel-compat] 内置插件 ↔ 内核导出兼容校验'];
+  lines.push(`  插件 ${result.stats.pluginCount} 个 / 服务端源码 ${result.stats.fileCount} 个文件 / 具名导入 ${result.stats.refCount} 处`);
+  if (result.stats.clientFileCount) {
+    lines.push(`  另跳过客户端（浏览器侧）bundle ${result.stats.clientFileCount} 个文件 —— 不经 Node ESM 链接期，不在本门禁范围`);
+  }
+  lines.push(`  引用内核包 ${result.stats.referencedPackages} 个（已静态解析导出 ${result.stats.checkedPackages} 个，跳过 ${result.skipped.length} 个）`);
+  if (result.skipped.length) {
+    lines.push(`  跳过（无法静态枚举导出）: ${result.skipped.map((s) => `${s.pkg}(${s.reason})`).join(', ')}`);
+  }
+  if (result.ok) {
+    lines.push('  ✓ 通过：未发现「导入内核不存在的导出」。');
+    return lines.join('\n');
+  }
+  lines.push(`  ✗ 命中 ${result.hits.length} 处不兼容 —— ESM 链接期即失败，会拖垮整棵插件树：`);
+  for (const h of result.hits) {
+    lines.push(`    · ${h.plugin}  ${h.file}`);
+    const what = h.type === 'missing-package'
+      ? `内核中不存在包 ${h.spec}`
+      : `内核 ${h.spec} 不导出 "${h.symbol}"（现有导出示例：${h.available.join(', ')}）`;
+    lines.push(`        import { ${h.symbol} } from '${h.spec}'  →  ${what}`);
+  }
+  lines.push('    修复方向：改用当前内核真实存在的 API（例如内核 0.1.3 起 settings 命名空间');
+  lines.push('    校验收进 sctx.settings.register(NS, Config, ...)），或把内置插件升级到适配');
+  lines.push('    当前内核的版本 —— 切勿让内置插件静态导入内核已删除的品牌函数。');
+  return lines.join('\n');
+}
+
+function readArg(argv, name) {
+  const i = argv.indexOf(name);
+  if (i === -1) return undefined;
+  const v = argv[i + 1];
+  return v && !v.startsWith('--') ? v : undefined;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const json = argv.includes('--json');
+  const kernelArg = readArg(argv, '--kernel');
+  const pluginsArg = readArg(argv, '--plugins');
+  const result = checkCompatibility({
+    ...(kernelArg ? { kernelRoot: kernelArg } : {}),
+    ...(pluginsArg ? { pluginsRoot: pluginsArg } : {}),
+  });
+
+  if (!result.kernelExists) {
+    if (json) {
+      process.stdout.write(JSON.stringify({ ok: false, error: 'kernel-missing', kernelRoot: result.kernelRoot }, null, 2) + '\n');
+    } else {
+      console.error('[plugin-kernel-compat] 内核目录不存在: ' + result.kernelRoot);
+      console.error('  请先安装依赖（npm run ci:install / npm ci），再运行本门禁。');
+    }
+    return 1;
+  }
+
+  if (json) {
+    process.stdout.write(JSON.stringify(result, (_k, v) => (v instanceof Set ? [...v] : v), 2) + '\n');
+  } else if (result.ok) {
+    console.log(formatReport(result));
+  } else {
+    console.error(formatReport(result));
+  }
+  return result.ok ? 0 : 1;
+}
+
+const invokedDirectly = process.argv[1] !== undefined
+  && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (invokedDirectly) process.exitCode = main();

--- a/dsh-desktop/test/plugin-kernel-compat.test.ts
+++ b/dsh-desktop/test/plugin-kernel-compat.test.ts
@@ -1,0 +1,221 @@
+// Tests for scripts/plugin-kernel-compat.mjs —— 内置插件 ↔ 内核导出兼容门禁。
+//
+// 事故背景（5.4.0）：内置 picturereader 3.3.2 顶层静态导入内核 0.1.3 已删除的
+// settingsNamespace，ESM 链接期即报错
+//   SyntaxError: The requested module '@deepseek-ai/dsh-settings'
+//   does not provide an export named 'settingsNamespace'
+// 失败冒泡到 cordis:include 组 → dsh web 退出码 1 → 保护中心记 boot-failed 事故 →
+// 救援链进入安全模式（safeModePatch 只留核心行）→ 用户侧「一对话就报错 + 插件大范围消失」。
+//
+// 本测试同时守两件事：
+//   ① 真实内置插件树 + 随包内核必须零命中（回归门禁，含「扫描未失效」的规模断言）；
+//   ② 门禁自身必须真的能报出同类写法（用合成夹具复现 3.3.2 → 3.3.3 的修复谱系），
+//      并且不得因「注释里的示例 import」「客户端 bundle」而误报。
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+interface CompatHit {
+  plugin: string;
+  file: string;
+  spec: string;
+  pkg: string;
+  symbol: string;
+  type: string;
+}
+interface CompatResult {
+  ok: boolean;
+  hits: CompatHit[];
+  skipped: { pkg: string; reason: string }[];
+  stats: {
+    pluginCount: number;
+    fileCount: number;
+    clientFileCount: number;
+    referencedPackages: number;
+    checkedPackages: number;
+    refCount: number;
+  };
+}
+
+const desktopRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const script = join(desktopRoot, 'scripts', 'plugin-kernel-compat.mjs');
+const kernelRoot = join(desktopRoot, 'node_modules', '@deepseek-ai');
+const pluginsRoot = join(desktopRoot, 'assets', 'plugins');
+
+const mod = (await import(pathToFileURL(script).href)) as {
+  checkCompatibility(opts?: { kernelRoot?: string; pluginsRoot?: string }): CompatResult;
+  scanPluginImports(root: string): { refs: unknown[]; pluginCount: number; fileCount: number; clientFileCount: number };
+};
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, [script, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+// 随包内核 0.1.3-alpha.1 的真实导出面（settingsNamespace 已被移除）
+const KERNEL_PKG_JSON = JSON.stringify({
+  name: '@deepseek-ai/dsh-settings',
+  version: '0.1.3-alpha.1',
+  type: 'module',
+  main: 'lib/index.js',
+}, null, 2) + '\n';
+const KERNEL_INDEX = 'export { SettingsConflictError, SettingsProvider, SettingsProvider as default, redactSecrets };\n';
+
+/** 合成夹具：假内核目录 + 单插件（文件按相对插件的路径写入）。 */
+function makeFixture(t: test.TestContext, files: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-kernel-compat-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, 'kernel', 'dsh-settings', 'lib'), { recursive: true });
+  writeFileSync(join(root, 'kernel', 'dsh-settings', 'package.json'), KERNEL_PKG_JSON);
+  writeFileSync(join(root, 'kernel', 'dsh-settings', 'lib', 'index.js'), KERNEL_INDEX);
+  mkdirSync(join(root, 'plugins', 'picturereader'), { recursive: true });
+  writeFileSync(join(root, 'plugins', 'picturereader', 'package.json'), JSON.stringify({
+    name: 'picturereader',
+    version: '3.3.2',
+    type: 'module',
+    exports: { '.': './src/index.js', './client': './client.js' },
+  }, null, 2) + '\n');
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(root, 'plugins', 'picturereader', rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return { kernelRoot: join(root, 'kernel'), pluginsRoot: join(root, 'plugins') };
+}
+
+const needKernel = (t: test.TestContext) => {
+  if (existsSync(kernelRoot)) return true;
+  t.skip('内核未安装（node_modules/@deepseek-ai 缺失，先跑 npm run ci:install）');
+  return false;
+};
+
+test('真实内置插件树 + 随包内核：零「导入内核不存在的导出」', (t) => {
+  if (!needKernel(t)) return;
+  const result = mod.checkCompatibility({ kernelRoot, pluginsRoot });
+  assert.deepEqual(result.hits, [], '内置插件出现内核不存在的导出（ESM 链接期会拖垮整棵插件树）');
+  assert.equal(result.ok, true);
+  // 规模断言：防止「扫描路径写错 → 空扫描 → 静默通过」这类门禁失效
+  assert.ok(result.stats.pluginCount >= 40, `内置插件数异常偏少：${result.stats.pluginCount}`);
+  assert.ok(result.stats.fileCount > 0, '服务端源码扫描为 0，门禁形同虚设');
+  assert.ok(result.stats.referencedPackages > 0, '未解析到任何内核包引用，门禁形同虚设');
+});
+
+test('CLI 契约：真实树上 --json 输出可解析且 ok=true，退出码 0', (t) => {
+  if (!needKernel(t)) return;
+  const r = run(['--json']);
+  assert.equal(r.status, 0, r.stderr);
+  const payload = JSON.parse(r.stdout) as CompatResult;
+  assert.equal(payload.ok, true);
+  assert.equal(payload.hits.length, 0);
+  assert.ok(payload.stats.pluginCount >= 40);
+});
+
+test('复现 5.4.0 事故写法：具名导入已删除的 settingsNamespace 必须命中', (t) => {
+  const fx = makeFixture(t, {
+    'src/index.js': [
+      "import { settingsNamespace } from '@deepseek-ai/dsh-settings';",
+      'export default {};',
+    ].join('\n') + '\n',
+  });
+  const result = mod.checkCompatibility(fx);
+  assert.equal(result.ok, false);
+  assert.equal(result.hits.length, 1);
+  const hit = result.hits[0]!;
+  assert.equal(hit.pkg, 'dsh-settings');
+  assert.equal(hit.symbol, 'settingsNamespace');
+  assert.equal(hit.type, 'missing-export');
+  assert.equal(hit.plugin, 'picturereader');
+
+  const r = run(['--kernel', fx.kernelRoot, '--plugins', fx.pluginsRoot]);
+  assert.equal(r.status, 1, '命中不兼容必须以退出码 1 结束 CI');
+  assert.match(r.stderr, /settingsNamespace/);
+});
+
+test('已修写法（settings.register 路径，不再静态导入品牌函数）通过；注释里的 import 不算', (t) => {
+  const fx = makeFixture(t, {
+    'src/index.js': [
+      "// import { settingsNamespace } from '@deepseek-ai/dsh-settings';",
+      "import { SettingsProvider } from '@deepseek-ai/dsh-settings';",
+      'export default { apply(ctx) { ctx.settings.register(NS, Config, { base: {} }); } };',
+    ].join('\n') + '\n',
+  });
+  const result = mod.checkCompatibility(fx);
+  assert.deepEqual(result.hits, []);
+  assert.equal(result.ok, true);
+  assert.equal(run(['--kernel', fx.kernelRoot, '--plugins', fx.pluginsRoot]).status, 0);
+});
+
+test('`import { A as B }`：要求被导入方导出 A（绑定名不参与判定）', (t) => {
+  const okFixture = makeFixture(t, {
+    'src/index.js': "import { SettingsProvider as SP } from '@deepseek-ai/dsh-settings';\nexport default SP;\n",
+  });
+  assert.equal(mod.checkCompatibility(okFixture).ok, true, '本地别名不应被当作导入符号');
+
+  const badFixture = makeFixture(t, {
+    'src/index.js': "import { settingsNamespace as ns } from '@deepseek-ai/dsh-settings';\nexport default ns;\n",
+  });
+  const hits = mod.checkCompatibility(badFixture).hits;
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0]!.symbol, 'settingsNamespace');
+});
+
+test('重导出 `export { X } from 内核包` 同样纳入判定', (t) => {
+  const fx = makeFixture(t, {
+    'src/index.js': "export { settingsNamespace } from '@deepseek-ai/dsh-settings';\n",
+  });
+  const hits = mod.checkCompatibility(fx).hits;
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0]!.type, 'missing-export');
+  assert.equal(hits[0]!.symbol, 'settingsNamespace');
+});
+
+test('引用内核里不存在的包 → missing-package', (t) => {
+  const fx = makeFixture(t, {
+    'src/index.js': "import { thing } from '@deepseek-ai/dsh-not-installed';\nexport default thing;\n",
+  });
+  const hits = mod.checkCompatibility(fx).hits;
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0]!.type, 'missing-package');
+  assert.equal(hits[0]!.pkg, 'dsh-not-installed');
+});
+
+test('客户端（浏览器侧）bundle 排除：lib/client/** 与 client.js 不参与判定，服务端入口仍判', (t) => {
+  const clientOnly = makeFixture(t, {
+    'client.js': [
+      "import { IconBranchOutline16 } from '@deepseek-ai/dsh-client-ui-primitives';",
+      'export default IconBranchOutline16;',
+    ].join('\n') + '\n',
+    'lib/client/ActivityPanel.js': [
+      "import { IconChevronDownOutline14 } from '@deepseek-ai/dsh-client-ui-primitives';",
+      'export default IconChevronDownOutline14;',
+    ].join('\n') + '\n',
+  });
+  const result = mod.checkCompatibility(clientOnly);
+  assert.deepEqual(result.hits, [], '客户端 bundle 的浏览器侧导入不得判为服务端链接期失败');
+  assert.ok(result.stats.clientFileCount >= 2, '客户端文件未被识别排除');
+  assert.equal(result.stats.fileCount, 0, '客户端文件不应计入服务端扫描');
+
+  // 同一处导入写在服务端入口就必须命中 —— 证明排除只作用于客户端路径
+  const serverSide = makeFixture(t, {
+    'src/index.js': [
+      "import { IconBranchOutline16 } from '@deepseek-ai/dsh-client-ui-primitives';",
+      'export default IconBranchOutline16;',
+    ].join('\n') + '\n',
+  });
+  const server = mod.checkCompatibility(serverSide);
+  assert.equal(server.hits.length, 1);
+  assert.equal(server.hits[0]!.pkg, 'dsh-client-ui-primitives');
+});
+
+test('内核未安装时报明确错误（不静默通过）', (t) => {
+  const fx = makeFixture(t, { 'src/index.js': 'export default {};\n' });
+  const r = run(['--kernel', join(fx.kernelRoot, 'not-here'), '--plugins', fx.pluginsRoot]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /内核目录不存在/);
+});

--- a/tauri-shell/tauri.conf.json
+++ b/tauri-shell/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Deepseek Harness EAC",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "identifier": "com.deepseek.dsh.desktop.tauri",
   "build": {},
   "app": {


### PR DESCRIPTION
## 背景：同一个 5.4.0 版本号下存在两种内容，其中一种会打挂整棵插件树

- 内置 `picturereader` **3.3.3** 适配（#353）于 2026-09-11 20:01 合入 main；
- 但 5.4.0 产物的描述符生成时间是 `2026-09-11T10:21:17Z`，pin 的是 `pkg:github/jing-hy/picturereader@3.3.2`；
- 于是 5.4.0 这个版本号既可能是「带病 3.3.2」也可能是「已修 3.3.3」，用户与支持侧都无法分辨。

带病产物的故障链路（内核 `0.1.3-alpha.1`）：

```
picturereader 3.3.2 顶层 import { settingsNamespace } from '@deepseek-ai/dsh-settings'
  → 内核 0.1.3 起该品牌函数已移除（现导出 SettingsConflictError / SettingsProvider / default / redactSecrets）
  → ESM 链接期 SyntaxError，模块整体加载失败
  → cordis:include 组加载失败 → dsh web 退出码 1
  → 保护中心记 boot-failed 事故 → 救援链进入安全模式（safeModePatch 只留核心行）
  → 用户侧「一对话就报错 + 插件大范围消失」
```

本 PR **不重复修插件**（3.3.3 已在 main），只补齐两件事：**修复产物的可识别性** 与 **同类事故的 CI 门禁**。

## 改动

1. **版本号 5.4.0 → 5.4.1**：`dsh-desktop/package.json`、`dsh-desktop/package-lock.json`、`tauri-shell/tauri.conf.json`
2. **CHANGELOG 补 5.4.1 段**：记录故障链路、修复要点与门禁设计
3. **新增 `dsh-desktop/scripts/plugin-kernel-compat.mjs`**（+ npm script `plugin:kernel-compat`）
   - 零依赖、只 `readFileSync` + 正则，**绝不 import / 执行插件代码**
   - 扫内置插件**服务端**源码的 `import { … } from '@deepseek-ai/<pkg>'` 与 `export { … } from …`
   - 与 `node_modules/@deepseek-ai/<pkg>` 的真实导出集合比对，命中即退出码 1
   - 防假阳性取舍：导出集合按包内所有文件求并集（真实导出的超集 → 只可能漏判、不会误判）；CJS / 无法静态枚举的包整包跳过并打印；注释示例剥除；客户端 bundle（`lib/client/**`、`client.js`）不计入服务端链接期判定
4. **新增 `dsh-desktop/test/plugin-kernel-compat.test.ts`**（9 用例）：真实树零命中回归 + 扫描规模断言（防门禁静默失效）+ 用夹具复现 3.3.2 → 3.3.3 修复谱系
5. **CI 接线**：`.github/workflows/ci.yml` 的 Windows / Linux 两个 job 在依赖安装后各加一步运行门禁

## 本地验证

| 项目 | 结果 |
|---|---|
| `npm run build`（tsc） | 通过 |
| `npm run typecheck` | 通过 |
| `npm run ledger:check` | 通过（组件 114 条 / 校验 60 个 package.json） |
| 新增测试 | 9/9 通过 |
| 门禁真实树运行 | 通过（48 插件 / 服务端 45 源文件 / 3 处内核具名导入；另跳过 127 个客户端 bundle 文件） |
| 事故复现夹具（3.3.2 写法） | 命中 `settingsNamespace` 且退出码 1 ✓（已修写法通过） |
| 全量 `npm test` | 849 用例 / 839 过 / 5 失败 / 5 skip |

5 个失败**均为本机环境项，与本次改动无关**：`raw-html-integration`、`raw-html-sanitize`、`viewport-lock` 是本机 `node_modules` 未安装 `jsdom`；`runtime-paths-platform` 是本机存在全局 DSH 安装（`C:\Program Files\DSH\node\node.exe`）干扰路径断言；`linux-release-boot` 的 client resolver 签名断言依赖本机内核已跑 `patch-deps`（本次未触碰内核与 patch-deps）。

## 门禁的已知边界（不夸大）

- 只判**具名**导入 / 重导出：`import x from`（default）、`import * as ns`、CJS `require()` 不在范围；
- 服务端源码侧目前是 3 处内核具名导入，门禁价值主要在**未来新增或升级内置插件**时拦住同类写法；
- 导出集合是超集，理论上可能漏判（不会误判）；无法静态枚举的包会打印为 `skipped`，便于后续收紧。

## 备注

- 客户端 bundle 里的 `@deepseek-ai/dsh-client-ui-primitives` 等导入**不是**服务端链接期问题（该包由内核 Web 前端加载面提供，`node_modules/@deepseek-ai` 下本就不存在），门禁显式排除，避免 CI 假红。
- 若维护方不希望引入补丁版本号（历史上 5.1.1 曾采用「版本号字段保持 5.1.0 + 内部代号」的做法），可只取第 3~5 项（门禁 + 测试 + CI），版本号与 CHANGELOG 两处回退即可。
